### PR TITLE
Chore: PR/이슈 템플릿 및 커밋 컨벤션 준수를 위한 Claude Code 스킬 추가

### DIFF
--- a/.claude/skills/commit-convention/SKILL.md
+++ b/.claude/skills/commit-convention/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: commit-convention
+description: Use whenever creating a git commit (git commit -m) in this repository. Ensures the commit message follows this project's emoji + type convention, e.g. "✨ feat: 설명".
+---
+
+# 커밋 메시지 컨벤션
+
+이 저장소의 커밋 메시지는 `{이모지} {타입}: {설명}` 형식을 따릅니다. `git log`에서 확인되는 실제 컨벤션입니다.
+
+```
+✨ feat: Comment 1-depth 제약을 정적 팩토리로 이동
+🐛 fix: EnableJpaAuditing을 별도 Config 클래스로 분리
+♻️ refactor: Policy 상수를 별도 클래스 대신 엔티티 상단으로 이동
+🧹 chore: 핵심 도메인 개발을 위한 인프라 세팅
+✅ test: Book 도메인 API 테스트 추가
+```
+
+## 타입 ↔ 이모지 매핑
+
+| 타입 | 이모지 | 용도 |
+|---|---|---|
+| feat | ✨ | 새로운 기능 추가 |
+| fix | 🐛 | 버그 수정 |
+| refactor | ♻️ | 동작 변경 없는 구조 개선 |
+| chore | 🧹 | 빌드/설정/패키지 등 자잘한 작업 (초기 커밋 일부는 🔧 chore도 사용됨 — 신규 커밋은 🧹 사용) |
+| test | ✅ | 테스트 코드 추가/수정 |
+| docs | 📝 | 문서/주석/API 명세 |
+| rename | 🚚 | 파일/디렉터리 이동·이름 변경 |
+
+이슈 라벨(✨ Feature, 🐛 Bug, ♻️ Refactor, 🧹 Chore, ✅ Test 등)과 타입을 맞추면 일관성이 유지됩니다.
+
+## 작성 규칙
+
+- 이모지는 유니코드 문자 그대로 사용한다 (`:sparkles:` 같은 gitmoji 코드 문자열이 아님 — 저장소 초기 커밋에는 코드 문자열이 남아 있지만 현재 컨벤션은 리터럴 이모지).
+- `{타입}:` 뒤 설명은 한국어, 현재형 동사 없이 변경 내용을 간결히 요약한다 (예: "~ 추가", "~ 분리", "~ 이동").
+- 이 저장소는 별도 CI 커밋 린트가 없으므로, 커밋을 생성할 때 이 컨벤션을 스스로 적용한다.
+- PR 제목은 커밋 컨벤션과 달리 이모지 없이 `Feat/#이슈번호 제목` 형태를 사용한다 (기존 PR 제목 참고). 커밋 메시지와 PR 제목의 형식을 혼동하지 않는다.

