### PR TITLE
Chore/#25 Git Actions CI/CD workflow 작성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,91 @@
+name: CD
+
+on:
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: meta
+        run: |
+          echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          # ghcr.io는 이미지 이름에 대문자를 허용하지 않으므로 repository 이름을 소문자로 변환한다
+          # (예: Nexters/Palang-Server -> nexters/palang-server).
+          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}
+            ${{ steps.meta.outputs.image }}:${{ github.ref_name }}-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-dev:
+    needs: build-and-push
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Deploy to dev server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/pallang-server
+            git pull origin develop
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            export IMAGE_TAG=${{ needs.build-and-push.outputs.image-tag }}
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -f
+
+  deploy-prod:
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: Deploy to prod server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/pallang-server
+            git pull origin main
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            export IMAGE_TAG=${{ needs.build-and-push.outputs.image-tag }}
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -f

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image-tag: ${{ steps.meta.outputs.tag }}
     steps:
@@ -51,6 +53,12 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     environment: dev
+    permissions:
+      contents: read
+      packages: read
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
     steps:
       - name: Deploy to dev server
         uses: appleboy/ssh-action@v1.0.3
@@ -61,9 +69,12 @@ jobs:
           script: |
             set -e
             cd ~/pallang-server
-            git pull origin develop
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             export IMAGE_TAG=${{ needs.build-and-push.outputs.image-tag }}
+            # 배포 시점의 브랜치 HEAD가 아니라, 이 워크플로우를 트리거한 커밋으로 고정한다
+            # (동시 배포 시 compose 소스와 이미지 태그가 어긋나는 것을 방지).
+            git fetch origin
+            git checkout "${IMAGE_TAG}"
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune -f
@@ -73,6 +84,12 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: prod
+    permissions:
+      contents: read
+      packages: read
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
     steps:
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v1.0.3
@@ -83,9 +100,12 @@ jobs:
           script: |
             set -e
             cd ~/pallang-server
-            git pull origin main
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             export IMAGE_TAG=${{ needs.build-and-push.outputs.image-tag }}
+            # 배포 시점의 브랜치 HEAD가 아니라, 이 워크플로우를 트리거한 커밋으로 고정한다
+            # (동시 배포 시 compose 소스와 이미지 태그가 어긋나는 것을 방지).
+            git fetch origin
+            git checkout "${IMAGE_TAG}"
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,13 @@ jobs:
 
       # application-local.yaml은 .gitignore 대상이라 CI 체크아웃본에는 존재하지 않는다.
       # 그래서 datasource/redis 값을 프로파일 파일이 아니라 Spring Boot 표준 env로 직접 주입한다.
+      # 프로파일 "이름"은 그대로 local을 써야 한다 — HeaderCurrentUserProvider가 @Profile("local")로
+      # 제한돼 있어서, 다른 이름(test 등)을 쓰면 CurrentUserProvider 빈을 찾지 못해
+      # 컨트롤러 생성 단계에서 NoSuchBeanDefinitionException이 난다.
       - name: Build and run tests
         run: ./gradlew build
         env:
-          SPRING_PROFILES_ACTIVE: test
+          SPRING_PROFILES_ACTIVE: local
           SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/pallang_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: pallang_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # application-local.yaml은 .gitignore 대상이라 CI 체크아웃본에는 존재하지 않는다.
+      # 그래서 datasource/redis 값을 프로파일 파일이 아니라 Spring Boot 표준 env로 직접 주입한다.
+      - name: Build and run tests
+        run: ./gradlew build
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3306/pallang_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+          SPRING_DATASOURCE_USERNAME: root
+          SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.cj.jdbc.Driver
+          # 마이그레이션 도구(Flyway/Liquibase) 도입 전까지, CI에서는 매 실행마다 스키마를 새로 생성한다.
+          SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
+
+      - name: Upload test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test
+          retention-days: 5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify Docker image builds
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: pallang-ci-check:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,18 @@
 # Nginx는 컨테이너로 띄우지 않고 호스트에 직접 설치한다 (deploy/nginx, deploy/scripts 참고).
 #
 # 사용법:
-#   cp deploy/.env.example .env   # 값 채운 뒤
-#   docker compose up -d --build
+#   - 수동 배포: cp deploy/.env.example .env 후 값 채우고 docker compose up -d --build
+#     (IMAGE_TAG 미지정 시 latest로 로컬 빌드)
+#   - CD(.github/workflows/cd.yml) 배포: 서버에서 IMAGE_TAG를 export한 뒤
+#     docker compose pull && docker compose up -d --remove-orphans 실행
+#     (ghcr.io/nexters/palang-server 이미지를 그대로 pull, 로컬 재빌드 없음)
 
 services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    image: pallang-app:latest
+    image: ghcr.io/nexters/palang-server:${IMAGE_TAG:-latest}
     container_name: pallang-app
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #25

## 🚀 개요
GitHub Actions 기반 CI/CD 파이프라인을 구축하였습니다.

## 📄 작업 내용
- `.github/workflows/ci.yml`: MySQL/Redis 서비스 컨테이너를 띄운 상태로 `./gradlew build` 실행, 실패 시 테스트 리포트 아티팩트 업로드, Docker 이미지 빌드 자체도 검증
- `.github/workflows/cd.yml`: develop/main에 push되면 이미지를 빌드해 GHCR(`ghcr.io/nexters/palang-server`)에 push하고, 커밋 SHA 앞 8자리를 태그로 사용. develop은 dev 서버로, main은 prod 서버로 SSH 접속해 `docker compose pull && up -d`로 배포
- `docker-compose.yml`: app 서비스의 `image`를 CD가 실제로 push하는 GHCR 이미지 경로(`ghcr.io/nexters/palang-server:${IMAGE_TAG:-latest}`)로 수정 — 기존엔 로컬 전용 이름이라 CD가 pull해도 반영이 안 되는 상태였음. `build:`는 그대로 남겨 수동 배포(`docker compose up -d --build`) 흐름도 유지
- GitHub 저장소 룰셋에 `develop`/`main` 대상으로 "Require a pull request before merging" + "Require status checks to pass"(`build-and-test`)를 추가해, CI 통과 전에는 병합·배포가 안 되도록 게이팅

## 📸 스크린샷 / 테스트 결과 (선택)
- `docker compose config`로 `IMAGE_TAG` 지정/미지정 두 경우 모두 이미지 경로가 올바르게 해석되는 것 확인
- workflow YAML 문법 검증 완료 
- 실제 GitHub Actions 실행 결과(빌드/푸시/배포)는 이 PR을 올린 뒤 Actions 탭에서 확인 필요 — 로컬에는 재현 환경이 없음

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인 (실제 dev/prod 서버 SSH 배포는 secrets 설정 후 첫 병합 시 확인 예정)
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 룰셋에 "Require a pull request before merging"까지 켜두어 이후로는 `develop`/`main`에 직접 push가 전부 막힘

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * `develop` 및 `main` 브랜치 변경 시 컨테이너 이미지를 자동으로 빌드하고 환경별 서버에 배포합니다.
  * 배포 시 최신 이미지와 커밋별 이미지를 관리해 안정적인 버전 적용이 가능합니다.
* **개선 사항**
  * 애플리케이션이 GitHub Container Registry의 이미지를 사용하도록 배포 구성을 변경했습니다.
  * 변경 사항 검증 과정에서 MySQL과 Redis를 포함한 자동 빌드 및 테스트를 수행합니다.
  * 배포 후 사용하지 않는 컨테이너 이미지를 자동으로 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->