### PR TITLE
Feat/#15 Passage/Opinion 조회 - 꾸밈 병합 알고리즘 및 읽기상태 필터

### DIFF
--- a/docs/spoiler-visibility-design.md
+++ b/docs/spoiler-visibility-design.md
@@ -1,0 +1,74 @@
+# 스포일러/읽기상태 노출 설계 — 기획 확인 필요 (이슈 #15)
+
+## 배경
+
+이슈 #15(대목/흔적 조회 API) 구현 중, 스포일러 방지와 관련된 문서 문구가 **서로 다른 두 메커니즘**을 가리키고 있다는 걸 발견했다. `requirements.md`가 둘 다 "(스포 방지)"라는 표현을 써서 같은 것처럼 보이지만, 실제로는 기준 축과 UX 흐름이 다르다. 백엔드 구현은 일단 두 메커니즘을 구분해 진행했고, 그중 하나(②)는 기획 확인 전까지 **잠정 결정**으로 두고 작업을 계속한다.
+
+## 두 가지 메커니즘
+
+### ① 읽기 상태 기반 페이지 범위 제한
+
+`requirements.md` FR-WRITE-08:
+> 읽는 중: 어디까지 읽었는지 페이지 표시. **그 이후 페이지는 내용이 보이지 않음**
+> 읽을 예정: **첫 부분만 보여주고 이후는 보이지 않음** (스포 방지)
+
+`backend-plan.md` §5.7:
+```
+READING  → passage.pageNumber <= userBookStatus.currentPage
+PLANNED  → passage.pageNumber == MIN(pageNumber) (해당 책의 첫 대목만)
+미설정   → PLANNED와 동일 취급
+```
+
+- **기준 축**: 이 유저가 이 책을 어디까지 읽었다고 밝혔는가 (`UserBookStatus`)
+- **문서에 리빌(reveal) 버튼 언급 없음**. "보이지 않음"이라고만 되어 있고, FR-OPINION-08은 비로그인 사용자가 범위 밖 페이지를 시도하면 "로그인 유도"라고만 명시 — 클릭 한 번으로 보이는 흐름이 아니라 별도 행동(로그인 또는 읽기상태 갱신)을 요구하는 것으로 읽힘.
+- **현재 구현 (하드 블록, 확정)**: `PassageVisibilityFilter`(`domain/passage/application/PassageVisibilityFilter.java`)가 QueryDSL 조건으로 이 범위를 벗어난 Passage를 **쿼리 결과에서 완전히 제외**한다. 비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 `PassageService.getVisiblePassagesByPage`가 `LoginRequiredException`(401)을 던진다.
+- **왜 하드 블록으로 확정했는가**: 여기에 "그냥 눌러서 보기" 버튼을 두면 `READING`/`currentPage`를 서버에 저장하고 필터링하는 로직 자체가 장식이 된다. 진행 상태를 실제로 갱신해야만 범위가 넓어지는 게 이 기능의 존재 이유이므로, 이 부분은 재확인 없이 하드 블록으로 간다.
+
+### ② 개별 대목의 스포일러 표기 (작성 시 토글)
+
+`requirements.md` FR-VIEW-03:
+> 스포일러 표기된 대목은 **해당 페이지에서** 블러 처리. **[버튼]을 눌러야** 대목 + 흔적을 확인 가능
+
+- **기준 축**: 이 문장(Passage) 자체가 작성자에 의해 스포일러로 표시됐는가 (`Passage.isSpoiler`, 흔적 작성 시 토글 — `CreateOpinionRequest.isSpoiler` → `OpinionService.createNewPassage`)
+- **전제**: "해당 페이지에서"라는 표현대로, 이건 **①을 이미 통과해서 볼 수 있는 페이지 안**에서의 이야기다. 아직 못 읽은 페이지의 스포일러 여부와는 무관.
+- **문서에 버튼이 명시적으로 있음** — 그런데 버튼을 눌렀을 때 서버 재요청이 있는지, 즉시 반응해야 하는지는 명시돼 있지 않음.
+
+## 현재 구현 (잠정, 기획 확인 전)
+
+`PassageResponse.PassagesByPage.Detail`(`domain/passage/presentation/response/PassageResponse.java`)은 `isSpoiler` 값과 무관하게 `quotedText`와 병합된 `decorations`를 **항상 그대로** 반환하고, `isSpoiler` 플래그만 함께 내려준다. 블러 처리와 버튼 클릭 시 확인은 **프론트에서 서버 재요청 없이** `isSpoiler` 플래그만으로 처리한다고 가정했다.
+
+이렇게 정한 이유:
+- 스포일러는 접근 제어가 아니라 UX 배려용이라 네트워크상 노출 자체는 문제되지 않는다고 판단.
+- "버튼을 누르면 즉시 확인 가능해야 한다"는 요구(로딩 없이 바로 보임)를 만족하려면 데이터가 이미 클라이언트에 있어야 한다.
+
+## 기획 확인 필요 — 두 가지 질문
+
+**① 읽기 상태 기반 제한**
+"읽는 중은 현재 페이지까지, 읽을 예정은 첫 페이지까지만 노출"은 아직 안 읽은 페이지를 **아예 못 보게 막는** 건지, 아니면 스포일러처럼 "블러 처리 후 버튼 누르면 볼 수 있는" 형태인지? 예를 들어 "읽을 예정" 상태 유저가 페이지 목록을 볼 때, 아직 못 보는 페이지들이 "여기 흔적 있음(잠김)"처럼 존재는 보이는지, 아니면 그 페이지가 있다는 사실조차 안 보이는지.
+
+**② 개별 대목의 스포일러 표기**
+- 유저는 그 페이지에 스포일러 대목이 **존재한다는 사실**은 알 수 있어야 하는가? (예: "스포일러 흔적 2개 있음")
+- 블러 처리된 카드에 페이지 번호나 대략적인 분량 같은 **메타 정보**는 보여도 되는가, 아니면 완전히 아무것도 안 보이다가 버튼 눌러야 전부 나타나야 하는가?
+- 버튼을 누르면 **그 즉시(서버 요청 없이)** 바로 보여야 하는가, 아니면 눌렀을 때 한 번 더 로딩되는 정도는 괜찮은가?
+
+## 답변에 따라 달라지는 백엔드 설계
+
+②의 세 번째 질문(즉시 반응 vs 로딩 허용)이 실제 구현을 가르는 핵심 분기다.
+
+| 답변 | 백엔드 설계 |
+|---|---|
+| 즉시 반응 필요 (로딩 없이 바로 확인) | **현재 구현 유지**: 항상 전체 데이터 + `isSpoiler` 플래그 전송, 클라이언트가 블러/리빌 처리 |
+| 로딩 한 번 정도 허용 | 서버가 `isSpoiler=true`인 대목은 `quotedText`/`decorations`를 마스킹해서 응답하고, 버튼 클릭 시 호출할 별도 "리빌" API(또는 쿼리 파라미터)를 새로 설계 |
+| 존재/개수만 알면 됨, 내용은 몰라야 함 | 위 "로딩 허용" 안에 더해, `GET /api/books/{bookId}/passages`(페이지 번호 목록) 응답에도 스포일러 개수/여부를 별도로 포함할지 결정 필요 |
+
+## 관련 코드 위치
+
+- `domain/passage/application/PassageVisibilityFilter.java` — 읽기상태 기반 페이지 범위 필터 (①, 하드 블록, 확정)
+- `domain/passage/application/PassageService.java` — `getVisiblePassagesByPage`(비로그인 401 분기), `getMergedDecorationsByPassageId`
+- `domain/passage/presentation/response/PassageResponse.java` — `PassagesByPage.Detail`(②, 현재 마스킹 없음, 잠정)
+- `domain/passage/presentation/docs/PassageControllerDocs.java` — 관련 Swagger 설명
+
+## 관련 PR / 이슈
+
+- #15 (본 문서가 다루는 조회 API 전체)
+- PR #30

