### PR TITLE
Feat/#18 마이페이지 API

### DIFF
--- a/src/main/java/com/nexters/palang/domain/opinion/application/LikedOpinionProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/LikedOpinionProjection.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.opinion.application;
+
+import java.time.LocalDateTime;
+
+public record LikedOpinionProjection(
+        Long opinionId,
+        Long bookId,
+        String bookTitle,
+        String bookCoverImageUrl,
+        Long passageId,
+        String quotedText,
+        int pageNumber,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt,
+        LocalDateTime likedAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/application/MyOpinionProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/MyOpinionProjection.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.opinion.application;
+
+import java.time.LocalDateTime;
+
+public record MyOpinionProjection(
+        Long opinionId,
+        Long bookId,
+        String bookTitle,
+        String bookCoverImageUrl,
+        Long passageId,
+        String quotedText,
+        int pageNumber,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -6,6 +6,7 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
 import com.nexters.palang.domain.passage.application.PassageNormalizer;
@@ -19,6 +20,8 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OpinionService {
 
     private final OpinionRepository opinionRepository;
+    private final OpinionQueryRepository opinionQueryRepository;
     private final PassageRepository passageRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
@@ -61,6 +65,18 @@ public class OpinionService {
             throw new PassageException(PassageErrorCode.PASSAGE_BOOK_MISMATCH);
         }
         return existing;
+    }
+
+    public Page<MyOpinionProjection> getMyOpinions(Long userId, Pageable pageable) {
+        return opinionQueryRepository.findMyOpinions(userId, pageable);
+    }
+
+    public Page<LikedOpinionProjection> getLikedOpinions(Long userId, Pageable pageable) {
+        return opinionQueryRepository.findLikedOpinions(userId, pageable);
+    }
+
+    public long getMyOpinionCount(Long userId) {
+        return opinionRepository.countByUserIdAndDeletedAtIsNull(userId);
     }
 
     private Passage createNewPassage(CreateOpinionRequest request, User creator) {

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -1,0 +1,83 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import com.nexters.palang.domain.book.domain.QBook;
+import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
+import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
+import com.nexters.palang.domain.opinion.domain.QOpinion;
+import com.nexters.palang.domain.opinion.domain.QOpinionLike;
+import com.nexters.palang.domain.passage.domain.QPassage;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OpinionQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<MyOpinionProjection> findMyOpinions(Long userId, Pageable pageable) {
+        QOpinion opinion = QOpinion.opinion;
+        QPassage passage = QPassage.passage;
+        QBook book = QBook.book;
+
+        List<MyOpinionProjection> content = queryFactory
+                .select(Projections.constructor(MyOpinionProjection.class,
+                        opinion.id, book.id, book.title, book.coverImageUrl,
+                        passage.id, passage.quotedText, passage.pageNumber,
+                        opinion.content, opinion.likeCount, opinion.createdAt))
+                .from(opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .orderBy(opinion.createdAt.desc(), opinion.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(opinion.count())
+                .from(opinion)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // liked_at(=OpinionLike.createdAt) 최신순. idx_likes_user_created(user_id, created_at) 인덱스와 정합.
+    public Page<LikedOpinionProjection> findLikedOpinions(Long userId, Pageable pageable) {
+        QOpinionLike opinionLike = QOpinionLike.opinionLike;
+        QOpinion opinion = QOpinion.opinion;
+        QPassage passage = QPassage.passage;
+        QBook book = QBook.book;
+
+        List<LikedOpinionProjection> content = queryFactory
+                .select(Projections.constructor(LikedOpinionProjection.class,
+                        opinion.id, book.id, book.title, book.coverImageUrl,
+                        passage.id, passage.quotedText, passage.pageNumber,
+                        opinion.content, opinion.likeCount, opinion.createdAt, opinionLike.createdAt))
+                .from(opinionLike)
+                .join(opinionLike.opinion, opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .orderBy(opinionLike.createdAt.desc(), opinionLike.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(opinionLike.count())
+                .from(opinionLike)
+                .join(opinionLike.opinion, opinion)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -4,4 +4,6 @@ import com.nexters.palang.domain.opinion.domain.Opinion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OpinionRepository extends JpaRepository<Opinion, Long> {
+
+    long countByUserIdAndDeletedAtIsNull(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -1,0 +1,48 @@
+package com.nexters.palang.domain.user.application;
+
+import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
+import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.LikedOpinionResponse;
+import com.nexters.palang.domain.user.presentation.dto.MeResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyOpinionResponse;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class UserMapper {
+
+    private UserMapper() {
+    }
+
+    public static MeResponse toMeResponse(User user, long opinionCount) {
+        return new MeResponse(
+                user.getId(), user.getNickname(), user.getProfileImageUrl(),
+                user.getBackgroundColor(), user.getSnsProvider(), opinionCount);
+    }
+
+    public static MyOpinionResponse toMyOpinionResponse(MyOpinionProjection projection) {
+        return new MyOpinionResponse(
+                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.bookCoverImageUrl(),
+                projection.passageId(), projection.quotedText(), projection.pageNumber(),
+                projection.content(), projection.likeCount(), projection.createdAt());
+    }
+
+    public static MyOpinionListResponse toMyOpinionListResponse(Page<MyOpinionProjection> projections) {
+        return new MyOpinionListResponse(
+                projections.map(UserMapper::toMyOpinionResponse).getContent(), PageInfo.from(projections));
+    }
+
+    public static LikedOpinionResponse toLikedOpinionResponse(LikedOpinionProjection projection) {
+        return new LikedOpinionResponse(
+                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.bookCoverImageUrl(),
+                projection.passageId(), projection.quotedText(), projection.pageNumber(),
+                projection.content(), projection.likeCount(), projection.createdAt(), projection.likedAt());
+    }
+
+    public static LikedOpinionListResponse toLikedOpinionListResponse(Page<LikedOpinionProjection> projections) {
+        return new LikedOpinionListResponse(
+                projections.map(UserMapper::toLikedOpinionResponse).getContent(), PageInfo.from(projections));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/application/UserService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserService.java
@@ -1,0 +1,54 @@
+package com.nexters.palang.domain.user.application;
+
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User getMe(Long userId) {
+        return getActiveUser(userId);
+    }
+
+    @Transactional
+    public User modifyNickname(Long userId, String nickname) {
+        User user = getActiveUser(userId);
+        if (userRepository.existsByNicknameAndIdNot(nickname, userId)) {
+            throw new UserException(UserErrorCode.NICKNAME_ALREADY_IN_USE);
+        }
+        user.changeNickname(nickname);
+        return user;
+    }
+
+    @Transactional
+    public User modifyBackgroundColor(Long userId, String backgroundColor) {
+        User user = getActiveUser(userId);
+        user.changeBackgroundColor(backgroundColor);
+        return user;
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = getActiveUser(userId);
+        user.withdraw();
+    }
+
+    // 탈퇴한 사용자는 더 이상 조작 대상이 아니므로 존재하지 않는 것과 동일하게 취급한다.
+    private User getActiveUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (user.isWithdrawn()) {
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements BaseErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_1", "해당 사용자를 찾을 수 없습니다."),
+    NICKNAME_CHANGE_LIMITED(HttpStatus.BAD_REQUEST, "USER_400_1", "닉네임은 하루에 한 번만 변경할 수 있습니다."),
+    NICKNAME_ALREADY_IN_USE(HttpStatus.CONFLICT, "USER_409_1", "이미 사용 중인 닉네임입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -1,5 +1,7 @@
 package com.nexters.palang.domain.user.domain;
 
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,6 +32,7 @@ import lombok.NoArgsConstructor;
 public class User extends BaseEntity {
 
     public static final int NICKNAME_MAX_LENGTH = 15;
+    public static final int BACKGROUND_COLOR_MAX_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,7 +48,7 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_url", columnDefinition = "TEXT")
     private String profileImageUrl;
 
-    @Column(name = "background_color", length = 20)
+    @Column(name = "background_color", length = BACKGROUND_COLOR_MAX_LENGTH)
     private String backgroundColor;
 
     @Enumerated(EnumType.STRING)
@@ -87,6 +91,20 @@ public class User extends BaseEntity {
 
     public void completeOnboarding() {
         this.hasCompletedOnboarding = true;
+    }
+
+    // 하루 1회 제한(FR-MY-05): 마지막 변경일이 오늘이면 재변경을 막는다. 이 사용자 한 명의 상태만으로
+    // 판단 가능한 생성/수정 시점 불변식이라 서비스 계층이 아닌 엔티티에서 직접 막는다.
+    public void changeNickname(String nickname) {
+        if (nicknameUpdatedAt != null && nicknameUpdatedAt.toLocalDate().isEqual(LocalDate.now())) {
+            throw new UserException(UserErrorCode.NICKNAME_CHANGE_LIMITED);
+        }
+        this.nickname = nickname;
+        this.nicknameUpdatedAt = LocalDateTime.now();
+    }
+
+    public void changeBackgroundColor(String backgroundColor) {
+        this.backgroundColor = backgroundColor;
     }
 
     public void withdraw() {

--- a/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
@@ -4,4 +4,6 @@ import com.nexters.palang.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -1,0 +1,138 @@
+package com.nexters.palang.domain.user.presentation;
+
+import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MeResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
+import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "User", description = "마이페이지 API")
+public interface UserApi {
+
+    @Operation(summary = "내 프로필 조회", description = "닉네임, 프로필 이미지, 배경색, 가입 경로(SNS), "
+            + "지금까지 남긴 흔적 수를 조회합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-01)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음(탈퇴 포함) (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MeResponse>> getMe();
+
+    @Operation(summary = "닉네임 변경", description = "최대 15자, 중복 불가, 하루 1회만 변경할 수 있습니다(달력일 기준). "
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-05)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "닉네임 누락/15자 초과 (COMMON_400_1) "
+                    + "또는 오늘 이미 변경함 (USER_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "COMMON_400_1", value = "{\"type\":\"/api/users/me/nickname\","
+                                    + "\"title\":\"COMMON_400_1\",\"status\":400,"
+                                    + "\"detail\":\"닉네임은 15자를 초과할 수 없습니다.\"}"),
+                            @ExampleObject(name = "USER_400_1", value = "{\"type\":\"/api/users/me/nickname\","
+                                    + "\"title\":\"USER_400_1\",\"status\":400,"
+                                    + "\"detail\":\"닉네임은 하루에 한 번만 변경할 수 있습니다.\"}")
+                    })),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/nickname\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음 (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/nickname\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임 (USER_409_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/nickname\",\"title\":\"USER_409_1\","
+                                    + "\"status\":409,\"detail\":\"이미 사용 중인 닉네임입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MeResponse>> modifyNickname(@Valid UpdateNicknameRequest request);
+
+    @Operation(summary = "배경색 변경", description = "흔적 보기 화면의 배경색을 변경합니다. "
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "배경색 누락/20자 초과 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/background-color\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"배경색은 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/background-color\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음 (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/background-color\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MeResponse>> modifyBackgroundColor(@Valid UpdateBackgroundColorRequest request);
+
+    @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
+            + "공개된 발췌·의견·댓글은 남습니다). X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (NFR-PRIVACY)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음(이미 탈퇴 포함) (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> withdraw();
+
+    @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "좋아요 누른 흔적 목록", description = "내가 좋아요를 누른 흔적을 좋아요 누른 순서대로(최신순) 조회합니다. "
+            + "좋아요 취소는 이 API가 아니라 흔적 좋아요 토글 API가 담당합니다. "
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/likes\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/likes\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<LikedOpinionListResponse>> getLikedOpinions(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -1,0 +1,98 @@
+package com.nexters.palang.domain.user.presentation;
+
+import com.nexters.palang.domain.opinion.application.OpinionService;
+import com.nexters.palang.domain.user.application.UserMapper;
+import com.nexters.palang.domain.user.application.UserService;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MeResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
+import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final UserService userService;
+    private final OpinionService opinionService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @GetMapping("/api/users/me")
+    public ResponseEntity<DataResponse<MeResponse>> getMe() {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        User user = userService.getMe(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(toMeResponse(currentUserId, user)));
+    }
+
+    @Override
+    @PatchMapping("/api/users/me/nickname")
+    public ResponseEntity<DataResponse<MeResponse>> modifyNickname(@RequestBody @Valid UpdateNicknameRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        User user = userService.modifyNickname(currentUserId, request.nickname());
+        return ResponseEntity.ok(DataResponse.from(toMeResponse(currentUserId, user)));
+    }
+
+    @Override
+    @PatchMapping("/api/users/me/background-color")
+    public ResponseEntity<DataResponse<MeResponse>> modifyBackgroundColor(
+            @RequestBody @Valid UpdateBackgroundColorRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        User user = userService.modifyBackgroundColor(currentUserId, request.backgroundColor());
+        return ResponseEntity.ok(DataResponse.from(toMeResponse(currentUserId, user)));
+    }
+
+    @Override
+    @DeleteMapping("/api/users/me")
+    public ResponseEntity<DataResponse<Void>> withdraw() {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        userService.withdraw(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @GetMapping("/api/users/me/opinions")
+    public ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(UserMapper.toMyOpinionListResponse(
+                opinionService.getMyOpinions(currentUserId, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/users/me/likes")
+    public ResponseEntity<DataResponse<LikedOpinionListResponse>> getLikedOpinions(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(UserMapper.toLikedOpinionListResponse(
+                opinionService.getLikedOpinions(currentUserId, pageable(page, size)))));
+    }
+
+    private MeResponse toMeResponse(Long userId, User user) {
+        return UserMapper.toMeResponse(user, opinionService.getMyOpinionCount(userId));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionListResponse.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import java.util.List;
+
+public record LikedOpinionListResponse(List<LikedOpinionResponse> opinions, PageInfo pageInfo) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import java.time.LocalDateTime;
+
+public record LikedOpinionResponse(
+        Long opinionId,
+        Long bookId,
+        String bookTitle,
+        String bookCoverImageUrl,
+        Long passageId,
+        String quotedText,
+        int pageNumber,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt,
+        LocalDateTime likedAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.domain.user.domain.SnsProvider;
+
+public record MeResponse(
+        Long userId,
+        String nickname,
+        String profileImageUrl,
+        String backgroundColor,
+        SnsProvider snsProvider,
+        long opinionCount
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionListResponse.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import java.util.List;
+
+public record MyOpinionListResponse(List<MyOpinionResponse> opinions, PageInfo pageInfo) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import java.time.LocalDateTime;
+
+public record MyOpinionResponse(
+        Long opinionId,
+        Long bookId,
+        String bookTitle,
+        String bookCoverImageUrl,
+        Long passageId,
+        String quotedText,
+        int pageNumber,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateBackgroundColorRequest.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateBackgroundColorRequest.java
@@ -1,0 +1,12 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.domain.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateBackgroundColorRequest(
+        @NotBlank(message = "배경색은 필수입니다.")
+        @Size(max = User.BACKGROUND_COLOR_MAX_LENGTH, message = "배경색은 20자를 초과할 수 없습니다.")
+        String backgroundColor
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.domain.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = User.NICKNAME_MAX_LENGTH, message = "닉네임은 15자를 초과할 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -10,6 +10,7 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest.DecorationRequest;
@@ -18,6 +19,7 @@ import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +28,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +39,9 @@ class OpinionServiceTest {
 
     @Mock
     private OpinionRepository opinionRepository;
+
+    @Mock
+    private OpinionQueryRepository opinionQueryRepository;
 
     @Mock
     private PassageRepository passageRepository;
@@ -47,7 +56,8 @@ class OpinionServiceTest {
 
     @BeforeEach
     void setUp() {
-        opinionService = new OpinionService(opinionRepository, passageRepository, bookRepository, userRepository);
+        opinionService = new OpinionService(
+                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository);
     }
 
     private User user(Long id) {
@@ -123,5 +133,44 @@ class OpinionServiceTest {
 
         assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, null)))
                 .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("내가 남긴 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
+    void getMyOpinionsReturnsPageFromQueryRepository() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<MyOpinionProjection> expected = new PageImpl<>(
+                List.of(new MyOpinionProjection(1L, 10L, "제목", "cover", 100L, "발췌", 5, "흔적", 0, LocalDateTime.now())),
+                pageable, 1);
+        given(opinionQueryRepository.findMyOpinions(1L, pageable)).willReturn(expected);
+
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(1L, pageable);
+
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
+    void getLikedOpinionsReturnsPageFromQueryRepository() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<LikedOpinionProjection> expected = new PageImpl<>(
+                List.of(new LikedOpinionProjection(1L, 10L, "제목", "cover", 100L, "발췌", 5, "흔적", 0,
+                        LocalDateTime.now(), LocalDateTime.now())),
+                pageable, 1);
+        given(opinionQueryRepository.findLikedOpinions(1L, pageable)).willReturn(expected);
+
+        Page<LikedOpinionProjection> results = opinionService.getLikedOpinions(1L, pageable);
+
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("내가 남긴 흔적 수를 조회하면 Repository의 카운트를 그대로 반환한다")
+    void getMyOpinionCountReturnsRepositoryCount() {
+        given(opinionRepository.countByUserIdAndDeletedAtIsNull(1L)).willReturn(3L);
+
+        long count = opinionService.getMyOpinionCount(1L);
+
+        assertThat(count).isEqualTo(3L);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
+import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionLike;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class OpinionQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private OpinionQueryRepository opinionQueryRepository;
+
+    private User me;
+    private User other;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        opinionQueryRepository = new OpinionQueryRepository(new JPAQueryFactory(entityManager.getEntityManager()));
+
+        me = user("me");
+        other = user("other");
+        book = entityManager.persistAndFlush(Book.builder()
+                .title("책").author("작가").publisher("출판사").pageCount(300).build());
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId)
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Passage passage(int pageNumber) {
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book).creator(me).pageNumber(pageNumber).quotedText("발췌 문장").isSpoiler(false)
+                .normalizedHash("hash-" + pageNumber).build());
+    }
+
+    private Opinion opinion(User user, Passage passage, String content) {
+        return entityManager.persistAndFlush(Opinion.builder().passage(passage).user(user).content(content).build());
+    }
+
+    @Test
+    @DisplayName("내가 남긴 흔적만 최신순으로 조회하고 삭제된 흔적/다른 사람 흔적은 제외한다")
+    void findMyOpinionsExcludesDeletedAndOtherUsers() {
+        Opinion older = opinion(me, passage(1), "첫 흔적");
+        Opinion newer = opinion(me, passage(2), "둘째 흔적");
+        Opinion deleted = opinion(me, passage(3), "삭제된 흔적");
+        deleted.delete();
+        opinion(other, passage(4), "다른 사람 흔적");
+
+        Page<MyOpinionProjection> results = opinionQueryRepository.findMyOpinions(me.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(MyOpinionProjection::opinionId)
+                .containsExactly(newer.getId(), older.getId());
+        assertThat(results.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 흔적을 좋아요 순서(최신순)로 조회하고 삭제된 흔적의 좋아요는 제외한다")
+    void findLikedOpinionsOrdersByLikedAtDescendingAndExcludesDeleted() {
+        Opinion opinion1 = opinion(other, passage(1), "흔적1");
+        Opinion opinion2 = opinion(other, passage(2), "흔적2");
+        Opinion deletedOpinion = opinion(other, passage(3), "삭제될 흔적");
+
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(opinion1).build());
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(opinion2).build());
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(deletedOpinion).build());
+        deletedOpinion.delete();
+        entityManager.persistAndFlush(deletedOpinion);
+
+        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(LikedOpinionProjection::opinionId)
+                .containsExactly(opinion2.getId(), opinion1.getId());
+        assertThat(results.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("좋아요가 없으면 빈 목록을 반환한다")
+    void findLikedOpinionsReturnsEmptyWhenNoLikes() {
+        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).isEmpty();
+        assertThat(results.getTotalElements()).isZero();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
@@ -1,0 +1,139 @@
+package com.nexters.palang.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepository);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("존재하는 사용자를 조회하면 그대로 반환한다")
+    void getMeReturnsUser() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        User result = userService.getMe(1L);
+
+        assertThat(result).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 조회하면 예외가 발생한다")
+    void getMeFailsWhenNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getMe(999L)).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 사용자를 조회하면 예외가 발생한다")
+    void getMeFailsWhenWithdrawn() {
+        User user = user(1L);
+        user.withdraw();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.getMe(1L)).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("중복되지 않은 닉네임으로 변경하면 반영된다")
+    void modifyNicknameSucceeds() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNicknameAndIdNot("새닉네임", 1L)).willReturn(false);
+
+        User result = userService.modifyNickname(1L, "새닉네임");
+
+        assertThat(result.getNickname()).isEqualTo("새닉네임");
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임으로 변경하려 하면 예외가 발생한다")
+    void modifyNicknameFailsWhenAlreadyInUse() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNicknameAndIdNot("중복닉네임", 1L)).willReturn(true);
+
+        assertThatThrownBy(() -> userService.modifyNickname(1L, "중복닉네임")).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("오늘 이미 닉네임을 변경했다면 다시 변경하려 할 때 예외가 발생한다")
+    void modifyNicknameFailsWhenChangedTwiceOnSameDay() {
+        User user = user(1L);
+        user.changeNickname("첫변경");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNicknameAndIdNot("두번째변경", 1L)).willReturn(false);
+
+        assertThatThrownBy(() -> userService.modifyNickname(1L, "두번째변경")).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자의 닉네임을 변경하려 하면 예외가 발생한다")
+    void modifyNicknameFailsWhenUserNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.modifyNickname(999L, "새닉네임")).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("배경색을 변경하면 반영된다")
+    void modifyBackgroundColorSucceeds() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        User result = userService.modifyBackgroundColor(1L, "#000000");
+
+        assertThat(result.getBackgroundColor()).isEqualTo("#000000");
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴를 요청하면 소프트 삭제된다")
+    void withdrawSoftDeletesUser() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        userService.withdraw(1L);
+
+        assertThat(user.isWithdrawn()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴한 사용자를 다시 탈퇴시키려 하면 예외가 발생한다")
+    void withdrawFailsWhenAlreadyWithdrawn() {
+        User user = user(1L);
+        user.withdraw();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.withdraw(1L)).isInstanceOf(UserException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
@@ -1,0 +1,58 @@
+package com.nexters.palang.domain.user.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.domain.user.common.error.UserException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class UserTest {
+
+    private User user() {
+        return User.builder().nickname("기존닉네임").build();
+    }
+
+    @Test
+    @DisplayName("닉네임을 변경한 적이 없으면 바로 변경할 수 있다")
+    void changeNicknameSucceedsWhenNeverChangedBefore() {
+        User user = user();
+
+        user.changeNickname("새닉네임");
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(user.getNicknameUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("같은 날짜에 닉네임을 다시 변경하려 하면 예외가 발생한다")
+    void changeNicknameFailsWhenChangedAgainOnSameDay() {
+        User user = user();
+        user.changeNickname("새닉네임");
+
+        assertThatThrownBy(() -> user.changeNickname("또다른닉네임")).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("전날 닉네임을 변경했다면 오늘 다시 변경할 수 있다")
+    void changeNicknameSucceedsWhenLastChangedOnPreviousDay() {
+        User user = user();
+        ReflectionTestUtils.setField(user, "nicknameUpdatedAt", LocalDateTime.now().minusDays(1));
+
+        user.changeNickname("새닉네임");
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+    }
+
+    @Test
+    @DisplayName("배경색을 변경하면 필드가 갱신된다")
+    void changeBackgroundColorUpdatesField() {
+        User user = user();
+
+        user.changeBackgroundColor("#FFFFFF");
+
+        assertThat(user.getBackgroundColor()).isEqualTo("#FFFFFF");
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -1,0 +1,237 @@
+package com.nexters.palang.domain.user.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
+import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
+import com.nexters.palang.domain.opinion.application.OpinionService;
+import com.nexters.palang.domain.user.application.UserService;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
+import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private OpinionService opinionService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 20);
+
+    private User user(Long id) {
+        User user = User.builder()
+                .nickname("닉네임")
+                .profileImageUrl("cover")
+                .backgroundColor("#FFFFFF")
+                .snsProvider(SnsProvider.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("내 프로필을 조회하면 흔적 수와 함께 반환한다")
+    void getMe() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.getMe(1L)).willReturn(user(1L));
+        given(opinionService.getMyOpinionCount(1L)).willReturn(5L);
+
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.nickname").value("닉네임"))
+                .andExpect(jsonPath("$.data.opinionCount").value(5));
+    }
+
+    @Test
+    @DisplayName("인증 없이 내 프로필을 조회하면 401 에러가 발생한다")
+    void getMeFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 조회하면 404 에러가 발생한다")
+    void getMeFailsWhenNotFound() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(999L);
+        given(userService.getMe(999L)).willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("USER_404_1"));
+    }
+
+    @Test
+    @DisplayName("닉네임을 변경하면 변경된 프로필을 반환한다")
+    void modifyNickname() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyNickname(eq(1L), eq("새닉네임"))).willReturn(user(1L));
+        given(opinionService.getMyOpinionCount(1L)).willReturn(0L);
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateNicknameRequest("새닉네임"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1));
+    }
+
+    @Test
+    @DisplayName("빈 닉네임으로 변경을 요청하면 400 에러가 발생한다")
+    void modifyNicknameFailsWhenBlank() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateNicknameRequest(""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("오늘 이미 변경했다면 400 에러가 발생한다")
+    void modifyNicknameFailsWhenLimited() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyNickname(eq(1L), any()))
+                .willThrow(new UserException(UserErrorCode.NICKNAME_CHANGE_LIMITED));
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateNicknameRequest("새닉네임"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("USER_400_1"));
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임이면 409 에러가 발생한다")
+    void modifyNicknameFailsWhenAlreadyInUse() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyNickname(eq(1L), any()))
+                .willThrow(new UserException(UserErrorCode.NICKNAME_ALREADY_IN_USE));
+
+        mockMvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateNicknameRequest("중복닉네임"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("USER_409_1"));
+    }
+
+    @Test
+    @DisplayName("배경색을 변경하면 변경된 프로필을 반환한다")
+    void modifyBackgroundColor() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyBackgroundColor(eq(1L), eq("#000000"))).willReturn(user(1L));
+        given(opinionService.getMyOpinionCount(1L)).willReturn(0L);
+
+        mockMvc.perform(patch("/api/users/me/background-color")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateBackgroundColorRequest("#000000"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1));
+    }
+
+    @Test
+    @DisplayName("빈 배경색으로 변경을 요청하면 400 에러가 발생한다")
+    void modifyBackgroundColorFailsWhenBlank() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/users/me/background-color")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateBackgroundColorRequest(""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴를 요청하면 서비스에 위임한다")
+    void withdraw() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/users/me"))
+                .andExpect(status().isOk());
+
+        verify(userService).withdraw(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 탈퇴를 요청하면 404 에러가 발생한다")
+    void withdrawFailsWhenNotFound() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        doThrow(new UserException(UserErrorCode.USER_NOT_FOUND)).when(userService).withdraw(1L);
+
+        mockMvc.perform(delete("/api/users/me"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("USER_404_1"));
+    }
+
+    @Test
+    @DisplayName("내가 남긴 흔적 목록을 조회한다")
+    void getMyOpinions() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        MyOpinionProjection projection = new MyOpinionProjection(
+                1L, 10L, "책 제목", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
+        given(opinionService.getMyOpinions(eq(1L), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/opinions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1))
+                .andExpect(jsonPath("$.data.opinions[0].bookTitle").value("책 제목"));
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 흔적 목록을 조회한다")
+    void getLikedOpinions() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        LikedOpinionProjection projection = new LikedOpinionProjection(
+                1L, 10L, "책 제목", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0,
+                LocalDateTime.now(), LocalDateTime.now());
+        given(opinionService.getLikedOpinions(eq(1L), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/likes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #18

## 🚀 개요
backend-plan.md §6 Phase 2 기준으로 마이페이지 API 6종을 구현했습니다. `User.withdraw()`(닉네임 익명화)는 이슈 #12에서 이미 구현되어 있었고, 이번 PR은 그 위에 프로필 조회/수정과 내 흔적·좋아요 흔적 목록 조회를 새로 구현했습니다.

## 📄 작업 내용
- **User 엔티티 보강**: `changeNickname()`(달력일 기준 하루 1회 제한), `changeBackgroundColor()`, `BACKGROUND_COLOR_MAX_LENGTH` 상수
- **에러코드**: `USER_400_1`(닉네임 하루 1회 제한), `USER_409_1`(닉네임 중복) 추가
- **마이페이지용 Opinion 조회 인프라**: `OpinionQueryRepository`(신규) — 내가 남긴 흔적(최신순), 좋아요 누른 흔적(liked_at desc) 조회. Opinion→Passage→Book, OpinionLike→Opinion→Passage→Book 조인. `OpinionRepository.countByUserIdAndDeletedAtIsNull`(프로필의 "지금까지 N개의 흔적을 남겼어요!")
- **UserService**: 프로필 조회/닉네임·배경색 변경/탈퇴. 탈퇴한 사용자는 존재하지 않는 것과 동일하게 취급(404)
- **API**: `UserController`/`UserApi`(Swagger, 에러코드별 JSON 예시 포함)

| Method | Path | 인증 | 설명 |
|---|---|---|---|
| GET | `/api/users/me` | 필요* | 프로필(닉네임, 배경색, SNS 가입 정보, 흔적 수) |
| PATCH | `/api/users/me/nickname` | 필요* | 닉네임 변경 (최대 15자, 중복 불가, 하루 1회) |
| PATCH | `/api/users/me/background-color` | 필요* | 배경색 변경 |
| DELETE | `/api/users/me` | 필요* | 회원탈퇴 (소프트 삭제 + 닉네임 익명화) |
| GET | `/api/users/me/opinions?page=&size=` | 필요* | 내가 남긴 흔적 목록 |
| GET | `/api/users/me/likes?page=&size=` | 필요* | 좋아요 누른 흔적 목록 (liked_at desc) |

- **테스트**: `UserTest`(도메인), `UserServiceTest`(Mockito), `UserControllerTest`(`@WebMvcTest`), `OpinionQueryRepositoryTest`(신규, `@DataJpaTest`), 기존 `OpinionServiceTest` 확장 — 총 27개 신규/보강 케이스

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 스위트 통과 확인
- 로컬 서버(`local` 프로파일) 기동 후 `/v3/api-docs`와 실제 응답을 대조:
  - `GET /api/users/me` (인증 없음) → `401 AUTH_401_1`
  - `GET /api/users/me`(존재하지 않는 사용자) → `404 USER_404_1`
  - `GET /api/users/me/opinions?size=abc` → `400 COMMON_400_1`
  - `PATCH /api/users/me/nickname`(빈 값) → `400 COMMON_400_1`
  - `PATCH /api/users/me/nickname`(존재하지 않는 사용자) → `404 USER_404_1`
  - `DELETE /api/users/me`(존재하지 않는 사용자) → `404 USER_404_1`
  - `GET /api/users/me/likes`(데이터 없음) → `200`, 빈 목록

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- **닉네임 "하루 1회 제한" 기준**: 요구사항에는 "1일 1회"만 명시되고 정확한 윈도우가 없어, `nicknameUpdatedAt`의 날짜(LocalDate)가 오늘과 같으면 막는 **달력일 기준**으로 구현했습니다. 자정 직후 재변경이 가능해지는 점(롤링 24시간이 아님)을 고려한 선택인데, 의도와 맞는지 확인 부탁드립니다.
- **좋아요 목록의 범위 경계**: "좋아요 누른 흔적... 취소 가능"(FR-MY-04)에서 취소(좋아요 토글) 자체는 이슈 #16(`POST /api/opinions/{opinionId}/like`)이 담당하는 것으로 보고 이번 PR은 조회(GET)만 구현했습니다. 이슈 #16이 아직 미착수라 `OpinionLike`에는 생성/삭제 로직이 없는 상태입니다.
- **탈퇴 사용자 처리**: 탈퇴한 사용자에 대한 모든 조작(프로필 조회 포함)을 `USER_404_1`(존재하지 않음)로 통일했습니다. 별도의 "이미 탈퇴함" 에러코드를 추가하지 않았는데, 프론트에서 탈퇴 여부를 구분해서 안내해야 한다면 코드 추가가 필요할 수 있습니다.
- **`OpinionQueryRepository`가 이번 PR에서 처음 생기는 점**: Opinion 도메인에 QueryDSL 기반 조회 클래스가 없어서 마이페이지 전용으로 신규 작성했습니다. 추후 이슈 #15(흔적 목록/꾸밈 병합)에서 Opinion 조회 로직이 추가될 때 이 클래스와 통합/분리 방향을 함께 검토하면 좋을 것 같습니다.