--- a/.claude/skills/issue-template/SKILL.md
+++ b/.claude/skills/issue-template/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: issue-template
+description: Use whenever creating or editing a GitHub issue (gh issue create, gh issue edit --body, or drafting an issue description) in this repository. Ensures the issue body follows this project's type-specific template under .github/ISSUE_TEMPLATE/ — the same structure used in issue #7.
+---
+
+# 이슈 템플릿 작성 가이드
+
+이 저장소의 이슈는 `.github/ISSUE_TEMPLATE/`에 정의된 작업 유형별 템플릿을 따릅니다.
+`gh issue create` 또는 이슈 본문을 작성/수정할 때는 먼저 작업 유형을 고른 뒤, 그 유형의 구조를 그대로 사용하세요.
+
+## 유형 선택
+
+| 유형 | 파일 | 제목 접두사 | 라벨 |
+|---|---|---|---|
+| 기능 구현 | `feat.md` | `feat: 기능명 - 세부 작업 내용` | ✨ Feature (엔티티/DB 중심이면 🗄️ DB, 배포/인프라면 🚀 Deploy 등 성격에 맞는 라벨 추가 가능) |
+| 버그 수정 | `fix.md` | `fix: 오류명 - 요약` | 🐛 Bug |
+| 단순 작업 | `chore.md` | `chore: 작업 내용` | 🧹 Chore |
+| 코드 개선 | `refactor.md` | `refactor: 개선 대상 - 요약` | ♻️ Refactor |
+| 배포/인프라 | `deploy.md` | `deploy: 배포 버전/환경 - 요약` | 🚀 Deploy |
+
+제목이 이미 `feat:`/`fix:`/`chore:`/`refactor:`/`deploy:` 중 하나로 시작하면 그 유형의 템플릿을 쓰고, 접두사가 없다면 내용에 맞는 접두사를 붙인다.
+
+## 공통 구조 (feat 예시)
+
+```markdown
+## 🎯 구현 목적
+- 이 기능을 구현하려는 이유와 최종 목표를 설명합니다.
+
+## 📝 작업 내용
+> 작업을 완료하기 위한 세부 업무를 쪼개어 작성합니다.
+- [ ]
+- [ ]
+- [ ]
+
+## 💡 참고 사항
+- 작업 시 주의사항, 참고할 만한 아키텍처나 라이브러리 정보 등이 있다면 적어주세요.
+```
+
+다른 유형은 첫 번째/두 번째 섹션 제목만 다르다 (`.github/ISSUE_TEMPLATE/<type>.md` 원본 참고):
+- `fix.md`: `## 🎯 수정 목표` → `## 🚨 오류 상세 및 재현 방법`(현상/재현) → `## 📝 수정 계획` → `## 💡 참고 사항`
+- `chore.md`: `## 🎯 작업 목적` → `## 📝 작업 내용` → `## 💡 참고 사항`
+- `refactor.md`: `## 🎯 리팩토링 목적` → `## 🏗 개선 범위 및 작업 내용` → `## 💡 참고 사항`
+- `deploy.md`: `## 🎯 배포 목표` → `## 🌐 배포 환경 및 변경 사항`(환경 명시) → `## 💡 참고 사항`
+
+## 작성 규칙
+
+- 헤딩은 반드시 `##`로 시작하고, 이모지를 원본 템플릿과 동일하게 유지한다.
+- `📝 작업 내용`(또는 해당 유형의 두 번째 섹션)은 체크박스(`- [ ]`)로 세부 업무를 쪼갠다. 이미 완료된 항목이 있으면 `- [x]`로 표시한다.
+- `💡 참고 사항`에는 관련 문서(예: `backend_plan.md` 섹션 번호), 선행/후속 이슈 번호, 미확정 사항을 적는다.
+- 기존에 이 형식을 따르지 않는 이슈 본문(예: `## 배경` / `## 작업 내용` / `## 참고` 형태)을 발견하면, 원래 내용을 보존하면서 유형에 맞는 섹션 구조로 재배치한다 (내용을 새로 지어내지 않는다).
+- 라벨이 없거나 제목 접두사와 라벨이 어긋나면, 저장소 라벨 목록(`gh label list`)에서 맞는 라벨을 찾아 붙인다.
+
+## 참고
+
+- 기준 예시: 이슈 #7 (https://github.com/Nexters/pallang-server/issues/7)
+- 템플릿 원본: `.github/ISSUE_TEMPLATE/*.md`

--- a/.claude/skills/pr-template/SKILL.md
+++ b/.claude/skills/pr-template/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pr-template
+description: Use whenever creating or editing a pull request (gh pr create, gh pr edit --body, or drafting a PR description) in this repository. Ensures the PR body follows this project's standard template — the same structure used in PR #9.
+---
+
+# PR 템플릿 작성 가이드
+
+이 저장소의 모든 PR 본문은 `.github/PULL_REQUEST_TEMPLATE.md`에 정의된 구조를 따릅니다.
+`gh pr create` 또는 PR 본문을 작성/수정할 때는 아래 섹션을 **이 순서 그대로** 사용하세요.
+
+## 템플릿 구조
+
+```markdown
+## 📌 관련 이슈
+- Close #이슈번호
+
+## 🚀 개요
+> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
+
+## 📄 작업 내용
+> 구체적인 작업 내용을 설명해주세요.
+-
+-
+-
+
+## 📸 스크린샷 / 테스트 결과 (선택)
+> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
+
+## ✅ 체크리스트
+- [ ] 브랜치 전략(GitHub Flow)을 준수했나요?
+- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
+- [ ] 테스트 통과 확인
+- [ ] 서버 실행 확인
+- [ ] API 동작 확인
+
+---
+## 🔍 리뷰 포인트 (Review Points)
+> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요.
+- (예: 이 로직이 최선일까요?)
+- (예: 예외 처리 누락 여부 확인 부탁드립니다.)
+```
+
+## 작성 규칙
+
+- 헤딩은 반드시 `##`로 시작한다 (일반 텍스트/굵은 글씨로만 쓰지 않기).
+- 체크리스트 섹션과 리뷰 포인트 섹션 사이에는 `---` 구분선을 넣는다.
+- `📌 관련 이슈`에는 브랜치명/이슈 번호에서 찾은 이슈를 `Close #N` 형식으로 적는다. 브랜치명이 `feat/#13`, `chore/#11`처럼 이슈 번호를 포함하면 그 번호를 사용한다.
+- `📄 작업 내용`은 변경된 파일/기능을 불릿으로 나열한다. API가 있다면 표(Method/Path/설명)로 정리해도 좋다.
+- `📸 스크린샷 / 테스트 결과`에는 최소한 `./gradlew test` 통과 여부를 적는다. 스크린샷이나 API 응답 예시가 있으면 첨부한다.
+- `✅ 체크리스트`는 실제로 확인한 항목만 `[x]`로 표시하고, 확인하지 않았거나 해당 없는 항목은 `[ ]`로 남긴다 (임의로 전부 체크하지 않기).
+- `🔍 리뷰 포인트`에는 설계 판단이 갈릴 수 있는 지점, 미해결 이슈, 리뷰어에게 확인받고 싶은 질문을 적는다. 비워두지 말고 최소 1개는 작성한다.
+- 기존에 이 형식을 따르지 않는 PR 본문을 발견하면, 원래 내용을 보존하면서 위 섹션 구조로 재배치한다 (내용을 새로 지어내지 않는다).
+
+## 참고
+
+- 기준 예시: PR #9 (https://github.com/Nexters/pallang-server/pull/9)
+- 템플릿 원본: `.github/PULL_REQUEST_TEMPLATE.md`


