### PR TITLE
Chore#25 Docker 기반 배포 인프라 세팅 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.gradle
+build
+out
+.idea
+.vscode
+*.iml
+*.log
+logs
+.env
+.env.*
+!deploy/.env.example
+docs
+README.md
+CLAUDE.md
+deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+FROM eclipse-temurin:21-jdk-jammy AS builder
+WORKDIR /workspace
+
+# Cache Gradle wrapper/dependencies in their own layer before copying source.
+COPY gradlew ./
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+RUN chmod +x gradlew && ./gradlew --no-daemon dependencies || true
+
+COPY src src
+RUN ./gradlew --no-daemon bootJar -x test
+
+# ---- Run stage ----
+FROM eclipse-temurin:21-jre-jammy AS runtime
+WORKDIR /app
+
+RUN addgroup --system pallang && adduser --system --ingroup pallang pallang
+COPY --from=builder /workspace/build/libs/*.jar app.jar
+RUN chown pallang:pallang app.jar
+USER pallang
+
+ENV SPRING_PROFILES_ACTIVE=prod
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/8080' || exit 1
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
 	// Dotenv
 	implementation platform('me.paulschwarz:spring-dotenv-bom:5.1.0')
-	developmentOnly 'me.paulschwarz:springboot4-dotenv'
+	developmentOnly 'me.paulschwarz:springboot4-dotenv:5.1.0'
 }
 
 tasks.named('test') {

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,22 @@
+# 운영 서버용 환경변수 템플릿.
+# 사용법: cp deploy/.env.example .env  (프로젝트 루트에 위치, docker compose가 자동으로 읽는다)
+# 절대 실제 값이 채워진 .env를 커밋하지 않는다 (.gitignore에 이미 제외됨).
+
+# ---- App ----
+APP_PORT=8080
+
+# ---- MySQL ----
+MYSQL_DATABASE=pallang
+MYSQL_USER=pallang
+MYSQL_PASSWORD=changeme
+MYSQL_ROOT_PASSWORD=changeme-root
+
+# ---- Redis ----
+REDIS_PASSWORD=changeme-redis
+
+# ---- 알라딘 OpenAPI ----
+ALADIN_TTB_KEY=
+
+# ---- 네이버 클로바 OCR ----
+CLOVA_OCR_INVOKE_URL=
+CLOVA_OCR_SECRET_KEY=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -2,9 +2,6 @@
 # 사용법: cp deploy/.env.example .env  (프로젝트 루트에 위치, docker compose가 자동으로 읽는다)
 # 절대 실제 값이 채워진 .env를 커밋하지 않는다 (.gitignore에 이미 제외됨).
 
-# ---- App ----
-APP_PORT=8080
-
 # ---- MySQL ----
 MYSQL_DATABASE=pallang
 MYSQL_USER=pallang

--- a/deploy/nginx/pallang.conf.template
+++ b/deploy/nginx/pallang.conf.template
@@ -1,0 +1,35 @@
+# Pallang API 리버스 프록시 설정
+# app 컨테이너는 127.0.0.1:8080 으로만 노출된다 (외부는 반드시 이 Nginx를 거친다).
+# 443 서버 블록과 HTTP->HTTPS 리다이렉트는 certbot이 자동으로 추가한다.
+
+upstream pallang_app {
+    server 127.0.0.1:8080;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __DOMAIN__;
+
+    # application.yaml의 multipart 최대 크기(10MB)와 맞춤
+    client_max_body_size 10m;
+
+    access_log /var/log/nginx/pallang.access.log;
+    error_log  /var/log/nginx/pallang.error.log;
+
+    location / {
+        proxy_pass http://pallang_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}

--- a/deploy/scripts/setup-server.sh
+++ b/deploy/scripts/setup-server.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Pallang 운영 서버 초기 세팅 스크립트 (Ubuntu 22.04/24.04 LTS 기준).
+# Docker Engine + Compose 플러그인, Nginx, Certbot, UFW 방화벽을 설치/구성한다.
+#
+# 사용법:
+#   sudo ./deploy/scripts/setup-server.sh [domain] [email]
+#
+#   domain, email을 넘기면 Nginx 사이트 등록 + certbot 인증서 발급까지 자동으로 수행한다.
+#   생략하면 패키지 설치와 방화벽 설정만 하고, Nginx/인증서 발급은 안내만 출력한다.
+#
+# 이 스크립트는 저장소를 클론한 뒤 저장소 루트에서 실행한다고 가정한다
+# (deploy/nginx/pallang.conf.template 경로를 상대경로로 참조).
+
+set -euo pipefail
+
+DOMAIN="${1:-}"
+EMAIL="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "root 권한(sudo)으로 실행해야 합니다." >&2
+    exit 1
+fi
+
+log() { echo -e "\n\033[1;32m==> $*\033[0m"; }
+
+log "패키지 목록 갱신"
+apt-get update -y
+apt-get upgrade -y
+
+log "기본 유틸리티 설치"
+apt-get install -y ca-certificates curl gnupg ufw
+
+# ---------------------------------------------------------------------------
+# Docker Engine + Compose 플러그인 (공식 apt 저장소)
+# ---------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+    log "Docker 공식 GPG 키 및 저장소 등록"
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    UBUNTU_CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${UBUNTU_CODENAME} stable" \
+        > /etc/apt/sources.list.d/docker.list
+
+    apt-get update -y
+
+    log "Docker Engine + Compose 플러그인 설치"
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    systemctl enable --now docker
+else
+    log "Docker가 이미 설치되어 있습니다 (건너뜀)"
+fi
+
+if [[ -n "${SUDO_USER:-}" ]]; then
+    log "현재 사용자(${SUDO_USER})를 docker 그룹에 추가 (재로그인 후 sudo 없이 docker 사용 가능)"
+    usermod -aG docker "${SUDO_USER}"
+fi
+
+# ---------------------------------------------------------------------------
+# Nginx
+# ---------------------------------------------------------------------------
+if ! command -v nginx >/dev/null 2>&1; then
+    log "Nginx 설치"
+    apt-get install -y nginx
+    systemctl enable --now nginx
+else
+    log "Nginx가 이미 설치되어 있습니다 (건너뜀)"
+fi
+
+# ---------------------------------------------------------------------------
+# Certbot (Nginx 플러그인 포함)
+# ---------------------------------------------------------------------------
+if ! command -v certbot >/dev/null 2>&1; then
+    log "Certbot 설치"
+    apt-get install -y certbot python3-certbot-nginx
+else
+    log "Certbot이 이미 설치되어 있습니다 (건너뜀)"
+fi
+
+# ---------------------------------------------------------------------------
+# 방화벽 (UFW) — SSH, HTTP/HTTPS만 허용
+# ---------------------------------------------------------------------------
+log "UFW 방화벽 설정 (OpenSSH, Nginx Full만 허용)"
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+ufw status verbose
+
+# ---------------------------------------------------------------------------
+# Nginx 사이트 등록 + SSL 발급 (domain/email이 주어진 경우에만)
+# ---------------------------------------------------------------------------
+if [[ -n "${DOMAIN}" && -n "${EMAIL}" ]]; then
+    log "Nginx 사이트(${DOMAIN}) 등록"
+    sed "s/__DOMAIN__/${DOMAIN}/g" "${REPO_ROOT}/deploy/nginx/pallang.conf.template" \
+        > "/etc/nginx/sites-available/pallang"
+    ln -sf /etc/nginx/sites-available/pallang /etc/nginx/sites-enabled/pallang
+    rm -f /etc/nginx/sites-enabled/default
+    nginx -t
+    systemctl reload nginx
+
+    log "Certbot으로 SSL 인증서 발급 및 자동 갱신 등록 (${DOMAIN})"
+    certbot --nginx -d "${DOMAIN}" -m "${EMAIL}" --agree-tos --redirect --non-interactive
+    systemctl enable --now certbot.timer
+else
+    log "domain/email 인자가 없어 Nginx 사이트 등록과 인증서 발급은 건너뜁니다."
+    echo "필요 시 다음을 수동으로 실행하세요:"
+    echo "  sudo ${SCRIPT_DIR}/setup-server.sh <domain> <email>"
+fi
+
+log "서버 초기 세팅 완료. 다음 단계:"
+cat <<EOF
+  1. 저장소를 원하는 경로로 클론 (이미 되어 있다면 생략)
+  2. cp deploy/.env.example .env  후 값 채우기
+  3. docker compose up -d --build
+  4. curl -I http://127.0.0.1:8080  로 컨테이너 헬스체크
+  5. (미실행 시) sudo ${SCRIPT_DIR}/setup-server.sh <domain> <email> 로 Nginx/SSL 구성
+EOF

--- a/deploy/scripts/setup-server.sh
+++ b/deploy/scripts/setup-server.sh
@@ -86,8 +86,18 @@ fi
 # ---------------------------------------------------------------------------
 # 방화벽 (UFW) — SSH, HTTP/HTTPS만 허용
 # ---------------------------------------------------------------------------
-log "UFW 방화벽 설정 (OpenSSH, Nginx Full만 허용)"
-ufw allow OpenSSH
+# sshd가 22번이 아닌 포트로 설정돼 있을 수 있으므로, 'OpenSSH' 프로필(22/tcp) 대신
+# 실제 리스닝 포트를 확인해서 허용한다. 안 그러면 ufw enable 직후 SSH 접속이 끊길 수 있다.
+SSH_PORT="22"
+if command -v sshd >/dev/null 2>&1; then
+    DETECTED_PORT="$(sshd -T 2>/dev/null | awk '/^port /{print $2; exit}')"
+    if [[ -n "${DETECTED_PORT}" ]]; then
+        SSH_PORT="${DETECTED_PORT}"
+    fi
+fi
+
+log "UFW 방화벽 설정 (SSH ${SSH_PORT}/tcp, Nginx Full만 허용)"
+ufw allow "${SSH_PORT}/tcp"
 ufw allow 'Nginx Full'
 ufw --force enable
 ufw status verbose
@@ -96,6 +106,13 @@ ufw status verbose
 # Nginx 사이트 등록 + SSL 발급 (domain/email이 주어진 경우에만)
 # ---------------------------------------------------------------------------
 if [[ -n "${DOMAIN}" && -n "${EMAIL}" ]]; then
+    # sed 치환식에 그대로 끼워 넣으므로, 호스트명 형식이 아니면 특수문자를 통한
+    # sed 명령 주입/치환 오염을 막기 위해 미리 형식을 검증한다.
+    if ! [[ "${DOMAIN}" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$ ]]; then
+        echo "유효하지 않은 도메인 형식입니다: ${DOMAIN}" >&2
+        exit 1
+    fi
+
     log "Nginx 사이트(${DOMAIN}) 등록"
     sed "s/__DOMAIN__/${DOMAIN}/g" "${REPO_ROOT}/deploy/nginx/pallang.conf.template" \
         > "/etc/nginx/sites-available/pallang"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+    # deploy/nginx/pallang.conf.template의 upstream이 127.0.0.1:8080을 하드코딩하고 있으므로
+    # 호스트 포트를 가변으로 두지 않는다 (바꾸려면 이 파일과 nginx 템플릿을 함께 수정할 것).
     ports:
-      - "127.0.0.1:${APP_PORT:-8080}:8080"
+      - "127.0.0.1:8080:8080"
     depends_on:
       mysql:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+# 운영 서버 배포용 compose 파일 (app + mysql + redis).
+# Nginx는 컨테이너로 띄우지 않고 호스트에 직접 설치한다 (deploy/nginx, deploy/scripts 참고).
+#
+# 사용법:
+#   cp deploy/.env.example .env   # 값 채운 뒤
+#   docker compose up -d --build
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: pallang-app:latest
+    container_name: pallang-app
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      DB_USERNAME: ${MYSQL_USER}
+      DB_PASSWORD: ${MYSQL_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    ports:
+      - "127.0.0.1:${APP_PORT:-8080}:8080"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - pallang-net
+
+  mysql:
+    image: mysql:8.0
+    container_name: pallang-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+09:00
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - pallang-net
+
+  redis:
+    image: redis:7-alpine
+    container_name: pallang-redis
+    restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - pallang-net
+
+volumes:
+  mysql-data:
+  redis-data:
+
+networks:
+  pallang-net:
+    driver: bridge

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,61 @@
+server:
+  port: ${SERVER_PORT:8080}
+
+spring:
+  application:
+    name: palang
+
+  # 1. 데이터베이스 설정
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
+
+  # 2. JPA 설정 (Hibernate)
+  jackson:
+    time-zone: Asia/Seoul
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      # 운영에서는 스키마를 자동 변경하지 않는다. 마이그레이션 도구(Flyway/Liquibase) 도입 전까지는
+      # 스키마를 미리 반영해두고 검증만 수행한다.
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        jdbc:
+          time_zone: Asia/Seoul
+    open-in-view: false
+
+  # 3. 캐시/세션용 Redis 설정
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
+  # 4. 파일 업로드 설정 (OCR용 이미지 업로드)
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+  # 5. 네이버 클로바 OCR 연동 설정
+  clova:
+    ocr:
+      invoke-url: ${CLOVA_OCR_INVOKE_URL:}
+      secret-key: ${CLOVA_OCR_SECRET_KEY:}
+
+aladin:
+  base-url: https://www.aladin.co.kr/ttb/api
+  ttb-key: ${ALADIN_TTB_KEY:}
+
+logging:
+  level:
+    root: INFO
+    com.nexters.palang: INFO


### PR DESCRIPTION
## 📌 관련 이슈
- #25 

## 🚀 개요
Docker 기반 배포 인프라 일체(Dockerfile, docker-compose, 운영 프로파일, Nginx 리버스 프록시 템플릿, 서버 초기 세팅 스크립트)를 추가했습니다.

## 📄 작업 내용
- `Dockerfile`: Gradle 빌드 스테이지 + JRE 21 런타임 스테이지로 나눈 멀티스테이지 빌드, non-root 유저로 실행, TCP 헬스체크 추가
- `docker-compose.yml`: `app` + `mysql:8.0` + `redis:7-alpine` 3개 서비스 구성. mysql/redis가 헬스체크를 통과한 뒤에만 app이 기동되도록 `depends_on: condition: service_healthy` 설정, app은 `127.0.0.1:8080`에만 바인딩(외부는 반드시 Nginx를 거치도록)
- `src/main/resources/application-prod.yaml`: 운영 프로파일 추가 — Redis 연동 설정, `ddl-auto: validate`로 전환, `show-sql: false` 등
- `deploy/nginx/pallang.conf.template`: Nginx 리버스 프록시 설정 템플릿(80 포트, `__DOMAIN__` 치환). `certbot --nginx`가 443 블록과 HTTP→HTTPS 리다이렉트를 자동으로 추가하는 것을 전제로 함
- `deploy/scripts/setup-server.sh`: Ubuntu 22.04/24.04 대상 초기 세팅 스크립트 — Docker Engine+Compose 플러그인, Nginx, Certbot(nginx 플러그인) 설치, UFW로 OpenSSH/Nginx Full만 허용. `domain`/`email` 인자를 주면 Nginx 사이트 등록 + 인증서 발급까지 자동 수행
- `deploy/.env.example`, `.dockerignore` 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- `docker compose config` 로 compose 파일 문법·변수 치환 검증 완료 (network/service 이름 정상 해석 확인)
- `bash -n deploy/scripts/setup-server.sh` 문법 검증 통과

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요? (해당 없음 — 설정/인프라 파일만 포함, Java 코드 변경 없음)
- [ ] 테스트 통과 확인 (기존부터 실패하던 8개 테스트, 이 PR과 무관 — 위 테스트 결과 참고)
- [ ] 서버 실행 확인 (Docker 데몬 부재로 미검증)
- [ ] API 동작 확인 (위와 동일한 사유로 미검증)

---
## 🔍 리뷰 포인트 (Review Points)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 운영 환경에서 애플리케이션, MySQL, Redis를 함께 실행할 수 있는 배포 구성을 추가했습니다.
  - Docker 기반 실행과 자동 상태 점검을 지원합니다.
  - Nginx를 통한 외부 접속 및 HTTPS 인증서 설정을 지원합니다.
  - 운영 환경용 데이터베이스, 캐시, 외부 API 설정 템플릿을 제공합니다.

- **개선 사항**
  - 파일 업로드 용량을 최대 10MB로 제한했습니다.
  - 운영 환경에서 안정적인 서비스 실행과 데이터 영속성을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->