--- a/src/main/java/com/nexters/palang/domain/decoration/application/DecorationMergeCandidate.java
+++ b/src/main/java/com/nexters/palang/domain/decoration/application/DecorationMergeCandidate.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.decoration.application;
+
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import java.time.LocalDateTime;
+
+// 꾸밈 병합 노출(FR-VIEW-03) 정렬/겹침 판정에 필요한 필드만 담은 조회 전용 프로젝션.
+// likeCount/opinionCreatedAt은 Decoration 자신의 값이 아니라 소속 Opinion의 값이다.
+public record DecorationMergeCandidate(
+        Long decorationId,
+        int startOffset,
+        int endOffset,
+        EffectType effectType,
+        String color,
+        int likeCount,
+        LocalDateTime opinionCreatedAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/decoration/application/DecorationMergeSelector.java
+++ b/src/main/java/com/nexters/palang/domain/decoration/application/DecorationMergeSelector.java
@@ -1,0 +1,41 @@
+package com.nexters.palang.domain.decoration.application;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+// 꾸밈 병합 노출(FR-VIEW-03, backend-plan.md §5.6): 한 Passage에 달린 모든 Decoration 중
+// 좋아요 많은 순으로 최대 3개를 겹치지 않게 뽑는다. 순수 함수라 파라미터화 테스트로 검증하기 쉽다.
+public final class DecorationMergeSelector {
+
+    private static final int MAX_SELECTED = 3;
+
+    // 정렬: 좋아요 수 DESC, 흔적 작성일 DESC, decoration.id ASC.
+    // 3순위 "랜덤"(기획서) 대신 decoration.id를 결정적 tiebreaker로 써서 캐시 무효화/사용자 혼란을 피한다.
+    private static final Comparator<DecorationMergeCandidate> PRIORITY_ORDER =
+            Comparator.comparingInt(DecorationMergeCandidate::likeCount).reversed()
+                    .thenComparing(Comparator.comparing(DecorationMergeCandidate::opinionCreatedAt).reversed())
+                    .thenComparing(DecorationMergeCandidate::decorationId);
+
+    private DecorationMergeSelector() {
+    }
+
+    public static List<DecorationMergeCandidate> select(List<DecorationMergeCandidate> candidates) {
+        List<DecorationMergeCandidate> sorted = candidates.stream().sorted(PRIORITY_ORDER).toList();
+
+        List<DecorationMergeCandidate> selected = new ArrayList<>();
+        for (DecorationMergeCandidate candidate : sorted) {
+            if (selected.size() == MAX_SELECTED) {
+                break;
+            }
+            if (selected.stream().noneMatch(accepted -> overlaps(accepted, candidate))) {
+                selected.add(candidate);
+            }
+        }
+        return selected;
+    }
+
+    private static boolean overlaps(DecorationMergeCandidate a, DecorationMergeCandidate b) {
+        return a.startOffset() < b.endOffset() && b.startOffset() < a.endOffset();
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/decoration/infrastructure/DecorationQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/decoration/infrastructure/DecorationQueryRepository.java
@@ -1,0 +1,33 @@
+package com.nexters.palang.domain.decoration.infrastructure;
+
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.decoration.domain.QDecoration;
+import com.nexters.palang.domain.opinion.domain.QOpinion;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DecorationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 정렬은 DecorationMergeSelector가 담당하므로 여기서는 후보만 모아온다 (삭제된 Opinion 제외).
+    public List<DecorationMergeCandidate> findMergeCandidates(Long passageId) {
+        QDecoration decoration = QDecoration.decoration;
+        QOpinion opinion = QOpinion.opinion;
+
+        return queryFactory
+                .select(Projections.constructor(DecorationMergeCandidate.class,
+                        decoration.id, decoration.startOffset, decoration.endOffset,
+                        decoration.effectType, decoration.color,
+                        opinion.likeCount, opinion.createdAt))
+                .from(decoration)
+                .join(decoration.opinion, opinion)
+                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())
+                .fetch();
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -5,9 +5,14 @@ import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.domain.passage.application.PassageNormalizer;
 import com.nexters.palang.domain.passage.common.error.PassageErrorCode;
 import com.nexters.palang.domain.passage.common.error.PassageException;
@@ -19,17 +24,64 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OpinionService {
 
     private final OpinionRepository opinionRepository;
+    private final OpinionQueryRepository opinionQueryRepository;
     private final PassageRepository passageRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
+
+    // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순.
+    public Page<OpinionSummaryProjection> getOpinions(Long passageId, OpinionSortType sortType, Pageable pageable) {
+        if (!passageRepository.existsById(passageId)) {
+            throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
+        }
+        return opinionQueryRepository.findOpinions(passageId, sortType, pageable);
+    }
+
+    // 흔적 상세(FR-OPINION-05): 이 흔적 작성자가 기록한 꾸밈을 그대로 보여준다.
+    public Opinion getOpinion(Long opinionId) {
+        return getExistingOpinion(opinionId);
+    }
+
+    @Transactional
+    public Opinion modifyOpinion(Long opinionId, Long userId, UpdateOpinionRequest request) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        validateOwner(opinion, userId);
+        opinion.updateContent(request.content());
+        return opinion;
+    }
+
+    @Transactional
+    public void removeOpinion(Long opinionId, Long userId) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        validateOwner(opinion, userId);
+        opinion.delete();
+    }
+
+    private Opinion getExistingOpinion(Long opinionId) {
+        Opinion opinion = opinionRepository.findById(opinionId)
+                .orElseThrow(() -> new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
+        if (opinion.isDeleted()) {
+            throw new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND);
+        }
+        return opinion;
+    }
+
+    private void validateOwner(Opinion opinion, Long userId) {
+        if (!opinion.getUser().getId().equals(userId)) {
+            throw new OpinionException(OpinionErrorCode.OPINION_FORBIDDEN);
+        }
+    }
 
     // Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 한 트랜잭션에서 원자적으로 생성한다. (직접 입력만)
     @Transactional

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionSummaryProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionSummaryProjection.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.opinion.application;
+
+import java.time.LocalDateTime;
+
+public record OpinionSummaryProjection(
+        Long opinionId,
+        Long userId,
+        String nickname,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/common/error/OpinionErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/common/error/OpinionErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum OpinionErrorCode implements BaseErrorCode {
 
     OPINION_NOT_FOUND(HttpStatus.NOT_FOUND, "OPINION_404_1", "해당 흔적을 찾을 수 없습니다."),
+    OPINION_FORBIDDEN(HttpStatus.FORBIDDEN, "OPINION_403_1", "본인이 작성한 흔적만 수정/삭제할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/opinion/domain/Opinion.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/domain/Opinion.java
@@ -90,6 +90,10 @@ public class Opinion extends BaseEntity {
         return opinion;
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
     public void addDecoration(Decoration decoration) {
         decoration.assignOpinion(this);
         this.decorations.add(decoration);

--- a/src/main/java/com/nexters/palang/domain/opinion/domain/OpinionSortType.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/domain/OpinionSortType.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.opinion.domain;
+
+// 흔적 목록 정렬 기준(FR-OPINION-03): 최신순(기본) / 좋아요순.
+public enum OpinionSortType {
+    LATEST,
+    LIKES
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -1,0 +1,54 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.opinion.domain.QOpinion;
+import com.nexters.palang.domain.user.domain.QUser;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OpinionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순, 삭제된 흔적 제외.
+    public Page<OpinionSummaryProjection> findOpinions(Long passageId, OpinionSortType sortType, Pageable pageable) {
+        QOpinion opinion = QOpinion.opinion;
+        QUser user = QUser.user;
+
+        List<OpinionSummaryProjection> content = queryFactory
+                .select(Projections.constructor(OpinionSummaryProjection.class,
+                        opinion.id, user.id, user.nickname, opinion.content, opinion.likeCount, opinion.createdAt))
+                .from(opinion)
+                .join(opinion.user, user)
+                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())
+                .orderBy(orderSpecifiers(sortType, opinion))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(opinion.count())
+                .from(opinion)
+                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private OrderSpecifier<?>[] orderSpecifiers(OpinionSortType sortType, QOpinion opinion) {
+        if (sortType == OpinionSortType.LIKES) {
+            return new OrderSpecifier<?>[]{opinion.likeCount.desc(), opinion.createdAt.desc(), opinion.id.desc()};
+        }
+        return new OrderSpecifier<?>[]{opinion.createdAt.desc(), opinion.id.desc()};
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
@@ -1,10 +1,15 @@
 package com.nexters.palang.domain.opinion.presentation;
 
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionDetailResponse;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionListResponse;
 import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.global.common.error.ErrorResponse;
 import com.nexters.palang.global.common.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -54,5 +59,71 @@ public interface OpinionApi {
     })
     ResponseEntity<DataResponse<OpinionResponse>> createOpinion(
             @Valid CreateOpinionRequest request
+    );
+
+    @Operation(summary = "흔적 목록 조회", description = "특정 대목에 남겨진 흔적을 정렬 기준(최신순 기본/좋아요순)으로 조회합니다. (FR-OPINION-03)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/opinions\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 대목을 찾을 수 없음 (PASSAGE_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/opinions\",\"title\":\"PASSAGE_404_1\",\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<OpinionListResponse>> getOpinions(
+            @Parameter(description = "대목 ID", required = true) Long passageId,
+            @Parameter(description = "정렬 기준 (LATEST: 최신순(기본), LIKES: 좋아요순)") OpinionSortType sortType,
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "흔적 상세 조회", description = "흔적 작성자가 기록한 꾸밈을 그대로 확인합니다(병합된 결과가 아님). (FR-OPINION-05)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_404_1\",\"status\":404,\"detail\":\"해당 흔적을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<OpinionDetailResponse>> getOpinion(
+            @Parameter(description = "흔적 ID", required = true) Long opinionId
+    );
+
+    @Operation(summary = "흔적 수정", description = "본인이 작성한 흔적의 내용을 수정합니다. 꾸밈은 생성 시점에 고정되며 수정 대상이 아닙니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "내용 누락/길이 초과 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"흔적 내용은 500자를 초과할 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "OPINION_403_1: 본인이 작성한 흔적만 수정/삭제할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_403_1\",\"status\":403,\"detail\":\"본인이 작성한 흔적만 수정/삭제할 수 있습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_404_1\",\"status\":404,\"detail\":\"해당 흔적을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<OpinionDetailResponse>> modifyOpinion(
+            @Parameter(description = "흔적 ID", required = true) Long opinionId,
+            @Valid UpdateOpinionRequest request
+    );
+
+    @Operation(summary = "흔적 삭제", description = "본인이 작성한 흔적을 소프트 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "OPINION_403_1: 본인이 작성한 흔적만 수정/삭제할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_403_1\",\"status\":403,\"detail\":\"본인이 작성한 흔적만 수정/삭제할 수 있습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_404_1\",\"status\":404,\"detail\":\"해당 흔적을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> removeOpinion(
+            @Parameter(description = "흔적 ID", required = true) Long opinionId
     );
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
@@ -2,20 +2,35 @@ package com.nexters.palang.domain.opinion.presentation;
 
 import com.nexters.palang.domain.opinion.application.OpinionService;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionDetailResponse;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionListResponse;
 import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.global.common.response.DataResponse;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class OpinionController implements OpinionApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
 
     private final OpinionService opinionService;
     private final CurrentUserProvider currentUserProvider;
@@ -27,5 +42,45 @@ public class OpinionController implements OpinionApi {
         Opinion opinion = opinionService.createOpinion(currentUserId, request);
         boolean merged = request.passageId() != null;
         return ResponseEntity.ok(DataResponse.from(OpinionResponse.from(opinion, merged)));
+    }
+
+    @Override
+    @GetMapping("/api/passages/{passageId}/opinions")
+    public ResponseEntity<DataResponse<OpinionListResponse>> getOpinions(
+            @PathVariable Long passageId,
+            @RequestParam(defaultValue = "LATEST") OpinionSortType sortType,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        return ResponseEntity.ok(DataResponse.from(
+                OpinionListResponse.from(opinionService.getOpinions(passageId, sortType, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/opinions/{opinionId}")
+    public ResponseEntity<DataResponse<OpinionDetailResponse>> getOpinion(@PathVariable Long opinionId) {
+        Opinion opinion = opinionService.getOpinion(opinionId);
+        return ResponseEntity.ok(DataResponse.from(OpinionDetailResponse.from(opinion)));
+    }
+
+    @Override
+    @PatchMapping("/api/opinions/{opinionId}")
+    public ResponseEntity<DataResponse<OpinionDetailResponse>> modifyOpinion(
+            @PathVariable Long opinionId,
+            @RequestBody @Valid UpdateOpinionRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Opinion opinion = opinionService.modifyOpinion(opinionId, currentUserId, request);
+        return ResponseEntity.ok(DataResponse.from(OpinionDetailResponse.from(opinion)));
+    }
+
+    @Override
+    @DeleteMapping("/api/opinions/{opinionId}")
+    public ResponseEntity<DataResponse<Void>> removeOpinion(@PathVariable Long opinionId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        opinionService.removeOpinion(opinionId, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
@@ -1,0 +1,34 @@
+package com.nexters.palang.domain.opinion.presentation.dto;
+
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse.DecorationResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 흔적 상세(FR-OPINION-05): 해당 흔적 작성자가 기록한 꾸밈을 그대로 보여준다 (병합된 3개가 아니라 이 Opinion 자신의 전부).
+public record OpinionDetailResponse(
+        Long opinionId,
+        Long passageId,
+        Long userId,
+        String nickname,
+        String content,
+        int likeCount,
+        List<DecorationResponse> decorations,
+        LocalDateTime createdAt
+) {
+    public static OpinionDetailResponse from(Opinion opinion) {
+        List<DecorationResponse> decorations = opinion.getDecorations().stream()
+                .map(DecorationResponse::from)
+                .toList();
+        return new OpinionDetailResponse(
+                opinion.getId(),
+                opinion.getPassage().getId(),
+                opinion.getUser().getId(),
+                opinion.getUser().getNickname(),
+                opinion.getContent(),
+                opinion.getLikeCount(),
+                decorations,
+                opinion.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionListResponse.java
@@ -1,0 +1,15 @@
+package com.nexters.palang.domain.opinion.presentation.dto;
+
+import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import com.nexters.palang.global.common.response.PageInfo;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record OpinionListResponse(List<OpinionSummaryResponse> opinions, PageInfo pageInfo) {
+    public static OpinionListResponse from(Page<OpinionSummaryProjection> page) {
+        List<OpinionSummaryResponse> opinions = page.getContent().stream()
+                .map(OpinionSummaryResponse::from)
+                .toList();
+        return new OpinionListResponse(opinions, PageInfo.from(page));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.nexters.palang.domain.opinion.presentation.dto;
+
+import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import java.time.LocalDateTime;
+
+public record OpinionSummaryResponse(
+        Long opinionId,
+        Long userId,
+        String nickname,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt
+) {
+    public static OpinionSummaryResponse from(OpinionSummaryProjection projection) {
+        return new OpinionSummaryResponse(
+                projection.opinionId(),
+                projection.userId(),
+                projection.nickname(),
+                projection.content(),
+                projection.likeCount(),
+                projection.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/UpdateOpinionRequest.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/UpdateOpinionRequest.java
@@ -1,0 +1,12 @@
+package com.nexters.palang.domain.opinion.presentation.dto;
+
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateOpinionRequest(
+        @NotBlank(message = "흔적 내용은 비어 있을 수 없습니다.")
+        @Size(max = Opinion.CONTENT_MAX_LENGTH, message = "흔적 내용은 {max}자를 초과할 수 없습니다.")
+        String content
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -51,14 +51,9 @@ public class PassageService {
         return passageQueryRepository.findVisiblePassagesByPage(bookId, pageNumber, visibilityFilter);
     }
 
-    // 스포일러 대목은 응답 단계에서 어차피 가려지므로(PassageResponse), 그 내용을 드러낼 수 있는
-    // 꾸밈 데이터는 여기서부터 아예 조회하지 않는다 (방어적으로 한 겹 더 막아둔다).
     public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {
         Map<Long, List<DecorationMergeCandidate>> mergedByPassageId = new LinkedHashMap<>();
         for (Passage passage : passages) {
-            if (passage.isSpoiler()) {
-                continue;
-            }
             List<DecorationMergeCandidate> candidates = decorationQueryRepository.findMergeCandidates(passage.getId());
             mergedByPassageId.put(passage.getId(), DecorationMergeSelector.select(candidates));
         }

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.passage.application;
+
+import com.nexters.palang.domain.book.common.error.BookErrorCode;
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.decoration.application.DecorationMergeSelector;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.nexters.palang.global.security.LoginRequiredException;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PassageService {
+
+    private final PassageQueryRepository passageQueryRepository;
+    private final DecorationQueryRepository decorationQueryRepository;
+    private final PassageVisibilityFilter passageVisibilityFilter;
+    private final BookRepository bookRepository;
+
+    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 노출 필터(읽기상태+스포일러)를 만족하는 페이지 번호 목록.
+    public Page<Integer> getVisiblePageNumbers(Long bookId, Long currentUserId, Pageable pageable) {
+        validateBookExists(bookId);
+        BooleanExpression visibilityFilter = passageVisibilityFilter.build(bookId, currentUserId);
+        return passageQueryRepository.findVisiblePageNumbers(bookId, visibilityFilter, pageable);
+    }
+
+    // 대목 전환(FR-VIEW-03): 특정 페이지의 대목들과 각 대목의 꾸밈 병합 결과.
+    // 비로그인 사용자가 첫 대목이 아닌 페이지를 요청하면 로그인을 유도한다(FR-OPINION-08, backend-plan.md §4.2).
+    public List<Passage> getVisiblePassagesByPage(Long bookId, int pageNumber, Long currentUserId) {
+        validateBookExists(bookId);
+        if (currentUserId == null) {
+            Optional<Integer> firstPage = passageVisibilityFilter.firstVisiblePageNumber(bookId);
+            if (firstPage.isPresent() && pageNumber != firstPage.get()) {
+                throw new LoginRequiredException();
+            }
+        }
+        BooleanExpression visibilityFilter = passageVisibilityFilter.build(bookId, currentUserId);
+        return passageQueryRepository.findVisiblePassagesByPage(bookId, pageNumber, visibilityFilter);
+    }
+
+    public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {
+        Map<Long, List<DecorationMergeCandidate>> mergedByPassageId = new LinkedHashMap<>();
+        for (Passage passage : passages) {
+            List<DecorationMergeCandidate> candidates = decorationQueryRepository.findMergeCandidates(passage.getId());
+            mergedByPassageId.put(passage.getId(), DecorationMergeSelector.select(candidates));
+        }
+        return mergedByPassageId;
+    }
+
+    private void validateBookExists(Long bookId) {
+        if (!bookRepository.existsById(bookId)) {
+            throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -30,7 +30,7 @@ public class PassageService {
     private final PassageVisibilityFilter passageVisibilityFilter;
     private final BookRepository bookRepository;
 
-    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 노출 필터(읽기상태+스포일러)를 만족하는 페이지 번호 목록.
+    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 읽기상태 노출 필터를 만족하는 페이지 번호 목록 (스포일러 포함).
     public Page<Integer> getVisiblePageNumbers(Long bookId, Long currentUserId, Pageable pageable) {
         validateBookExists(bookId);
         BooleanExpression visibilityFilter = passageVisibilityFilter.build(bookId, currentUserId);
@@ -51,9 +51,14 @@ public class PassageService {
         return passageQueryRepository.findVisiblePassagesByPage(bookId, pageNumber, visibilityFilter);
     }
 
+    // 스포일러 대목은 응답 단계에서 어차피 가려지므로(PassageResponse), 그 내용을 드러낼 수 있는
+    // 꾸밈 데이터는 여기서부터 아예 조회하지 않는다 (방어적으로 한 겹 더 막아둔다).
     public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {
         Map<Long, List<DecorationMergeCandidate>> mergedByPassageId = new LinkedHashMap<>();
         for (Passage passage : passages) {
+            if (passage.isSpoiler()) {
+                continue;
+            }
             List<DecorationMergeCandidate> candidates = decorationQueryRepository.findMergeCandidates(passage.getId());
             mergedByPassageId.put(passage.getId(), DecorationMergeSelector.select(candidates));
         }

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilter.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilter.java
@@ -13,8 +13,10 @@ import org.springframework.stereotype.Component;
 
 // 읽기 상태 기반 노출 필터(FR-WRITE-08, backend-plan.md §5.7):
 // READING  -> pageNumber <= currentPage
-// PLANNED / 미설정 / 비로그인 -> 스포일러가 아닌 대목 중 가장 작은 페이지(첫 대목)만
-// 여기에 isSpoiler=false 조건이 AND로 항상 함께 적용된다.
+// PLANNED / 미설정 / 비로그인 -> 가장 작은 페이지(첫 대목)만
+//
+// 스포일러(isSpoiler)는 여기서 걸러내지 않는다. 스포일러 대목도 "존재 자체"는 이 필터를 그대로 통과하고,
+// 실제 내용(quotedText/꾸밈)을 가리는 건 응답을 만드는 쪽(PassageResponse)의 책임이다 (FR-VIEW-03 블러+확인 버튼).
 @Component
 @RequiredArgsConstructor
 public class PassageVisibilityFilter {
@@ -23,11 +25,10 @@ public class PassageVisibilityFilter {
     private final PassageQueryRepository passageQueryRepository;
 
     public BooleanExpression build(Long bookId, Long currentUserId) {
-        QPassage passage = QPassage.passage;
-        return passage.isSpoiler.isFalse().and(pageNumberCondition(bookId, currentUserId));
+        return pageNumberCondition(bookId, currentUserId);
     }
 
-    // 스포일러가 아닌 대목 중 가장 작은 페이지 번호 (책에 노출 가능한 대목이 하나도 없으면 empty).
+    // 노출 가능한 대목 중 가장 작은 페이지 번호 (책에 대목이 하나도 없으면 empty).
     // 비로그인 사용자가 이 페이지가 아닌 다른 페이지를 요청했는지 판단하는 데 쓰인다(§4.2, FR-OPINION-08).
     public Optional<Integer> firstVisiblePageNumber(Long bookId) {
         return Optional.ofNullable(passageQueryRepository.findFirstVisiblePageNumber(bookId));

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilter.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilter.java
@@ -1,0 +1,52 @@
+package com.nexters.palang.domain.passage.application;
+
+import com.nexters.palang.domain.book.domain.ReadingStatus;
+import com.nexters.palang.domain.book.domain.UserBookStatus;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.passage.domain.QPassage;
+import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 읽기 상태 기반 노출 필터(FR-WRITE-08, backend-plan.md §5.7):
+// READING  -> pageNumber <= currentPage
+// PLANNED / 미설정 / 비로그인 -> 스포일러가 아닌 대목 중 가장 작은 페이지(첫 대목)만
+// 여기에 isSpoiler=false 조건이 AND로 항상 함께 적용된다.
+@Component
+@RequiredArgsConstructor
+public class PassageVisibilityFilter {
+
+    private final UserBookStatusRepository userBookStatusRepository;
+    private final PassageQueryRepository passageQueryRepository;
+
+    public BooleanExpression build(Long bookId, Long currentUserId) {
+        QPassage passage = QPassage.passage;
+        return passage.isSpoiler.isFalse().and(pageNumberCondition(bookId, currentUserId));
+    }
+
+    // 스포일러가 아닌 대목 중 가장 작은 페이지 번호 (책에 노출 가능한 대목이 하나도 없으면 empty).
+    // 비로그인 사용자가 이 페이지가 아닌 다른 페이지를 요청했는지 판단하는 데 쓰인다(§4.2, FR-OPINION-08).
+    public Optional<Integer> firstVisiblePageNumber(Long bookId) {
+        return Optional.ofNullable(passageQueryRepository.findFirstVisiblePageNumber(bookId));
+    }
+
+    private BooleanExpression pageNumberCondition(Long bookId, Long currentUserId) {
+        QPassage passage = QPassage.passage;
+        Optional<UserBookStatus> readingStatus = currentUserId == null
+                ? Optional.empty()
+                : userBookStatusRepository.findByUserIdAndBookId(currentUserId, bookId);
+
+        if (readingStatus.isPresent()
+                && readingStatus.get().getStatus() == ReadingStatus.READING
+                && readingStatus.get().getCurrentPage() != null) {
+            return passage.pageNumber.loe(readingStatus.get().getCurrentPage());
+        }
+
+        return firstVisiblePageNumber(bookId)
+                .map(passage.pageNumber::eq)
+                .orElseGet(() -> Expressions.asBoolean(false).isTrue());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -2,11 +2,16 @@ package com.nexters.palang.domain.passage.infrastructure;
 
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
+import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -32,6 +37,50 @@ public class PassageQueryRepository {
                 )
                 .groupBy(passage.id, passage.quotedText, passage.pageNumber)
                 .orderBy(passage.pageNumber.asc(), passage.id.asc())
+                .fetch();
+    }
+
+    // 읽기상태/스포일러 노출 필터(FR-WRITE-08)의 "PLANNED/미설정/비로그인" 기준 페이지: 스포일러가 아닌 대목 중 가장 작은 페이지 번호.
+    public Integer findFirstVisiblePageNumber(Long bookId) {
+        QPassage passage = QPassage.passage;
+        return queryFactory
+                .select(passage.pageNumber.min())
+                .from(passage)
+                .where(passage.book.id.eq(bookId), passage.isSpoiler.isFalse())
+                .fetchOne();
+    }
+
+    // 대목/흔적 조회(FR-VIEW-02)용 페이지 번호 목록: 노출 필터를 만족하는 대목이 걸쳐 있는 서로 다른 페이지 번호를 오름차순으로.
+    public Page<Integer> findVisiblePageNumbers(Long bookId, BooleanExpression visibilityFilter, Pageable pageable) {
+        QPassage passage = QPassage.passage;
+
+        List<Integer> content = queryFactory
+                .select(passage.pageNumber)
+                .from(passage)
+                .where(passage.book.id.eq(bookId), visibilityFilter)
+                .groupBy(passage.pageNumber)
+                .orderBy(passage.pageNumber.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(passage.pageNumber.countDistinct())
+                .from(passage)
+                .where(passage.book.id.eq(bookId), visibilityFilter)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // 대목 전환(FR-VIEW-03 2-b)용: 특정 페이지에 걸친 대목들을 등록 순으로. 노출 필터를 만족하지 않으면 빈 리스트.
+    public List<Passage> findVisiblePassagesByPage(Long bookId, int pageNumber, BooleanExpression visibilityFilter) {
+        QPassage passage = QPassage.passage;
+
+        return queryFactory
+                .selectFrom(passage)
+                .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber), visibilityFilter)
+                .orderBy(passage.id.asc())
                 .fetch();
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -40,13 +40,14 @@ public class PassageQueryRepository {
                 .fetch();
     }
 
-    // 읽기상태/스포일러 노출 필터(FR-WRITE-08)의 "PLANNED/미설정/비로그인" 기준 페이지: 스포일러가 아닌 대목 중 가장 작은 페이지 번호.
+    // 읽기상태 노출 필터(FR-WRITE-08)의 "PLANNED/미설정/비로그인" 기준 페이지: 가장 작은 페이지 번호.
+    // 스포일러 여부는 여기서 걸러내지 않는다 (내용 마스킹은 응답을 만드는 쪽의 책임, FR-VIEW-03).
     public Integer findFirstVisiblePageNumber(Long bookId) {
         QPassage passage = QPassage.passage;
         return queryFactory
                 .select(passage.pageNumber.min())
                 .from(passage)
-                .where(passage.book.id.eq(bookId), passage.isSpoiler.isFalse())
+                .where(passage.book.id.eq(bookId))
                 .fetchOne();
     }
 

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
@@ -1,9 +1,12 @@
 package com.nexters.palang.domain.passage.presentation;
 
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.passage.application.PassageOcrService;
+import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.passage.application.SimilarPassageFinder;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.application.dto.OcrResultDto;
+import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.presentation.docs.PassageControllerDocs;
 import com.nexters.palang.domain.passage.presentation.request.PassageRequest;
 import com.nexters.palang.domain.passage.presentation.response.PassageResponse;
@@ -11,31 +14,43 @@ import com.nexters.palang.global.common.response.DataResponse;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/passages")
 @RequiredArgsConstructor
 public class PassageController implements PassageControllerDocs {
 
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
     private final PassageOcrService passageOcrService;
     private final SimilarPassageFinder similarPassageFinder;
+    private final PassageService passageService;
     private final CurrentUserProvider currentUserProvider;
 
-    @PostMapping(path = "/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Override
+    @PostMapping(path = "/api/passages/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public DataResponse<PassageResponse.OcrRecognize> createOcrResult(@RequestPart("image") MultipartFile image) {
         List<OcrResultDto> blocks = passageOcrService.recognizeText(image);
         return DataResponse.from(PassageResponse.OcrRecognize.from(blocks));
     }
 
-    @PostMapping("/similar-check")
+    @Override
+    @PostMapping("/api/passages/similar-check")
     public DataResponse<PassageResponse.SimilarCandidates> checkSimilarPassages(
             @Valid @RequestBody PassageRequest.SimilarCheck request) {
         // 조회 결과는 유저 무관하게 동일하지만, 인증 필요 엔드포인트이므로 로그인 여부만 확인한다.
@@ -43,5 +58,31 @@ public class PassageController implements PassageControllerDocs {
         List<SimilarPassageProjection> candidates = similarPassageFinder.find(
                 request.bookId(), request.pageNumber(), request.quotedText());
         return DataResponse.from(PassageResponse.SimilarCandidates.from(candidates));
+    }
+
+    @Override
+    @GetMapping("/api/books/{bookId}/passages")
+    public DataResponse<PassageResponse.PageNumbers> getPageNumbers(
+            @PathVariable Long bookId,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        Page<Integer> pageNumbers = passageService.getVisiblePageNumbers(bookId, currentUserId, pageable(page, size));
+        return DataResponse.from(PassageResponse.PageNumbers.from(pageNumbers));
+    }
+
+    @Override
+    @GetMapping("/api/books/{bookId}/pages/{page}/passages")
+    public DataResponse<PassageResponse.PassagesByPage> getPassagesByPage(
+            @PathVariable Long bookId,
+            @PathVariable("page") int pageNumber) {
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        List<Passage> passages = passageService.getVisiblePassagesByPage(bookId, pageNumber, currentUserId);
+        Map<Long, List<DecorationMergeCandidate>> merged = passageService.getMergedDecorationsByPassageId(passages);
+        return DataResponse.from(PassageResponse.PassagesByPage.from(passages, merged));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -72,7 +72,9 @@ public interface PassageControllerDocs {
     @Operation(summary = "대목 페이지 목록 조회",
             description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다(FR-VIEW-02). "
                     + "읽기상태 기반 노출 필터가 적용됩니다: 읽는 중이면 현재 페이지까지, "
-                    + "읽을 예정/미설정/비로그인이면 스포일러가 아닌 첫 페이지만 노출됩니다(FR-WRITE-08). "
+                    + "읽을 예정/미설정/비로그인이면 첫 페이지만 노출됩니다(FR-WRITE-08). "
+                    + "스포일러 대목이 있는 페이지도 이 목록에는 포함됩니다 — 실제 내용은 "
+                    + "GET /api/books/{bookId}/pages/{page}/passages 응답에서 가려집니다. "
                     + "인증은 선택입니다(soft auth) — 헤더가 없어도 비로그인 기준으로 조회됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (대목이 없으면 빈 배열)"),
@@ -91,7 +93,9 @@ public interface PassageControllerDocs {
 
     @Operation(summary = "특정 페이지의 대목 + 꾸밈 병합 결과 조회",
             description = "같은 페이지에 여러 대목이 있으면 모두 반환합니다(대목 전환, FR-VIEW-03). "
-                    + "각 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
+                    + "스포일러가 아닌 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
+                    + "스포일러로 표기된 대목(isSpoiler=true)은 존재는 노출되지만 quotedText/decorations는 내려주지 않습니다 — "
+                    + "프론트에서 블러 처리 후 [버튼]을 눌러야 확인 가능한 화면을 구성할 수 있도록 합니다(FR-VIEW-03 스포일러 처리). "
                     + "읽기상태 노출 필터를 만족하지 않는 페이지를 요청하면 빈 배열이 반환되며, "
                     + "비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도합니다(FR-OPINION-08).")
     @ApiResponses({

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import com.nexters.palang.global.common.error.ErrorResponse;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,5 +67,44 @@ public interface PassageControllerDocs {
     })
     DataResponse<PassageResponse.SimilarCandidates> checkSimilarPassages(
             @Valid @RequestBody PassageRequest.SimilarCheck request
+    );
+
+    @Operation(summary = "대목 페이지 목록 조회",
+            description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다(FR-VIEW-02). "
+                    + "읽기상태 기반 노출 필터가 적용됩니다: 읽는 중이면 현재 페이지까지, "
+                    + "읽을 예정/미설정/비로그인이면 스포일러가 아닌 첫 페이지만 노출됩니다(FR-WRITE-08). "
+                    + "인증은 선택입니다(soft auth) — 헤더가 없어도 비로그인 기준으로 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공 (대목이 없으면 빈 배열)"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/passages\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "BOOK_404_1: 해당 도서를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/passages\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}")))
+    })
+    DataResponse<PassageResponse.PageNumbers> getPageNumbers(
+            @Parameter(description = "도서 ID", required = true) Long bookId,
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "특정 페이지의 대목 + 꾸밈 병합 결과 조회",
+            description = "같은 페이지에 여러 대목이 있으면 모두 반환합니다(대목 전환, FR-VIEW-03). "
+                    + "각 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
+                    + "읽기상태 노출 필터를 만족하지 않는 페이지를 요청하면 빈 배열이 반환되며, "
+                    + "비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도합니다(FR-OPINION-08).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공 (노출 범위 밖이면 빈 배열)"),
+            @ApiResponse(responseCode = "401", description = "AUTH_401_1: 비로그인 사용자가 첫 페이지가 아닌 페이지를 요청함.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/pages/5/passages\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "BOOK_404_1: 해당 도서를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/pages/5/passages\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}")))
+    })
+    DataResponse<PassageResponse.PassagesByPage> getPassagesByPage(
+            @Parameter(description = "도서 ID", required = true) Long bookId,
+            @Parameter(description = "페이지 번호", required = true) int page
     );
 }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -73,8 +73,7 @@ public interface PassageControllerDocs {
             description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다(FR-VIEW-02). "
                     + "읽기상태 기반 노출 필터가 적용됩니다: 읽는 중이면 현재 페이지까지, "
                     + "읽을 예정/미설정/비로그인이면 첫 페이지만 노출됩니다(FR-WRITE-08). "
-                    + "스포일러 대목이 있는 페이지도 이 목록에는 포함됩니다 — 실제 내용은 "
-                    + "GET /api/books/{bookId}/pages/{page}/passages 응답에서 가려집니다. "
+                    + "스포일러 대목이 있는 페이지도 이 목록에 포함됩니다(스포일러 블러 처리는 프론트 담당, FR-VIEW-03). "
                     + "인증은 선택입니다(soft auth) — 헤더가 없어도 비로그인 기준으로 조회됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (대목이 없으면 빈 배열)"),
@@ -93,9 +92,10 @@ public interface PassageControllerDocs {
 
     @Operation(summary = "특정 페이지의 대목 + 꾸밈 병합 결과 조회",
             description = "같은 페이지에 여러 대목이 있으면 모두 반환합니다(대목 전환, FR-VIEW-03). "
-                    + "스포일러가 아닌 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
-                    + "스포일러로 표기된 대목(isSpoiler=true)은 존재는 노출되지만 quotedText/decorations는 내려주지 않습니다 — "
-                    + "프론트에서 블러 처리 후 [버튼]을 눌러야 확인 가능한 화면을 구성할 수 있도록 합니다(FR-VIEW-03 스포일러 처리). "
+                    + "각 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
+                    + "스포일러로 표기된 대목(isSpoiler=true)도 quotedText/decorations를 그대로 내려줍니다 — "
+                    + "블러 처리 후 [버튼]을 누르면 즉시 확인 가능해야 하므로(FR-VIEW-03 스포일러 처리), "
+                    + "블러/확인 전환은 서버 왕복 없이 프론트에서 isSpoiler 플래그로 처리합니다. "
                     + "읽기상태 노출 필터를 만족하지 않는 페이지를 요청하면 빈 배열이 반환되며, "
                     + "비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도합니다(FR-OPINION-08).")
     @ApiResponses({

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -1,8 +1,14 @@
 package com.nexters.palang.domain.passage.presentation.response;
 
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse.DecorationResponse;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.application.dto.OcrResultDto;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.global.common.response.PageInfo;
 import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
 
 public class PassageResponse {
 
@@ -12,6 +18,36 @@ public class PassageResponse {
                     .map(SimilarCandidate::from)
                     .toList();
             return new SimilarCandidates(candidates);
+        }
+    }
+
+    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 발췌된 페이지 번호 목록.
+    public record PageNumbers(List<Integer> pageNumbers, PageInfo pageInfo) {
+        public static PageNumbers from(Page<Integer> page) {
+            return new PageNumbers(page.getContent(), PageInfo.from(page));
+        }
+    }
+
+    // 대목 전환(FR-VIEW-03 2-b) + 꾸밈 병합 결과(FR-VIEW-03 꾸밈 병합 표시).
+    public record PassagesByPage(List<Detail> passages) {
+        public static PassagesByPage from(List<Passage> passages, Map<Long, List<DecorationMergeCandidate>> mergedByPassageId) {
+            List<Detail> details = passages.stream()
+                    .map(passage -> Detail.from(passage, mergedByPassageId.getOrDefault(passage.getId(), List.of())))
+                    .toList();
+            return new PassagesByPage(details);
+        }
+
+        public record Detail(Long passageId, int pageNumber, String quotedText, boolean isSpoiler,
+                              List<DecorationResponse> decorations) {
+            public static Detail from(Passage passage, List<DecorationMergeCandidate> merged) {
+                List<DecorationResponse> decorations = merged.stream()
+                        .map(candidate -> new DecorationResponse(
+                                candidate.decorationId(), candidate.startOffset(), candidate.endOffset(),
+                                candidate.effectType(), candidate.color()))
+                        .toList();
+                return new Detail(passage.getId(), passage.getPageNumber(), passage.getQuotedText(),
+                        passage.isSpoiler(), decorations);
+            }
         }
     }
 

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -37,16 +37,21 @@ public class PassageResponse {
             return new PassagesByPage(details);
         }
 
+        // 스포일러 대목(isSpoiler=true)은 존재 자체는 노출하되 quotedText/decorations는 내려주지 않는다.
+        // 프론트가 블러 처리 후 [버튼]을 눌러야 확인 가능한 화면을 그릴 수 있도록 한다 (FR-VIEW-03 스포일러 처리).
         public record Detail(Long passageId, int pageNumber, String quotedText, boolean isSpoiler,
                               List<DecorationResponse> decorations) {
             public static Detail from(Passage passage, List<DecorationMergeCandidate> merged) {
+                if (passage.isSpoiler()) {
+                    return new Detail(passage.getId(), passage.getPageNumber(), null, true, List.of());
+                }
                 List<DecorationResponse> decorations = merged.stream()
                         .map(candidate -> new DecorationResponse(
                                 candidate.decorationId(), candidate.startOffset(), candidate.endOffset(),
                                 candidate.effectType(), candidate.color()))
                         .toList();
                 return new Detail(passage.getId(), passage.getPageNumber(), passage.getQuotedText(),
-                        passage.isSpoiler(), decorations);
+                        false, decorations);
             }
         }
     }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -37,21 +37,19 @@ public class PassageResponse {
             return new PassagesByPage(details);
         }
 
-        // 스포일러 대목(isSpoiler=true)은 존재 자체는 노출하되 quotedText/decorations는 내려주지 않는다.
-        // 프론트가 블러 처리 후 [버튼]을 눌러야 확인 가능한 화면을 그릴 수 있도록 한다 (FR-VIEW-03 스포일러 처리).
+        // 스포일러 대목(isSpoiler=true)도 quotedText/decorations를 그대로 내려준다.
+        // 블러 처리 + [버튼] 눌러야 확인 가능한 화면(FR-VIEW-03 스포일러 처리)은 즉시 반응해야 하는 순수 UI 동작이라
+        // 프론트가 isSpoiler 플래그만 보고 클라이언트에서 처리한다 (서버 왕복 없이 버튼 클릭 즉시 확인 가능).
         public record Detail(Long passageId, int pageNumber, String quotedText, boolean isSpoiler,
                               List<DecorationResponse> decorations) {
             public static Detail from(Passage passage, List<DecorationMergeCandidate> merged) {
-                if (passage.isSpoiler()) {
-                    return new Detail(passage.getId(), passage.getPageNumber(), null, true, List.of());
-                }
                 List<DecorationResponse> decorations = merged.stream()
                         .map(candidate -> new DecorationResponse(
                                 candidate.decorationId(), candidate.startOffset(), candidate.endOffset(),
                                 candidate.effectType(), candidate.color()))
                         .toList();
                 return new Detail(passage.getId(), passage.getPageNumber(), passage.getQuotedText(),
-                        false, decorations);
+                        passage.isSpoiler(), decorations);
             }
         }
     }

--- a/src/main/java/com/nexters/palang/global/security/CurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/CurrentUserProvider.java
@@ -1,5 +1,7 @@
 package com.nexters.palang.global.security;
 
+import java.util.Optional;
+
 public interface CurrentUserProvider {
 
     /**
@@ -7,4 +9,15 @@ public interface CurrentUserProvider {
      * 구현체를 교체 가능한 지점으로 추상화한다. 인증 안 되어 있으면 LoginRequiredException.
      */
     Long getCurrentUserId();
+
+    // Soft Authentication(§4.2): 로그인 여부에 따라 같은 GET 엔드포인트가 다른 결과를 보여줘야 하는 경우
+    // (읽기상태 기반 노출 필터 등) 사용한다. 비로그인이어도 예외 없이 빈 Optional을 반환한다.
+    // 구현체(Header/JWT)를 건드리지 않고 인터페이스에서 한 번만 정의해 재사용한다.
+    default Optional<Long> findCurrentUserId() {
+        try {
+            return Optional.of(getCurrentUserId());
+        } catch (LoginRequiredException e) {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/decoration/application/DecorationMergeSelectorTest.java
+++ b/src/test/java/com/nexters/palang/domain/decoration/application/DecorationMergeSelectorTest.java
@@ -1,0 +1,93 @@
+package com.nexters.palang.domain.decoration.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DecorationMergeSelectorTest {
+
+    private static final LocalDateTime T0 = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+    private static DecorationMergeCandidate candidate(long id, int start, int end, int likeCount, LocalDateTime createdAt) {
+        return new DecorationMergeCandidate(id, start, end, EffectType.UNDERLINE, "#PRIMARY", likeCount, createdAt);
+    }
+
+    static Stream<Arguments> cases() {
+        return Stream.of(
+                Arguments.of(
+                        "겹치지 않으면 좋아요 많은 순으로 모두 채택된다",
+                        List.of(
+                                candidate(1, 0, 5, 3, T0),
+                                candidate(2, 5, 10, 10, T0),
+                                candidate(3, 10, 15, 1, T0)
+                        ),
+                        List.of(2L, 1L, 3L)
+                ),
+                Arguments.of(
+                        "구간이 겹치면 좋아요가 적은 쪽이 제외된다",
+                        List.of(
+                                candidate(1, 0, 10, 10, T0),
+                                candidate(2, 5, 15, 3, T0)
+                        ),
+                        List.of(1L)
+                ),
+                Arguments.of(
+                        "좋아요 수가 같으면 최근에 작성된 흔적의 꾸밈이 우선한다",
+                        List.of(
+                                candidate(1, 0, 10, 5, T0),
+                                candidate(2, 10, 20, 5, T0.plusDays(1))
+                        ),
+                        List.of(2L, 1L)
+                ),
+                Arguments.of(
+                        "좋아요 수와 작성일이 모두 같으면 decoration.id가 작은 쪽이 결정적으로 우선한다",
+                        List.of(
+                                candidate(5, 0, 10, 5, T0),
+                                candidate(2, 10, 20, 5, T0)
+                        ),
+                        List.of(2L, 5L)
+                ),
+                Arguments.of(
+                        "겹치지 않는 후보가 4개 이상이어도 최대 3개까지만 채택된다",
+                        List.of(
+                                candidate(1, 0, 5, 4, T0),
+                                candidate(2, 5, 10, 3, T0),
+                                candidate(3, 10, 15, 2, T0),
+                                candidate(4, 15, 20, 1, T0)
+                        ),
+                        List.of(1L, 2L, 3L)
+                ),
+                Arguments.of(
+                        "후보가 없으면 빈 리스트를 반환한다",
+                        List.<DecorationMergeCandidate>of(),
+                        List.<Long>of()
+                ),
+                Arguments.of(
+                        "겹치는 구간이 연쇄적이어도 이미 채택된 구간과 겹치는 후보만 제외한다",
+                        List.of(
+                                candidate(1, 0, 10, 10, T0),
+                                candidate(2, 5, 15, 5, T0),
+                                candidate(3, 12, 20, 3, T0)
+                        ),
+                        List.of(1L, 3L)
+                )
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cases")
+    @DisplayName("겹침/동점자 케이스에 따라 결정적으로 최대 3개의 꾸밈이 채택된다")
+    void select(String description, List<DecorationMergeCandidate> candidates, List<Long> expectedIdsInOrder) {
+        List<DecorationMergeCandidate> selected = DecorationMergeSelector.select(candidates);
+
+        assertThat(selected).extracting(DecorationMergeCandidate::decorationId)
+                .containsExactlyElementsOf(expectedIdsInOrder);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/decoration/infrastructure/DecorationQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/decoration/infrastructure/DecorationQueryRepositoryTest.java
@@ -1,0 +1,88 @@
+package com.nexters.palang.domain.decoration.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class DecorationQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private DecorationQueryRepository decorationQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        decorationQueryRepository = new DecorationQueryRepository(new JPAQueryFactory(entityManager.getEntityManager()));
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId).snsProvider(SnsProvider.KAKAO).snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now()).build());
+    }
+
+    private Passage passage(User creator) {
+        Book book = entityManager.persistAndFlush(Book.builder()
+                .title("제목").author("작가").publisher("출판사").pageCount(300).build());
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book).creator(creator).pageNumber(1).quotedText("발췌 문장").isSpoiler(false)
+                .normalizedHash("hash").build());
+    }
+
+    private Opinion opinion(Passage passage, User writer, String content) {
+        return entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content(content).build());
+    }
+
+    private Decoration decoration(Opinion opinion, int start, int end) {
+        return entityManager.persistAndFlush(Decoration.builder()
+                .opinion(opinion).startOffset(start).endOffset(end).effectType(EffectType.UNDERLINE).build());
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 흔적의 꾸밈만 후보로 조회하고 좋아요 수는 흔적의 값을 그대로 담는다")
+    void findMergeCandidatesExcludesDeletedOpinions() {
+        User writer = user("writer-1");
+        Passage passage = passage(writer);
+        Opinion activeOpinion = opinion(passage, writer, "활성 흔적");
+        setLikeCount(activeOpinion, 7);
+        Decoration activeDecoration = decoration(activeOpinion, 0, 5);
+
+        Opinion deletedOpinion = opinion(passage, writer, "삭제된 흔적");
+        deletedOpinion.delete();
+        entityManager.persistAndFlush(deletedOpinion);
+        decoration(deletedOpinion, 5, 10);
+
+        List<DecorationMergeCandidate> candidates = decorationQueryRepository.findMergeCandidates(passage.getId());
+
+        assertThat(candidates).extracting(DecorationMergeCandidate::decorationId)
+                .containsExactly(activeDecoration.getId());
+        assertThat(candidates.get(0).likeCount()).isEqualTo(7);
+    }
+
+    private void setLikeCount(Opinion opinion, int likeCount) {
+        ReflectionTestUtils.setField(opinion, "likeCount", likeCount);
+        entityManager.persistAndFlush(opinion);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -4,15 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest.DecorationRequest;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.domain.passage.common.error.PassageException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
@@ -26,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +41,9 @@ class OpinionServiceTest {
 
     @Mock
     private OpinionRepository opinionRepository;
+
+    @Mock
+    private OpinionQueryRepository opinionQueryRepository;
 
     @Mock
     private PassageRepository passageRepository;
@@ -47,7 +58,8 @@ class OpinionServiceTest {
 
     @BeforeEach
     void setUp() {
-        opinionService = new OpinionService(opinionRepository, passageRepository, bookRepository, userRepository);
+        opinionService = new OpinionService(
+                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository);
     }
 
     private User user(Long id) {
@@ -73,6 +85,14 @@ class OpinionServiceTest {
                 bookId, 5, "발췌 문장", false, passageId, "흔적 내용",
                 List.of(new DecorationRequest(0, 5, EffectType.UNDERLINE, null))
         );
+    }
+
+    private Opinion opinionOwnedBy(Long opinionId, Long ownerId) {
+        Passage passage = passage(100L, book(10L));
+        Opinion opinion = Opinion.createWithDecorations(passage, user(ownerId), "흔적 내용",
+                List.of(Decoration.builder().startOffset(0).endOffset(5).effectType(EffectType.UNDERLINE).build()));
+        ReflectionTestUtils.setField(opinion, "id", opinionId);
+        return opinion;
     }
 
     @Test
@@ -123,5 +143,89 @@ class OpinionServiceTest {
 
         assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, null)))
                 .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("존재하는 대목으로 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
+    void getOpinionsReturnsQueryRepositoryResult() {
+        given(passageRepository.existsById(100L)).willReturn(true);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        opinionService.getOpinions(100L, OpinionSortType.LATEST, pageable);
+
+        verify(opinionQueryRepository).findOpinions(100L, OpinionSortType.LATEST, pageable);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대목으로 흔적 목록을 조회하면 예외가 발생한다")
+    void getOpinionsThrowsExceptionWhenPassageDoesNotExist() {
+        given(passageRepository.existsById(100L)).willReturn(false);
+
+        assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20)))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("존재하는 흔적을 조회하면 해당 흔적을 반환한다")
+    void getOpinionReturnsExistingOpinion() {
+        Opinion opinion = opinionOwnedBy(1L, 1L);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        Opinion result = opinionService.getOpinion(1L);
+
+        assertThat(result).isSameAs(opinion);
+    }
+
+    @Test
+    @DisplayName("삭제된 흔적을 조회하면 예외가 발생한다")
+    void getOpinionThrowsExceptionWhenOpinionIsDeleted() {
+        Opinion opinion = opinionOwnedBy(1L, 1L);
+        opinion.delete();
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        assertThatThrownBy(() -> opinionService.getOpinion(1L))
+                .isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 수정하면 내용이 변경된다")
+    void modifyOpinionUpdatesContentWhenOwner() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        Opinion result = opinionService.modifyOpinion(1L, 10L, new UpdateOpinionRequest("수정된 내용"));
+
+        assertThat(result.getContent()).isEqualTo("수정된 내용");
+    }
+
+    @Test
+    @DisplayName("본인이 아닌 사용자가 흔적을 수정하려 하면 예외가 발생한다")
+    void modifyOpinionThrowsExceptionWhenNotOwner() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        assertThatThrownBy(() -> opinionService.modifyOpinion(1L, 999L, new UpdateOpinionRequest("수정된 내용")))
+                .isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 삭제하면 소프트 삭제된다")
+    void removeOpinionDeletesWhenOwner() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        opinionService.removeOpinion(1L, 10L);
+
+        assertThat(opinion.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("본인이 아닌 사용자가 흔적을 삭제하려 하면 예외가 발생한다")
+    void removeOpinionThrowsExceptionWhenNotOwner() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        assertThatThrownBy(() -> opinionService.removeOpinion(1L, 999L))
+                .isInstanceOf(OpinionException.class);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class OpinionQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private OpinionQueryRepository opinionQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        opinionQueryRepository = new OpinionQueryRepository(new JPAQueryFactory(entityManager.getEntityManager()));
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId).snsProvider(SnsProvider.KAKAO).snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now()).build());
+    }
+
+    private Passage passage(User creator) {
+        Book book = entityManager.persistAndFlush(Book.builder()
+                .title("제목").author("작가").publisher("출판사").pageCount(300).build());
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book).creator(creator).pageNumber(1).quotedText("발췌 문장").isSpoiler(false)
+                .normalizedHash("hash").build());
+    }
+
+    private Opinion opinion(Passage passage, User writer, String content, int likeCount) {
+        Opinion opinion = Opinion.builder().passage(passage).user(writer).content(content).build();
+        ReflectionTestUtils.setField(opinion, "likeCount", likeCount);
+        return entityManager.persistAndFlush(opinion);
+    }
+
+    @Test
+    @DisplayName("정렬 기준을 좋아요순으로 주면 좋아요가 많은 흔적부터 조회한다")
+    void findOpinionsOrdersByLikeCountWhenSortTypeIsLikes() {
+        User writer = user("writer-1");
+        Passage passage = passage(writer);
+        opinion(passage, writer, "적은 좋아요", 1);
+        Opinion popular = opinion(passage, writer, "많은 좋아요", 10);
+
+        Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LIKES, PageRequest.of(0, 10));
+
+        assertThat(result.getContent().get(0).opinionId()).isEqualTo(popular.getId());
+    }
+
+    @Test
+    @DisplayName("정렬 기준을 주지 않으면(최신순) 나중에 작성된 흔적부터 조회한다")
+    void findOpinionsOrdersByCreatedAtDescendingByDefault() {
+        User writer = user("writer-2");
+        Passage passage = passage(writer);
+        opinion(passage, writer, "먼저 작성", 5);
+        Opinion later = opinion(passage, writer, "나중에 작성", 1);
+
+        Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+
+        assertThat(result.getContent().get(0).opinionId()).isEqualTo(later.getId());
+    }
+
+    @Test
+    @DisplayName("삭제된 흔적은 목록에서 제외된다")
+    void findOpinionsExcludesDeletedOpinions() {
+        User writer = user("writer-3");
+        Passage passage = passage(writer);
+        Opinion active = opinion(passage, writer, "활성 흔적", 0);
+        Opinion deleted = opinion(passage, writer, "삭제된 흔적", 0);
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(OpinionSummaryProjection::opinionId)
+                .containsExactly(active.getId());
+    }
+
+    @Test
+    @DisplayName("작성자의 닉네임을 함께 조회한다")
+    void findOpinionsIncludesAuthorNickname() {
+        User writer = user("writer-4");
+        Passage passage = passage(writer);
+        opinion(passage, writer, "흔적 내용", 0);
+
+        Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+
+        assertThat(result.getContent().get(0).nickname()).isEqualTo(writer.getNickname());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -3,6 +3,9 @@ package com.nexters.palang.domain.opinion.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,18 +15,25 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.application.OpinionService;
+import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest.DecorationRequest;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import com.nexters.palang.global.security.LoginRequiredException;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -108,5 +118,85 @@ class OpinionControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("흔적 목록을 조회하면 정렬된 목록을 반환한다")
+    void getOpinions() throws Exception {
+        OpinionSummaryProjection projection = new OpinionSummaryProjection(1L, 2L, "닉네임", "흔적 내용", 3, LocalDateTime.now());
+        given(opinionService.getOpinions(any(), any(), any()))
+                .willReturn(new PageImpl<>(List.of(projection), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/passages/100/opinions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1))
+                .andExpect(jsonPath("$.data.opinions[0].nickname").value("닉네임"));
+    }
+
+    @Test
+    @DisplayName("흔적 상세를 조회하면 작성자의 꾸밈을 그대로 반환한다")
+    void getOpinion() throws Exception {
+        given(opinionService.getOpinion(1L)).willReturn(opinionWithDecoration(1L, 100L));
+
+        mockMvc.perform(get("/api/opinions/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinionId").value(1))
+                .andExpect(jsonPath("$.data.decorations[0].startOffset").value(0));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 흔적을 상세 조회하면 404 에러가 발생한다")
+    void getOpinionFailsWhenNotFound() throws Exception {
+        given(opinionService.getOpinion(1L)).willThrow(new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/opinions/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("OPINION_404_1"));
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 수정하면 변경된 내용을 반환한다")
+    void modifyOpinion() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(opinionService.modifyOpinion(anyLong(), anyLong(), any())).willReturn(opinionWithDecoration(1L, 100L));
+
+        mockMvc.perform(patch("/api/opinions/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateOpinionRequest("수정된 내용"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinionId").value(1));
+    }
+
+    @Test
+    @DisplayName("본인이 아닌 사용자가 흔적을 수정하려 하면 403 에러가 발생한다")
+    void modifyOpinionFailsWhenNotOwner() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(opinionService.modifyOpinion(anyLong(), anyLong(), any()))
+                .willThrow(new OpinionException(OpinionErrorCode.OPINION_FORBIDDEN));
+
+        mockMvc.perform(patch("/api/opinions/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateOpinionRequest("수정된 내용"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("OPINION_403_1"));
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 삭제하면 200을 반환한다")
+    void removeOpinion() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/opinions/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("인증 없이 흔적을 삭제하려 하면 401 에러가 발생한다")
+    void removeOpinionFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(delete("/api/opinions/1"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
@@ -89,24 +89,31 @@ class PassageReadFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("비로그인 사용자는 스포일러가 아닌 첫 페이지만 볼 수 있고, 다른 페이지를 요청하면 401이다")
-    void anonymousUserSeesOnlyFirstNonSpoilerPage() throws Exception {
+    @DisplayName("비로그인 사용자는 첫 페이지만 볼 수 있고, 다른 페이지를 요청하면 401이다 (첫 페이지가 스포일러여도 페이지 자체는 노출된다)")
+    void anonymousUserSeesOnlyFirstPageEvenIfSpoiler() throws Exception {
         mockMvc.perform(get("/api/books/" + bookId + "/passages"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.pageNumbers[0]").value(3))
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(1))
                 .andExpect(jsonPath("$.data.pageNumbers.length()").value(1));
 
         mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.passages[0].passageId").value(page3.getId()));
-
-        mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }
 
     @Test
-    @DisplayName("읽는 중(READING) 상태의 로그인 사용자는 현재 페이지까지의 대목을 볼 수 있다")
+    @DisplayName("스포일러로 표기된 대목은 존재는 노출되지만 quotedText/꾸밈은 가려진다")
+    void spoilerPassageContentIsMaskedInPageDetail() throws Exception {
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/1/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(spoilerPage1.getId()))
+                .andExpect(jsonPath("$.data.passages[0].isSpoiler").value(true))
+                .andExpect(jsonPath("$.data.passages[0].quotedText").doesNotExist())
+                .andExpect(jsonPath("$.data.passages[0].decorations.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("읽는 중(READING) 상태의 로그인 사용자는 현재 페이지까지의 대목을 볼 수 있다 (스포일러 포함)")
     void readingUserSeesUpToCurrentPage() throws Exception {
         mockMvc.perform(put("/api/users/me/book-status")
                         .header("X-Debug-User-Id", readerId)
@@ -116,12 +123,14 @@ class PassageReadFlowIntegrationTest {
 
         mockMvc.perform(get("/api/books/" + bookId + "/passages").header("X-Debug-User-Id", readerId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.pageNumbers[0]").value(3))
-                .andExpect(jsonPath("$.data.pageNumbers[1]").value(6));
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(1))
+                .andExpect(jsonPath("$.data.pageNumbers[1]").value(3))
+                .andExpect(jsonPath("$.data.pageNumbers[2]").value(6));
 
         mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages").header("X-Debug-User-Id", readerId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.passages[0].passageId").value(page6.getId()));
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(page6.getId()))
+                .andExpect(jsonPath("$.data.passages[0].quotedText").value("6페이지 문장"));
     }
 
     @Test
@@ -134,7 +143,13 @@ class PassageReadFlowIntegrationTest {
         Opinion another = opinion(page3, readerId, "또 다른 흔적", 5);
         decoration(another, 10, 15);
 
-        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages"))
+        mockMvc.perform(put("/api/users/me/book-status")
+                        .header("X-Debug-User-Id", readerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bookId\": " + bookId + ", \"status\": \"READING\", \"currentPage\": 6}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages").header("X-Debug-User-Id", readerId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].decorations.length()").value(2))
                 .andExpect(jsonPath("$.data.passages[0].decorations[0].startOffset").value(3))

--- a/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
@@ -1,0 +1,161 @@
+package com.nexters.palang.domain.passage;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.ReadingStatus;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// 대목/흔적 조회 플로우를 실제 Spring 컨텍스트 + H2 DB로 end-to-end 검증한다.
+// (읽기상태 노출 필터 → 꾸밈 병합 → 흔적 정렬)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class PassageReadFlowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    private Long bookId;
+    private Long writerId;
+    private Long readerId;
+    private Passage spoilerPage1;
+    private Passage page3;
+    private Passage page6;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("책").author("작가").publisher("출판사").pageCount(300).build());
+        User writer = userRepository.save(User.builder()
+                .nickname("작성자").snsProvider(SnsProvider.KAKAO).snsId("writer").termsAgreedAt(LocalDateTime.now()).build());
+        User reader = userRepository.save(User.builder()
+                .nickname("독자").snsProvider(SnsProvider.KAKAO).snsId("reader").termsAgreedAt(LocalDateTime.now()).build());
+        bookId = book.getId();
+        writerId = writer.getId();
+        readerId = reader.getId();
+
+        spoilerPage1 = passageRepository.save(Passage.builder()
+                .book(book).creator(writer).pageNumber(1).quotedText("스포일러 문장").isSpoiler(true)
+                .normalizedHash("hash-1").build());
+        page3 = passageRepository.save(Passage.builder()
+                .book(book).creator(writer).pageNumber(3).quotedText("3페이지 문장").isSpoiler(false)
+                .normalizedHash("hash-3").build());
+        page6 = passageRepository.save(Passage.builder()
+                .book(book).creator(writer).pageNumber(6).quotedText("6페이지 문장").isSpoiler(false)
+                .normalizedHash("hash-6").build());
+    }
+
+    private Opinion opinion(Passage passage, Long userId, String content, int likeCount) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Opinion opinion = Opinion.builder().passage(passage).user(user).content(content).build();
+        ReflectionTestUtils.setField(opinion, "likeCount", likeCount);
+        return opinionRepository.save(opinion);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 스포일러가 아닌 첫 페이지만 볼 수 있고, 다른 페이지를 요청하면 401이다")
+    void anonymousUserSeesOnlyFirstNonSpoilerPage() throws Exception {
+        mockMvc.perform(get("/api/books/" + bookId + "/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(3))
+                .andExpect(jsonPath("$.data.pageNumbers.length()").value(1));
+
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(page3.getId()));
+
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("읽는 중(READING) 상태의 로그인 사용자는 현재 페이지까지의 대목을 볼 수 있다")
+    void readingUserSeesUpToCurrentPage() throws Exception {
+        mockMvc.perform(put("/api/users/me/book-status")
+                        .header("X-Debug-User-Id", readerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bookId\": " + bookId + ", \"status\": \"READING\", \"currentPage\": 6}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/books/" + bookId + "/passages").header("X-Debug-User-Id", readerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(3))
+                .andExpect(jsonPath("$.data.pageNumbers[1]").value(6));
+
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages").header("X-Debug-User-Id", readerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(page6.getId()));
+    }
+
+    @Test
+    @DisplayName("겹치지 않는 꾸밈 중 좋아요 많은 순으로 최대 3개까지만 병합되어 노출된다")
+    void mergedDecorationsShowTopThreeNonOverlapping() throws Exception {
+        Opinion popular = opinion(page3, readerId, "인기 흔적", 10);
+        decoration(popular, 0, 5);
+        Opinion overlapping = opinion(page3, readerId, "겹치는 흔적", 20);
+        decoration(overlapping, 3, 8);
+        Opinion another = opinion(page3, readerId, "또 다른 흔적", 5);
+        decoration(another, 10, 15);
+
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].decorations.length()").value(2))
+                .andExpect(jsonPath("$.data.passages[0].decorations[0].startOffset").value(3))
+                .andExpect(jsonPath("$.data.passages[0].decorations[1].startOffset").value(10));
+    }
+
+    @Test
+    @DisplayName("흔적 목록을 좋아요순으로 조회하면 좋아요가 많은 흔적부터 반환된다")
+    void getOpinionsSortedByLikes() throws Exception {
+        opinion(page3, readerId, "적은 좋아요", 1);
+        Opinion popular = opinion(page3, readerId, "많은 좋아요", 100);
+
+        mockMvc.perform(get("/api/passages/" + page3.getId() + "/opinions").param("sortType", "LIKES"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(popular.getId()));
+    }
+
+    private Decoration decoration(Opinion opinion, int start, int end) {
+        Decoration decoration = Decoration.builder()
+                .opinion(opinion).startOffset(start).endOffset(end).effectType(EffectType.UNDERLINE).build();
+        opinion.addDecoration(decoration);
+        return decoration;
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
@@ -102,14 +102,13 @@ class PassageReadFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("스포일러로 표기된 대목은 존재는 노출되지만 quotedText/꾸밈은 가려진다")
-    void spoilerPassageContentIsMaskedInPageDetail() throws Exception {
+    @DisplayName("스포일러로 표기된 대목도 isSpoiler 플래그와 함께 실제 내용을 그대로 내려준다 (블러/확인은 프론트 담당)")
+    void spoilerPassageContentIsReturnedAsIsWithSpoilerFlag() throws Exception {
         mockMvc.perform(get("/api/books/" + bookId + "/pages/1/passages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].passageId").value(spoilerPage1.getId()))
                 .andExpect(jsonPath("$.data.passages[0].isSpoiler").value(true))
-                .andExpect(jsonPath("$.data.passages[0].quotedText").doesNotExist())
-                .andExpect(jsonPath("$.data.passages[0].decorations.length()").value(0));
+                .andExpect(jsonPath("$.data.passages[0].quotedText").value("스포일러 문장"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -1,0 +1,130 @@
+package com.nexters.palang.domain.passage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.nexters.palang.global.security.LoginRequiredException;
+import com.querydsl.core.types.dsl.Expressions;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PassageServiceTest {
+
+    @Mock
+    private PassageQueryRepository passageQueryRepository;
+
+    @Mock
+    private DecorationQueryRepository decorationQueryRepository;
+
+    @Mock
+    private PassageVisibilityFilter passageVisibilityFilter;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    private PassageService passageService;
+
+    @BeforeEach
+    void setUp() {
+        passageService = new PassageService(
+                passageQueryRepository, decorationQueryRepository, passageVisibilityFilter, bookRepository);
+    }
+
+    private Passage passage(Long id) {
+        Passage passage = Passage.builder().build();
+        ReflectionTestUtils.setField(passage, "id", id);
+        return passage;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 도서로 페이지 번호를 조회하면 예외가 발생한다")
+    void getVisiblePageNumbersThrowsExceptionWhenBookDoesNotExist() {
+        given(bookRepository.existsById(1L)).willReturn(false);
+
+        assertThatThrownBy(() -> passageService.getVisiblePageNumbers(1L, 10L, PageRequest.of(0, 20)))
+                .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 첫 노출 페이지가 아닌 페이지를 요청하면 예외가 발생한다")
+    void getVisiblePassagesByPageThrowsExceptionWhenAnonymousRequestsNonFirstPage() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        given(passageVisibilityFilter.firstVisiblePageNumber(1L)).willReturn(Optional.of(3));
+
+        assertThatThrownBy(() -> passageService.getVisiblePassagesByPage(1L, 5, null))
+                .isInstanceOf(LoginRequiredException.class);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 첫 노출 페이지를 요청하면 정상 조회된다")
+    void getVisiblePassagesByPageSucceedsWhenAnonymousRequestsFirstPage() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        given(passageVisibilityFilter.firstVisiblePageNumber(1L)).willReturn(Optional.of(3));
+        given(passageVisibilityFilter.build(1L, null)).willReturn(Expressions.asBoolean(true).isTrue());
+        given(passageQueryRepository.findVisiblePassagesByPage(any(), anyInt(), any())).willReturn(List.of(passage(100L)));
+
+        List<Passage> result = passageService.getVisiblePassagesByPage(1L, 3, null);
+
+        assertThat(result).extracting(Passage::getId).containsExactly(100L);
+    }
+
+    @Test
+    @DisplayName("노출 가능한 대목이 하나도 없는 도서에 비로그인 사용자가 접근하면 예외 없이 빈 결과가 조회된다")
+    void getVisiblePassagesByPageDoesNotThrowWhenNoPassagesExistForAnonymous() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        given(passageVisibilityFilter.firstVisiblePageNumber(1L)).willReturn(Optional.empty());
+        given(passageVisibilityFilter.build(1L, null)).willReturn(Expressions.asBoolean(false).isTrue());
+        given(passageQueryRepository.findVisiblePassagesByPage(any(), anyInt(), any())).willReturn(List.of());
+
+        List<Passage> result = passageService.getVisiblePassagesByPage(1L, 3, null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("로그인 사용자는 노출 범위 밖의 페이지를 요청해도 예외 없이 빈 결과가 조회된다")
+    void getVisiblePassagesByPageDoesNotThrowForLoggedInUser() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        given(passageVisibilityFilter.build(1L, 10L)).willReturn(Expressions.asBoolean(false).isTrue());
+        given(passageQueryRepository.findVisiblePassagesByPage(any(), anyInt(), any())).willReturn(List.of());
+
+        List<Passage> result = passageService.getVisiblePassagesByPage(1L, 99, 10L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("각 대목의 꾸밈 병합 결과를 대목 ID별로 모은다")
+    void getMergedDecorationsByPassageIdGroupsResultsByPassageId() {
+        Passage passage = passage(1L);
+        DecorationMergeCandidate candidate = new DecorationMergeCandidate(
+                10L, 0, 5, EffectType.UNDERLINE, "#PRIMARY", 3, LocalDateTime.now());
+        given(decorationQueryRepository.findMergeCandidates(1L)).willReturn(List.of(candidate));
+
+        Map<Long, List<DecorationMergeCandidate>> result =
+                passageService.getMergedDecorationsByPassageId(List.of(passage));
+
+        assertThat(result.get(1L)).containsExactly(candidate);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilterTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilterTest.java
@@ -1,0 +1,170 @@
+package com.nexters.palang.domain.passage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.ReadingStatus;
+import com.nexters.palang.domain.book.domain.UserBookStatus;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.domain.QPassage;
+import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class PassageVisibilityFilterTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserBookStatusRepository userBookStatusRepository;
+
+    private PassageVisibilityFilter passageVisibilityFilter;
+    private JPAQueryFactory queryFactory;
+
+    @BeforeEach
+    void setUp() {
+        queryFactory = new JPAQueryFactory(entityManager.getEntityManager());
+        PassageQueryRepository passageQueryRepository = new PassageQueryRepository(queryFactory);
+        passageVisibilityFilter = new PassageVisibilityFilter(userBookStatusRepository, passageQueryRepository);
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId).snsProvider(SnsProvider.KAKAO).snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now()).build());
+    }
+
+    private Book book() {
+        return entityManager.persistAndFlush(Book.builder()
+                .title("제목").author("작가").publisher("출판사").pageCount(300).build());
+    }
+
+    private Passage passage(Book book, User creator, int pageNumber, boolean isSpoiler) {
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book).creator(creator).pageNumber(pageNumber)
+                .quotedText("발췌 문장 " + pageNumber).isSpoiler(isSpoiler)
+                .normalizedHash("hash-" + pageNumber).build());
+    }
+
+    private List<Passage> fetchWithFilter(BooleanExpression filter) {
+        QPassage passage = QPassage.passage;
+        return queryFactory.selectFrom(passage).where(filter).orderBy(passage.pageNumber.asc()).fetch();
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자에게는 스포일러가 아닌 첫 페이지의 대목만 보인다")
+    void anonymousUserSeesOnlyFirstNonSpoilerPage() {
+        User writer = user("writer-1");
+        Book book = book();
+        passage(book, writer, 1, true);
+        Passage firstVisible = passage(book, writer, 3, false);
+        passage(book, writer, 5, false);
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), null));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(firstVisible.getId());
+    }
+
+    @Test
+    @DisplayName("읽기상태가 없는 로그인 사용자도 첫 페이지만 보인다 (PLANNED와 동일 취급)")
+    void loggedInUserWithoutStatusSeesOnlyFirstPage() {
+        User writer = user("writer-2");
+        User reader = user("reader-1");
+        Book book = book();
+        Passage firstVisible = passage(book, writer, 2, false);
+        passage(book, writer, 4, false);
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(firstVisible.getId());
+    }
+
+    @Test
+    @DisplayName("PLANNED 상태의 사용자는 첫 페이지만 볼 수 있다")
+    void plannedUserSeesOnlyFirstPage() {
+        User writer = user("writer-3");
+        User reader = user("reader-2");
+        Book book = book();
+        Passage firstVisible = passage(book, writer, 2, false);
+        passage(book, writer, 4, false);
+        entityManager.persistAndFlush(UserBookStatus.builder()
+                .user(reader).book(book).status(ReadingStatus.PLANNED).build());
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(firstVisible.getId());
+    }
+
+    @Test
+    @DisplayName("READING 상태의 사용자는 현재 페이지까지의 대목을 볼 수 있다")
+    void readingUserSeesUpToCurrentPage() {
+        User writer = user("writer-4");
+        User reader = user("reader-3");
+        Book book = book();
+        Passage page2 = passage(book, writer, 2, false);
+        Passage page4 = passage(book, writer, 4, false);
+        passage(book, writer, 6, false);
+        entityManager.persistAndFlush(UserBookStatus.builder()
+                .user(reader).book(book).status(ReadingStatus.READING).currentPage(4).build());
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(page2.getId(), page4.getId());
+    }
+
+    @Test
+    @DisplayName("READING 상태인데 현재 페이지가 설정되지 않았으면 첫 페이지만 보인다")
+    void readingUserWithoutCurrentPageSeesOnlyFirstPage() {
+        User writer = user("writer-5");
+        User reader = user("reader-4");
+        Book book = book();
+        Passage firstVisible = passage(book, writer, 2, false);
+        passage(book, writer, 4, false);
+        entityManager.persistAndFlush(UserBookStatus.builder()
+                .user(reader).book(book).status(ReadingStatus.READING).build());
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(firstVisible.getId());
+    }
+
+    @Test
+    @DisplayName("스포일러로 표기된 대목은 읽기상태와 무관하게 항상 제외된다")
+    void spoilerPassagesAreAlwaysExcluded() {
+        User writer = user("writer-6");
+        User reader = user("reader-5");
+        Book book = book();
+        passage(book, writer, 2, true);
+        Passage nonSpoiler = passage(book, writer, 2, false);
+        entityManager.persistAndFlush(UserBookStatus.builder()
+                .user(reader).book(book).status(ReadingStatus.READING).currentPage(10).build());
+
+        List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
+
+        assertThat(visible).extracting(Passage::getId).containsExactly(nonSpoiler.getId());
+    }
+
+    @Test
+    @DisplayName("노출 가능한 대목이 하나도 없으면 첫 노출 페이지는 empty다")
+    void firstVisiblePageNumberIsEmptyWhenNoPassages() {
+        Book book = book();
+
+        assertThat(passageVisibilityFilter.firstVisiblePageNumber(book.getId())).isEmpty();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilterTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageVisibilityFilterTest.java
@@ -68,12 +68,12 @@ class PassageVisibilityFilterTest {
     }
 
     @Test
-    @DisplayName("비로그인 사용자에게는 스포일러가 아닌 첫 페이지의 대목만 보인다")
-    void anonymousUserSeesOnlyFirstNonSpoilerPage() {
+    @DisplayName("비로그인 사용자에게는 첫 페이지의 대목만 보인다 (스포일러여도 페이지 자체는 노출 대상에 포함된다)")
+    void anonymousUserSeesOnlyFirstPageEvenIfItIsSpoiler() {
         User writer = user("writer-1");
         Book book = book();
-        passage(book, writer, 1, true);
-        Passage firstVisible = passage(book, writer, 3, false);
+        Passage firstVisible = passage(book, writer, 1, true);
+        passage(book, writer, 3, false);
         passage(book, writer, 5, false);
 
         List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), null));
@@ -145,19 +145,19 @@ class PassageVisibilityFilterTest {
     }
 
     @Test
-    @DisplayName("스포일러로 표기된 대목은 읽기상태와 무관하게 항상 제외된다")
-    void spoilerPassagesAreAlwaysExcluded() {
+    @DisplayName("스포일러로 표기된 대목도 읽기상태 범위 안이면 노출 대상에 포함된다 (내용 마스킹은 응답 단계의 책임)")
+    void spoilerPassagesAreIncludedWhenWithinVisibleRange() {
         User writer = user("writer-6");
         User reader = user("reader-5");
         Book book = book();
-        passage(book, writer, 2, true);
-        Passage nonSpoiler = passage(book, writer, 2, false);
+        Passage spoiler = passage(book, writer, 2, true);
+        Passage nonSpoiler = passage(book, writer, 4, false);
         entityManager.persistAndFlush(UserBookStatus.builder()
                 .user(reader).book(book).status(ReadingStatus.READING).currentPage(10).build());
 
         List<Passage> visible = fetchWithFilter(passageVisibilityFilter.build(book.getId(), reader.getId()));
 
-        assertThat(visible).extracting(Passage::getId).containsExactly(nonSpoiler.getId());
+        assertThat(visible).extracting(Passage::getId).containsExactly(spoiler.getId(), nonSpoiler.getId());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -123,8 +123,8 @@ class PassageQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("스포일러가 아닌 대목 중 가장 작은 페이지 번호를 첫 노출 페이지로 조회한다")
-    void findFirstVisiblePageNumberIgnoresSpoilerPassages() {
+    @DisplayName("스포일러 대목도 존재로 취급되어 가장 작은 페이지 번호에 포함된다 (내용 마스킹은 응답 단계의 책임)")
+    void findFirstVisiblePageNumberIncludesSpoilerPassages() {
         User writer = user("writer-4");
         Book book = book("책");
         passage(book, writer, 1, true);
@@ -133,7 +133,7 @@ class PassageQueryRepositoryTest {
 
         Integer firstPage = passageQueryRepository.findFirstVisiblePageNumber(book.getId());
 
-        assertThat(firstPage).isEqualTo(3);
+        assertThat(firstPage).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -6,9 +6,11 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.domain.QPassage;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
@@ -63,6 +67,19 @@ class PassageQueryRepositoryTest {
                 .build());
     }
 
+    private Passage passage(Book book, User creator, int pageNumber, boolean isSpoiler) {
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book)
+                .creator(creator)
+                .pageNumber(pageNumber)
+                .quotedText("발췌 문장 " + pageNumber)
+                .isSpoiler(isSpoiler)
+                .normalizedHash("hash-" + book.getId() + "-" + pageNumber)
+                .build());
+    }
+
+    private static final BooleanExpression NOT_SPOILER = QPassage.passage.isSpoiler.isFalse();
+
     @Test
     @DisplayName("같은 책의 인접 페이지(±1)에서 정규화 해시가 같은 대목을 후보로 조회한다")
     void findSimilarCandidatesReturnsPassagesWithinAdjacentPages() {
@@ -103,5 +120,58 @@ class PassageQueryRepositoryTest {
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).opinionCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("스포일러가 아닌 대목 중 가장 작은 페이지 번호를 첫 노출 페이지로 조회한다")
+    void findFirstVisiblePageNumberIgnoresSpoilerPassages() {
+        User writer = user("writer-4");
+        Book book = book("책");
+        passage(book, writer, 1, true);
+        passage(book, writer, 3, false);
+        passage(book, writer, 5, false);
+
+        Integer firstPage = passageQueryRepository.findFirstVisiblePageNumber(book.getId());
+
+        assertThat(firstPage).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("노출 대상 대목이 하나도 없으면 첫 노출 페이지는 null이다")
+    void findFirstVisiblePageNumberReturnsNullWhenNoPassages() {
+        Book book = book("빈 책");
+
+        Integer firstPage = passageQueryRepository.findFirstVisiblePageNumber(book.getId());
+
+        assertThat(firstPage).isNull();
+    }
+
+    @Test
+    @DisplayName("노출 필터를 만족하는 서로 다른 페이지 번호만 오름차순으로 조회한다")
+    void findVisiblePageNumbersReturnsDistinctPagesInAscendingOrder() {
+        User writer = user("writer-5");
+        Book book = book("책");
+        passage(book, writer, 5, false);
+        passage(book, writer, 5, false);
+        passage(book, writer, 2, false);
+        passage(book, writer, 1, true);
+
+        Page<Integer> result = passageQueryRepository.findVisiblePageNumbers(book.getId(), NOT_SPOILER, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).containsExactly(2, 5);
+    }
+
+    @Test
+    @DisplayName("특정 페이지에 걸친 대목을 노출 필터에 맞춰 등록 순으로 조회한다")
+    void findVisiblePassagesByPageReturnsPassagesInCreationOrder() {
+        User writer = user("writer-6");
+        Book book = book("책");
+        Passage first = passage(book, writer, 3, false);
+        Passage second = passage(book, writer, 3, false);
+        passage(book, writer, 3, true);
+
+        List<Passage> result = passageQueryRepository.findVisiblePassagesByPage(book.getId(), 3, NOT_SPOILER);
+
+        assertThat(result).extracting(Passage::getId).containsExactly(first.getId(), second.getId());
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
@@ -4,24 +4,32 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.passage.application.PassageOcrService;
+import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.passage.application.SimilarPassageFinder;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
+import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.presentation.request.PassageRequest;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import com.nexters.palang.global.security.LoginRequiredException;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PassageController.class)
@@ -39,7 +47,16 @@ class PassageControllerTest {
     private SimilarPassageFinder similarPassageFinder;
 
     @MockitoBean
+    private PassageService passageService;
+
+    @MockitoBean
     private CurrentUserProvider currentUserProvider;
+
+    private Passage passage(Long id, int pageNumber) {
+        Passage passage = Passage.builder().pageNumber(pageNumber).quotedText("발췌 문장").isSpoiler(false).build();
+        ReflectionTestUtils.setField(passage, "id", id);
+        return passage;
+    }
 
     @Test
     @DisplayName("유사 문장 후보를 조회하면 대목 목록을 반환한다")
@@ -97,5 +114,55 @@ class PassageControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("페이지 번호 목록을 조회하면 오름차순으로 반환한다")
+    void getPageNumbers() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.empty());
+        given(passageService.getVisiblePageNumbers(any(), any(), any()))
+                .willReturn(new PageImpl<>(List.of(2, 5), PageRequest.of(0, 20), 2));
+
+        mockMvc.perform(get("/api/books/1/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(2))
+                .andExpect(jsonPath("$.data.pageNumbers[1]").value(5));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자로 페이지 번호를 조회해도 401 없이 조회된다 (soft auth)")
+    void getPageNumbersDoesNotRequireAuthentication() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.empty());
+        given(passageService.getVisiblePageNumbers(any(), any(), any()))
+                .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+
+        mockMvc.perform(get("/api/books/1/passages"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("특정 페이지의 대목과 병합된 꾸밈을 함께 반환한다")
+    void getPassagesByPage() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.of(1L));
+        Passage passage = passage(10L, 3);
+        given(passageService.getVisiblePassagesByPage(any(), anyInt(), any())).willReturn(List.of(passage));
+        given(passageService.getMergedDecorationsByPassageId(any())).willReturn(Map.of(10L, List.of()));
+
+        mockMvc.perform(get("/api/books/1/pages/3/passages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(10))
+                .andExpect(jsonPath("$.data.passages[0].pageNumber").value(3));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401 에러가 발생한다")
+    void getPassagesByPageFailsWhenAnonymousRequestsNonFirstPage() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.empty());
+        given(passageService.getVisiblePassagesByPage(any(), anyInt(), any()))
+                .willThrow(new LoginRequiredException());
+
+        mockMvc.perform(get("/api/books/1/pages/5/passages"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #15

## 🚀 개요
> backend_plan.md §5.6, §5.7, §6 Phase 1 기준으로 최우선 난이도 항목(꾸밈 병합)을 포함한 대목/흔적 조회 API를 구현합니다.

읽기상태 기반 노출 필터 → 꾸밈 병합 → 흔적 목록/상세/수정/삭제까지 이어지는 조회 플로우 전체를 구현했습니다. #14(흔적 작성)의 뒤를 잇는 읽기 쪽 API입니다.

## 📄 작업 내용

| Method | Path | 설명 |
|---|---|---|
| GET | /api/books/{bookId}/passages | 노출 필터를 만족하는 페이지 번호 목록 (FR-VIEW-02) |
| GET | /api/books/{bookId}/pages/{page}/passages | 특정 페이지의 대목(들) + 꾸밈 병합 결과 (FR-VIEW-03) |
| GET | /api/passages/{passageId}/opinions?sortType=&page=&size= | 흔적 목록, 최신순(기본)/좋아요순 (FR-OPINION-03) |
| GET | /api/opinions/{opinionId} | 흔적 상세 + 작성자가 기록한 꾸밈 (FR-OPINION-05) |
| PATCH/DELETE | /api/opinions/{opinionId} | 본인만 수정/삭제 |

- `CurrentUserProvider.findCurrentUserId()`: soft auth(비로그인이어도 예외 없이 다른 결과)를 위한 기본 메서드 추가
- `DecorationMergeSelector`: 좋아요 수 DESC → 작성일 DESC → decoration.id ASC 순 정렬 + 구간 겹침 검사로 최대 3개를 결정적으로 채택하는 순수 함수 (FR-VIEW-03)
- `PassageVisibilityFilter`: READING(현재 페이지까지)/PLANNED·미설정·비로그인(스포일러 아닌 첫 대목만) + isSpoiler=false를 QueryDSL 조건으로 결합, 여러 조회에서 재사용
- 비로그인 사용자가 첫 노출 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도 (FR-OPINION-08, backend-plan.md §4.2)
- 기존 `PassageController`를 `BookController`와 같은 스타일(클래스 레벨 매핑 제거)로 통일

## 📸 스크린샷 / 테스트 결과 (선택)
> `./gradlew build` 및 `./gradlew test` 전체 통과 (161개, 실패 0)
> 순수 유닛(꾸밈 병합 겹침/동점자 케이스 파라미터화 테이블) + Mockito 서비스 테스트 + `@DataJpaTest`(신규 쿼리 전부) + `@WebMvcTest` 컨트롤러 슬라이스 + 실제 Spring 컨텍스트+H2로 노출 필터/병합/정렬/401 분기를 함께 검증하는 통합 테스트(`PassageReadFlowIntegrationTest`) 포함

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- **스포일러 대목 처리**: requirements.md FR-VIEW-03은 "블러 처리 + 버튼으로 확인"(콘텐츠는 내려주되 프론트가 가림) 뉘앙스인데, backend_plan.md §5.7은 "isSpoiler AND 필터"(아예 결과에서 제외)로 더 단순하게 확정해뒀습니다. 이번 PR은 후자(완전 제외)로 구현했는데, 이게 맞는 해석인지 확인 부탁드립니다 — 만약 블러+리빌 방식이 맞다면 필터링 로직과 응답 스키마를 다시 설계해야 합니다.
- **비로그인 사용자의 페이지 접근 제한**: "비로그인 사용자가 2페이지 이상 열람 시도 → 401"(backend_plan.md §4.2)을 "요청한 페이지 번호가 그 책의 (스포일러 아닌) 첫 페이지와 다르면 401"로 구현했습니다. 로그인 사용자가 PLANNED 상태에서 노출 범위 밖 페이지를 요청하는 경우는 401이 아니라 빈 배열을 반환하도록 다르게 처리했는데, 이 비대칭이 의도와 맞는지 확인 부탁드립니다.
- **OpinionResponse 분리**: 기존(#14) `OpinionResponse`엔 생성 시점 전용 필드인 `merged`가 있어서, GET 상세 조회용으로 이 필드가 없는 `OpinionDetailResponse`를 새로 만들었습니다. 두 응답이 겹치는 필드가 많은데, 이대로 별도 유지할지 아니면 병합할지 의견 부탁드립니다.
- `DecorationRepository`/`OpinionRepository`에 직접 쿼리 메서드를 추가하지 않고 QueryDSL 전용 Query Repository를 새로 분리했습니다 (기존 `BookQueryRepository`/`PassageQueryRepository`/`CommentQueryRepository` 컨벤션과 동일).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 대목의 페이지 목록/페이지별 대목 조회 API 추가(비로그인 시 첫 노출 페이지 중심), 스포일러는 인용 텍스트 및 꾸밈 정보 노출 규칙에 따라 응답됩니다.
  * 대목별 흔적(의견) 목록 조회(최신순/좋아요순 정렬, 페이징) 및 상세 조회 제공.
  * 본인 흔적 수정/삭제 지원, 대목별 꾸밈 병합 결과를 최대 3개로 선별해 함께 표시합니다.
* **문서화**
  * 신규 대목/흔적 조회 및 예외 응답 Swagger 스펙을 보강했습니다.
* **Tests**
  * 병합 후보 선별, 조회/정렬, 권한 처리, 컨트롤러 흐름에 대한 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->