### PR TITLE
Chore/#11 핵심 도메인 개발을 위한 인프라 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ desktop.ini
 ### Logs ###
 *.log
 logs/
+
+### QueryDSL ###
+src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 	// Web & Validation
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// 알라딘 외부 API 호출용 WebClient (WebMVC와 병행 사용, reactive 서버로 전환 아님)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// Database & Cache
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -29,8 +31,14 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -47,4 +55,23 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QueryDSL Q-class generated source directory
+def querydslDir = 'src/main/generated'
+
+sourceSets {
+	main {
+		java {
+			srcDirs += [querydslDir]
+		}
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/com/nexters/palang/global/config/QuerydslConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
+++ b/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.global.security;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "로그인이 필요합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/global/security/CurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/CurrentUserProvider.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.global.security;
+
+public interface CurrentUserProvider {
+
+    /**
+     * 인증 Phase 이전에는 로그인 없이도 "인증 필요" 엔드포인트를 개발/테스트할 수 있도록
+     * 구현체를 교체 가능한 지점으로 추상화한다. 인증 안 되어 있으면 LoginRequiredException.
+     */
+    Long getCurrentUserId();
+}

--- a/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
@@ -1,0 +1,32 @@
+package com.nexters.palang.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증(JWT) Phase 착수 전까지 사용하는 임시 인증 스탠드인.
+ * X-Debug-User-Id 요청 헤더 값을 그대로 유저 ID로 사용한다.
+ * 인증 Phase 착수 시 JwtCurrentUserProvider로 구현체만 교체한다.
+ */
+@Profile("local")
+@Component
+public class HeaderCurrentUserProvider implements CurrentUserProvider {
+
+    private static final String DEBUG_USER_ID_HEADER = "X-Debug-User-Id";
+
+    private final HttpServletRequest request;
+
+    public HeaderCurrentUserProvider(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public Long getCurrentUserId() {
+        String userId = request.getHeader(DEBUG_USER_ID_HEADER);
+        if (userId == null || userId.isBlank()) {
+            throw new LoginRequiredException();
+        }
+        return Long.valueOf(userId);
+    }
+}

--- a/src/main/java/com/nexters/palang/global/security/LoginRequiredException.java
+++ b/src/main/java/com/nexters/palang/global/security/LoginRequiredException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.global.security;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class LoginRequiredException extends AppException {
+
+    public LoginRequiredException() {
+        super(AuthErrorCode.LOGIN_REQUIRED);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: palang
+  profiles:
+    active: local


### PR DESCRIPTION
## 📌 관련 이슈
- Close #11

## 🚀 개요
backend_plan.md §1, §2, §4.3 기준 핵심 도메인 개발을 위한 인프라를 세팅했습니다.

## 📄 작업 내용
- build.gradle: `spring-boot-starter-validation`(기존 유지), `spring-boot-starter-webflux`(알라딘 WebClient용), QueryDSL(`querydsl-jpa`/`querydsl-apt`) 추가
- QueryDSL Q-class 생성 디렉토리(`src/main/generated`) 설정 + `.gitignore` 추가
- `QuerydslConfig` — `JPAQueryFactory` 빈 등록
- `global/security/CurrentUserProvider` 인터페이스 — 인증 Phase 전까지 "현재 유저" 조회 지점 추상화
- `global/security/HeaderCurrentUserProvider` — `@Profile("local")`, `X-Debug-User-Id` 헤더 기반 임시 인증 스탠드인, 헤더 없으면 `LoginRequiredException`
- `AuthErrorCode.LOGIN_REQUIRED` (`AUTH_401_1`, 401)
- `application.yaml`에 기본 활성 프로파일 `local` 설정
- springdoc-openapi 2.8.0 → 3.0.3 업그레이드: QueryDSL을 추가하니 springdoc의 Querydsl 자동연동 빈이 활성화되는데, 2.8.0은 Spring Boot 4.1(spring-data-commons 4.1의 `TypeInformation` 패키지 이동)과 호환되지 않아 컨텍스트 로딩이 실패해서 해결

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- springdoc-openapi를 2.8.0 → 3.0.3으로 올렸는데, 이 외에 영향받는 부분이 없는지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