### PR DESCRIPTION
## 📌 관련 이슈
- (관련 이슈 없음 — 팀 컨벤션 정비)

## 🚀 개요
앞으로 Claude Code가 이 저장소에서 PR/이슈/커밋을 작성·수정할 때 기존 팀 컨벤션(PR #9 템플릿, 이슈 템플릿, 이모지 커밋 컨벤션)을 자동으로 따르도록 스킬 문서 3종을 추가했습니다.

## 📄 작업 내용
- `.claude/skills/pr-template/SKILL.md` 추가
  - `## 📌 관련 이슈 / 🚀 개요 / 📄 작업 내용 / 📸 스크린샷·테스트 결과 / ✅ 체크리스트 / --- / 🔍 리뷰 포인트` 섹션 구조와 작성 규칙 명시
  - 체크리스트는 실제 확인한 항목만 `[x]`로 표시하도록 안내
  - 기존 PR 본문이 템플릿을 따르지 않을 경우, 내용을 보존하며 재배치하도록 안내
  - 이 스킬을 기준으로 기존 PR #20, #21, #23, #24의 본문도 템플릿 구조에 맞게 정리했습니다.
- `.claude/skills/issue-template/SKILL.md` 추가
  - `.github/ISSUE_TEMPLATE/{feat,fix,chore,refactor,deploy}.md` 5종 유형과 제목 접두사/라벨 매핑, 유형별 섹션 구조 명시
  - 이 스킬을 기준으로 기존 이슈 #12, #13, #14, #15, #16, #17, #18, #19, #22("## 배경/작업 내용/참고" 형식)의 본문도 유형별 템플릿 구조로 정리하고, #22는 라벨을 `🧹 Chore`로, 제목을 `chore: CodeRabbit 설정 파일 추가`로 맞췄습니다.
- `.claude/skills/commit-convention/SKILL.md` 추가
  - `git log`에서 확인되는 기존 `{이모지} {타입}: 설명` 컨벤션(✨ feat, 🐛 fix, ♻️ refactor, 🧹 chore, ✅ test, 📝 docs, 🚚 rename)을 표로 정리

## 📸 스크린샷 / 테스트 결과 (선택)
- 문서(스킬) 추가로 별도 실행/테스트 대상 없음

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 스킬 문서 위치를 `.claude/skills/`로 두었는데, 팀에서 사용하는 Claude Code 스킬 경로 컨벤션과 맞는지 확인 부탁드립니다.
- 템플릿 작성 규칙(체크리스트 임의 체크 금지, 리뷰 포인트 최소 1개 등)에 추가/수정하고 싶은 규칙이 있다면 알려주세요.
- 커밋 컨벤션 스킬의 이모지 매핑은 `git log` 관찰로 유추한 것이라, docs/rename처럼 최근 커밋에 없던 타입은 추측이 섞여 있습니다. 실제 팀 규칙과 다르면 알려주세요.
- 이슈 #22는 원래 라벨이 없었는데 `🧹 Chore`로 임의 지정했습니다. 다른 라벨이 맞다면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
