### PR TITLE
Feat/#35 Swagger 문서 요구사항 ID 제거 및 응답 예시값 현실화

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -34,7 +34,7 @@ public interface BookApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "도서 내부 검색", description = "서비스 DB에 이미 등록된 도서를 제목으로 검색합니다. (FR-HOME-03)")
+    @Operation(summary = "도서 내부 검색", description = "서비스 DB에 이미 등록된 도서를 제목으로 검색합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),
             @ApiResponse(responseCode = "400", description = "keyword 누락 또는 page/size 형식 오류 (COMMON_400_1)",
@@ -46,7 +46,7 @@ public interface BookApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "도서 직접 등록", description = "검색 결과에 없는 도서를 직접 등록합니다. 인증 불필요. (FR-WRITE-03)")
+    @Operation(summary = "도서 직접 등록", description = "검색 결과에 없는 도서를 직접 등록합니다. 인증 불필요.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "등록 성공"),
             @ApiResponse(responseCode = "400", description = "필수값 누락 또는 페이지수가 1 미만 (COMMON_400_1)",
@@ -56,7 +56,7 @@ public interface BookApi {
             @Valid CreateBookRequest request
     );
 
-    @Operation(summary = "홈 캐러셀 도서 목록", description = "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다. (FR-HOME-01,02)")
+    @Operation(summary = "홈 캐러셀 도서 목록", description = "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -69,7 +69,7 @@ public interface BookApi {
 
     @Operation(summary = "내가 최근에 남긴 도서 목록",
             description = "현재 로그인한 사용자가 최근에 대목을 남긴 도서 목록입니다. "
-                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-WRITE-01)")
+                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -82,7 +82,7 @@ public interface BookApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "흔적 많은 도서 목록", description = "서비스 전체에서 흔적(Opinion)이 많은 순으로 도서를 조회합니다. (FR-WRITE-01)")
+    @Operation(summary = "흔적 많은 도서 목록", description = "서비스 전체에서 흔적(Opinion)이 많은 순으로 도서를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 public interface UserBookStatusApi {
 
     @Operation(summary = "읽기상태/현재페이지 설정", description = "로그인한 사용자의 특정 도서에 대한 읽기상태와 현재 페이지를 설정합니다. "
-            + "기존 상태가 없으면 새로 생성합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-WRITE-08)")
+            + "기존 상태가 없으면 새로 생성합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "설정 성공"),
             @ApiResponse(responseCode = "400", description = "필수값 누락 또는 현재 페이지가 전체 페이지 수 초과(BOOK_400_2)",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
@@ -1,11 +1,13 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record BookActivityResponse(
-        Long bookId,
-        String title,
-        String author,
-        String coverImageUrl,
-        long passageCount,
-        long opinionCount
+        @Schema(example = "1") Long bookId,
+        @Schema(example = "채식주의자") String title,
+        @Schema(example = "한강") String author,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl,
+        @Schema(example = "12") long passageCount,
+        @Schema(example = "34") long opinionCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
@@ -1,15 +1,16 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.domain.book.domain.BookSource;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record BookResponse(
-        Long bookId,
-        String title,
-        String author,
-        String publisher,
-        int pageCount,
-        String isbn,
-        String coverImageUrl,
-        BookSource source
+        @Schema(example = "1") Long bookId,
+        @Schema(example = "채식주의자") String title,
+        @Schema(example = "한강") String author,
+        @Schema(example = "창비") String publisher,
+        @Schema(example = "268") int pageCount,
+        @Schema(example = "9788936434120") String isbn,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl,
+        @Schema(example = "API") BookSource source
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/CreateBookRequest.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/CreateBookRequest.java
@@ -1,14 +1,15 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
 public record CreateBookRequest(
-        @NotBlank(message = "제목은 필수입니다.") String title,
-        @NotBlank(message = "지은이는 필수입니다.") String author,
-        @NotBlank(message = "출판사는 필수입니다.") String publisher,
-        @Positive(message = "페이지수는 1 이상이어야 합니다.") int pageCount,
-        String isbn,
-        String coverImageUrl
+        @NotBlank(message = "제목은 필수입니다.") @Schema(example = "채식주의자") String title,
+        @NotBlank(message = "지은이는 필수입니다.") @Schema(example = "한강") String author,
+        @NotBlank(message = "출판사는 필수입니다.") @Schema(example = "창비") String publisher,
+        @Positive(message = "페이지수는 1 이상이어야 합니다.") @Schema(example = "268") int pageCount,
+        @Schema(example = "9788936434120") String isbn,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookResponse.java
@@ -1,11 +1,13 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ExternalBookResponse(
-        String title,
-        String author,
-        String publisher,
-        Integer pageCount,
-        String isbn,
-        String coverImageUrl
+        @Schema(example = "채식주의자") String title,
+        @Schema(example = "한강") String author,
+        @Schema(example = "창비") String publisher,
+        @Schema(description = "응답 속도를 위해 채우지 않으며 항상 null입니다.", nullable = true) Integer pageCount,
+        @Schema(example = "9788936434120") String isbn,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/UpdateUserBookStatusRequest.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/UpdateUserBookStatusRequest.java
@@ -1,12 +1,13 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.domain.book.domain.ReadingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record UpdateUserBookStatusRequest(
-        @NotNull(message = "도서 ID는 필수입니다.") Long bookId,
-        @NotNull(message = "읽기 상태는 필수입니다.") ReadingStatus status,
-        @PositiveOrZero(message = "현재 페이지는 0 이상이어야 합니다.") Integer currentPage
+        @NotNull(message = "도서 ID는 필수입니다.") @Schema(example = "1") Long bookId,
+        @NotNull(message = "읽기 상태는 필수입니다.") @Schema(example = "READING") ReadingStatus status,
+        @PositiveOrZero(message = "현재 페이지는 0 이상이어야 합니다.") @Schema(example = "87") Integer currentPage
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/UserBookStatusResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/UserBookStatusResponse.java
@@ -2,8 +2,13 @@ package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.domain.book.domain.ReadingStatus;
 import com.nexters.palang.domain.book.domain.UserBookStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserBookStatusResponse(Long bookId, ReadingStatus status, Integer currentPage) {
+public record UserBookStatusResponse(
+        @Schema(example = "1") Long bookId,
+        @Schema(example = "READING") ReadingStatus status,
+        @Schema(example = "87") Integer currentPage
+) {
 
     public static UserBookStatusResponse from(UserBookStatus userBookStatus) {
         return new UserBookStatusResponse(

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
@@ -24,7 +24,7 @@ public interface CommentApi {
     @Operation(summary = "댓글 목록 조회",
             description = "흔적에 달린 원댓글과 답글을 조회합니다. 원댓글은 page/size로 페이지네이션되며, "
                     + "각 원댓글에는 답글이 최대 5개까지 미리보기로 포함됩니다. 5개를 초과하면 hasMoreReplies=true이며, "
-                    + "나머지는 GET /api/comments/{commentId}/replies로 조회합니다. (FR-OPINION-07)")
+                    + "나머지는 GET /api/comments/{commentId}/replies로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -43,7 +43,7 @@ public interface CommentApi {
     );
 
     @Operation(summary = "답글 더보기",
-            description = "특정 원댓글에 달린 답글을 page/size로 페이지네이션 조회합니다. (FR-OPINION-07)")
+            description = "특정 원댓글에 달린 답글을 page/size로 페이지네이션 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
@@ -1,15 +1,16 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record CommentResponse(
-        Long commentId,
-        Long userId,
-        String nickname,
-        String profileImageUrl,
-        String content,
-        boolean isDeleted,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        @Schema(example = "1") Long commentId,
+        @Schema(example = "7") Long userId,
+        @Schema(example = "책읽는고양이") String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
+        @Schema(example = "저도 같은 생각이에요!") String content,
+        @Schema(example = "false") boolean isDeleted,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CreateCommentRequest.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CreateCommentRequest.java
@@ -1,13 +1,16 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
 import com.nexters.palang.domain.comment.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CreateCommentRequest(
+        @Schema(description = "답글로 남길 경우 원댓글 ID. 원댓글이면 null입니다.", example = "3", nullable = true)
         Long parentCommentId,
         @NotBlank(message = "댓글 내용은 필수입니다.")
         @Size(max = Comment.CONTENT_MAX_LENGTH, message = "댓글은 500자를 초과할 수 없습니다.")
+        @Schema(example = "저도 같은 생각이에요!")
         String content
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
@@ -1,19 +1,20 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record RootCommentResponse(
-        Long commentId,
-        Long userId,
-        String nickname,
-        String profileImageUrl,
-        String content,
-        boolean isDeleted,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt,
+        @Schema(example = "1") Long commentId,
+        @Schema(example = "7") Long userId,
+        @Schema(example = "책읽는고양이") String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
+        @Schema(example = "저도 같은 생각이에요!") String content,
+        @Schema(example = "false") boolean isDeleted,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime updatedAt,
         List<CommentResponse> replies,
-        int replyCount,
-        boolean hasMoreReplies
+        @Schema(example = "8") int replyCount,
+        @Schema(example = "true") boolean hasMoreReplies
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/UpdateCommentRequest.java
@@ -1,12 +1,14 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
 import com.nexters.palang.domain.comment.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateCommentRequest(
         @NotBlank(message = "댓글 내용은 필수입니다.")
         @Size(max = Comment.CONTENT_MAX_LENGTH, message = "댓글은 500자를 초과할 수 없습니다.")
+        @Schema(example = "다시 읽어보니 더 공감돼요.")
         String content
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
@@ -26,7 +26,7 @@ public interface OpinionApi {
             description = "Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 원자적으로 생성합니다. "
                     + "passageId가 없으면 새 Passage를 만들고, 있으면 해당 Passage에 병합합니다(Q-06). "
                     + "OCR 입력은 별도 플로우이며 이 API는 직접 입력만 지원합니다. "
-                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-WRITE-06~10)")
+                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "흔적 생성 성공"),
             @ApiResponse(responseCode = "400",
@@ -61,7 +61,7 @@ public interface OpinionApi {
             @Valid CreateOpinionRequest request
     );
 
-    @Operation(summary = "흔적 목록 조회", description = "특정 대목에 남겨진 흔적을 정렬 기준(최신순 기본/좋아요순)으로 조회합니다. (FR-OPINION-03)")
+    @Operation(summary = "흔적 목록 조회", description = "특정 대목에 남겨진 흔적을 정렬 기준(최신순 기본/좋아요순)으로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -78,7 +78,7 @@ public interface OpinionApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "흔적 상세 조회", description = "흔적 작성자가 기록한 꾸밈을 그대로 확인합니다(병합된 결과가 아님). (FR-OPINION-05)")
+    @Operation(summary = "흔적 상세 조회", description = "흔적 작성자가 기록한 꾸밈을 그대로 확인합니다(병합된 결과가 아님).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/CreateOpinionRequest.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/CreateOpinionRequest.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.opinion.presentation.dto;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.domain.Passage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -14,22 +15,28 @@ import java.util.List;
 
 public record CreateOpinionRequest(
         @NotNull(message = "도서 ID는 필수입니다.")
+        @Schema(example = "1")
         Long bookId,
 
         @Positive(message = "페이지 번호는 1 이상이어야 합니다.")
+        @Schema(example = "87")
         int pageNumber,
 
         @NotBlank(message = "인용 문구는 비어 있을 수 없습니다.")
         @Size(max = Passage.QUOTED_TEXT_MAX_LENGTH, message = "인용 문구는 {max}자를 초과할 수 없습니다.")
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.")
         String quotedText,
 
+        @Schema(example = "false")
         boolean isSpoiler,
 
         // null이면 새 Passage를 생성(신규 또는 유사 문장 병합 거부), 값이 있으면 해당 Passage에 병합한다. (Q-06)
+        @Schema(description = "병합할 기존 대목 ID. 없으면 새 대목을 생성합니다.", example = "5", nullable = true)
         Long passageId,
 
         @NotBlank(message = "흔적 내용은 비어 있을 수 없습니다.")
         @Size(max = Opinion.CONTENT_MAX_LENGTH, message = "흔적 내용은 {max}자를 초과할 수 없습니다.")
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.")
         String content,
 
         @NotEmpty(message = "꾸밈 효과는 최소 1개 이상이어야 합니다.")
@@ -39,14 +46,18 @@ public record CreateOpinionRequest(
 
     public record DecorationRequest(
             @PositiveOrZero(message = "시작 위치는 0 이상이어야 합니다.")
+            @Schema(example = "3")
             int startOffset,
 
             @Positive(message = "끝 위치는 1 이상이어야 합니다.")
+            @Schema(example = "12")
             int endOffset,
 
             @NotNull(message = "효과 종류는 필수입니다.")
+            @Schema(example = "HIGHLIGHT")
             EffectType effectType,
 
+            @Schema(example = "#FFE08A")
             String color
     ) {
     }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
@@ -2,19 +2,20 @@ package com.nexters.palang.domain.opinion.presentation.dto;
 
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse.DecorationResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
 // 흔적 상세(FR-OPINION-05): 해당 흔적 작성자가 기록한 꾸밈을 그대로 보여준다 (병합된 3개가 아니라 이 Opinion 자신의 전부).
 public record OpinionDetailResponse(
-        Long opinionId,
-        Long passageId,
-        Long userId,
-        String nickname,
-        String content,
-        int likeCount,
+        @Schema(example = "1") Long opinionId,
+        @Schema(example = "1") Long passageId,
+        @Schema(example = "7") Long userId,
+        @Schema(example = "책읽는고양이") String nickname,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "5") int likeCount,
         List<DecorationResponse> decorations,
-        LocalDateTime createdAt
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
 ) {
     public static OpinionDetailResponse from(Opinion opinion) {
         List<DecorationResponse> decorations = opinion.getDecorations().stream()

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
@@ -3,16 +3,17 @@ package com.nexters.palang.domain.opinion.presentation.dto;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record OpinionResponse(
-        Long opinionId,
-        Long passageId,
-        boolean merged,
-        String content,
+        @Schema(example = "1") Long opinionId,
+        @Schema(example = "1") Long passageId,
+        @Schema(example = "false") boolean merged,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
         List<DecorationResponse> decorations,
-        LocalDateTime createdAt
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
 ) {
 
     public static OpinionResponse from(Opinion opinion, boolean merged) {
@@ -29,7 +30,13 @@ public record OpinionResponse(
         );
     }
 
-    public record DecorationResponse(Long decorationId, int startOffset, int endOffset, EffectType effectType, String color) {
+    public record DecorationResponse(
+            @Schema(example = "1") Long decorationId,
+            @Schema(example = "3") int startOffset,
+            @Schema(example = "12") int endOffset,
+            @Schema(example = "HIGHLIGHT") EffectType effectType,
+            @Schema(example = "#FFE08A") String color
+    ) {
         public static DecorationResponse from(Decoration decoration) {
             return new DecorationResponse(
                     decoration.getId(),

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
@@ -1,15 +1,16 @@
 package com.nexters.palang.domain.opinion.presentation.dto;
 
 import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record OpinionSummaryResponse(
-        Long opinionId,
-        Long userId,
-        String nickname,
-        String content,
-        int likeCount,
-        LocalDateTime createdAt
+        @Schema(example = "1") Long opinionId,
+        @Schema(example = "7") Long userId,
+        @Schema(example = "책읽는고양이") String nickname,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "5") int likeCount,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
 ) {
     public static OpinionSummaryResponse from(OpinionSummaryProjection projection) {
         return new OpinionSummaryResponse(

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/UpdateOpinionRequest.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/UpdateOpinionRequest.java
@@ -1,12 +1,14 @@
 package com.nexters.palang.domain.opinion.presentation.dto;
 
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateOpinionRequest(
         @NotBlank(message = "흔적 내용은 비어 있을 수 없습니다.")
         @Size(max = Opinion.CONTENT_MAX_LENGTH, message = "흔적 내용은 {max}자를 초과할 수 없습니다.")
+        @Schema(example = "다시 읽어보니 더 와닿는 문장이었어요.")
         String content
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -46,7 +46,7 @@ public interface PassageControllerDocs {
     );
 
     @Operation(summary = "유사 문장 후보 조회", description = "저장 전 같은 도서의 인접 페이지(±1)에서 정규화 해시가 같은 대목 후보를 조회합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-WRITE-07)")
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (후보가 없으면 빈 배열)"),
             @ApiResponse(
@@ -70,10 +70,10 @@ public interface PassageControllerDocs {
     );
 
     @Operation(summary = "대목 페이지 목록 조회",
-            description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다(FR-VIEW-02). "
+            description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다. "
                     + "읽기상태 기반 노출 필터가 적용됩니다: 읽는 중이면 현재 페이지까지, "
-                    + "읽을 예정/미설정/비로그인이면 첫 페이지만 노출됩니다(FR-WRITE-08). "
-                    + "스포일러 대목이 있는 페이지도 이 목록에 포함됩니다(스포일러 블러 처리는 프론트 담당, FR-VIEW-03). "
+                    + "읽을 예정/미설정/비로그인이면 첫 페이지만 노출됩니다. "
+                    + "스포일러 대목이 있는 페이지도 이 목록에 포함됩니다(스포일러 블러 처리는 프론트 담당). "
                     + "인증은 선택입니다(soft auth) — 헤더가 없어도 비로그인 기준으로 조회됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (대목이 없으면 빈 배열)"),
@@ -91,13 +91,13 @@ public interface PassageControllerDocs {
     );
 
     @Operation(summary = "특정 페이지의 대목 + 꾸밈 병합 결과 조회",
-            description = "같은 페이지에 여러 대목이 있으면 모두 반환합니다(대목 전환, FR-VIEW-03). "
+            description = "같은 페이지에 여러 대목이 있으면 모두 반환합니다(대목 전환). "
                     + "각 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
                     + "스포일러로 표기된 대목(isSpoiler=true)도 quotedText/decorations를 그대로 내려줍니다 — "
-                    + "블러 처리 후 [버튼]을 누르면 즉시 확인 가능해야 하므로(FR-VIEW-03 스포일러 처리), "
+                    + "블러 처리 후 [버튼]을 누르면 즉시 확인 가능해야 하므로, "
                     + "블러/확인 전환은 서버 왕복 없이 프론트에서 isSpoiler 플래그로 처리합니다. "
                     + "읽기상태 노출 필터를 만족하지 않는 페이지를 요청하면 빈 배열이 반환되며, "
-                    + "비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도합니다(FR-OPINION-08).")
+                    + "비로그인 사용자가 첫 페이지가 아닌 페이지를 요청하면 401로 로그인을 유도합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (노출 범위 밖이면 빈 배열)"),
             @ApiResponse(responseCode = "401", description = "AUTH_401_1: 비로그인 사용자가 첫 페이지가 아닌 페이지를 요청함.",

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.passage.presentation.request;
 
 import com.nexters.palang.domain.passage.domain.Passage;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -10,13 +11,16 @@ public class PassageRequest {
 
     public record SimilarCheck(
             @NotNull(message = "도서 ID는 필수입니다.")
+            @Schema(example = "1")
             Long bookId,
 
             @Positive(message = "페이지 번호는 1 이상이어야 합니다.")
+            @Schema(example = "87")
             int pageNumber,
 
             @NotBlank(message = "인용 문구는 비어 있을 수 없습니다.")
             @Size(max = Passage.QUOTED_TEXT_MAX_LENGTH, message = "인용 문구는 {max}자를 초과할 수 없습니다.")
+            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.")
             String quotedText
     ) {
     }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -6,6 +6,8 @@ import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.application.dto.OcrResultDto;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import org.springframework.data.domain.Page;
@@ -22,7 +24,10 @@ public class PassageResponse {
     }
 
     // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 발췌된 페이지 번호 목록.
-    public record PageNumbers(List<Integer> pageNumbers, PageInfo pageInfo) {
+    public record PageNumbers(
+            @ArraySchema(schema = @Schema(example = "3")) List<Integer> pageNumbers,
+            PageInfo pageInfo
+    ) {
         public static PageNumbers from(Page<Integer> page) {
             return new PageNumbers(page.getContent(), PageInfo.from(page));
         }
@@ -40,8 +45,13 @@ public class PassageResponse {
         // 스포일러 대목(isSpoiler=true)도 quotedText/decorations를 그대로 내려준다.
         // 블러 처리 + [버튼] 눌러야 확인 가능한 화면(FR-VIEW-03 스포일러 처리)은 즉시 반응해야 하는 순수 UI 동작이라
         // 프론트가 isSpoiler 플래그만 보고 클라이언트에서 처리한다 (서버 왕복 없이 버튼 클릭 즉시 확인 가능).
-        public record Detail(Long passageId, int pageNumber, String quotedText, boolean isSpoiler,
-                              List<DecorationResponse> decorations) {
+        public record Detail(
+                @Schema(example = "1") Long passageId,
+                @Schema(example = "87") int pageNumber,
+                @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+                @Schema(example = "false") boolean isSpoiler,
+                List<DecorationResponse> decorations
+        ) {
             public static Detail from(Passage passage, List<DecorationMergeCandidate> merged) {
                 List<DecorationResponse> decorations = merged.stream()
                         .map(candidate -> new DecorationResponse(
@@ -54,7 +64,12 @@ public class PassageResponse {
         }
     }
 
-    public record SimilarCandidate(Long passageId, String quotedText, int pageNumber, long opinionCount) {
+    public record SimilarCandidate(
+            @Schema(example = "1") Long passageId,
+            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+            @Schema(example = "87") int pageNumber,
+            @Schema(example = "4") long opinionCount
+    ) {
         public static SimilarCandidate from(SimilarPassageProjection projection) {
             return new SimilarCandidate(
                     projection.passageId(),
@@ -74,7 +89,11 @@ public class PassageResponse {
         }
     }
 
-    public record TextBlock(String text, BoundingBox boundingBox, boolean lineBreak) {
+    public record TextBlock(
+            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String text,
+            BoundingBox boundingBox,
+            @Schema(example = "true") boolean lineBreak
+    ) {
         public static TextBlock from(OcrResultDto block) {
             return new TextBlock(block.text(), BoundingBox.from(block.boundingBox()), block.lineBreak());
         }
@@ -89,6 +108,6 @@ public class PassageResponse {
         }
     }
 
-    public record Point(double x, double y) {
+    public record Point(@Schema(example = "120.5") double x, @Schema(example = "48.0") double y) {
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -22,7 +22,7 @@ import org.springframework.http.ResponseEntity;
 public interface UserApi {
 
     @Operation(summary = "내 프로필 조회", description = "닉네임, 프로필 이미지, 배경색, 가입 경로(SNS), "
-            + "지금까지 남긴 흔적 수를 조회합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-01)")
+            + "지금까지 남긴 흔적 수를 조회합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
@@ -37,7 +37,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> getMe();
 
     @Operation(summary = "닉네임 변경", description = "최대 15자, 중복 불가, 하루 1회만 변경할 수 있습니다(달력일 기준). "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-05)")
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(responseCode = "400", description = "닉네임 누락/15자 초과 (COMMON_400_1) "
@@ -66,7 +66,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> modifyNickname(@Valid UpdateNicknameRequest request);
 
     @Operation(summary = "배경색 변경", description = "흔적 보기 화면의 배경색을 변경합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(responseCode = "400", description = "배경색 누락/20자 초과 (COMMON_400_1)",
@@ -85,7 +85,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> modifyBackgroundColor(@Valid UpdateBackgroundColorRequest request);
 
     @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
-            + "공개된 발췌·의견·댓글은 남습니다). X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (NFR-PRIVACY)")
+            + "공개된 발췌·의견·댓글은 남습니다). X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
             @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
@@ -100,7 +100,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<Void>> withdraw();
 
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -119,7 +119,7 @@ public interface UserApi {
 
     @Operation(summary = "좋아요 누른 흔적 목록", description = "내가 좋아요를 누른 흔적을 좋아요 누른 순서대로(최신순) 조회합니다. "
             + "좋아요 취소는 이 API가 아니라 흔적 좋아요 토글 API가 담당합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인). (FR-MY-04)")
+            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
@@ -1,18 +1,19 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record LikedOpinionResponse(
-        Long opinionId,
-        Long bookId,
-        String bookTitle,
-        String bookCoverImageUrl,
-        Long passageId,
-        String quotedText,
-        int pageNumber,
-        String content,
-        int likeCount,
-        LocalDateTime createdAt,
-        LocalDateTime likedAt
+        @Schema(example = "1") Long opinionId,
+        @Schema(example = "1") Long bookId,
+        @Schema(example = "채식주의자") String bookTitle,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String bookCoverImageUrl,
+        @Schema(example = "1") Long passageId,
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+        @Schema(example = "87") int pageNumber,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "5") int likeCount,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
+        @Schema(example = "2026-07-25T09:10:00") LocalDateTime likedAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
@@ -1,13 +1,14 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
 import com.nexters.palang.domain.user.domain.SnsProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeResponse(
-        Long userId,
-        String nickname,
-        String profileImageUrl,
-        String backgroundColor,
-        SnsProvider snsProvider,
-        long opinionCount
+        @Schema(example = "7") Long userId,
+        @Schema(example = "책읽는고양이") String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
+        @Schema(example = "#FDF6E3") String backgroundColor,
+        @Schema(example = "KAKAO") SnsProvider snsProvider,
+        @Schema(example = "23") long opinionCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
@@ -1,17 +1,18 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record MyOpinionResponse(
-        Long opinionId,
-        Long bookId,
-        String bookTitle,
-        String bookCoverImageUrl,
-        Long passageId,
-        String quotedText,
-        int pageNumber,
-        String content,
-        int likeCount,
-        LocalDateTime createdAt
+        @Schema(example = "1") Long opinionId,
+        @Schema(example = "1") Long bookId,
+        @Schema(example = "채식주의자") String bookTitle,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String bookCoverImageUrl,
+        @Schema(example = "1") Long passageId,
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+        @Schema(example = "87") int pageNumber,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "5") int likeCount,
+        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateBackgroundColorRequest.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateBackgroundColorRequest.java
@@ -1,12 +1,14 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
 import com.nexters.palang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateBackgroundColorRequest(
         @NotBlank(message = "배경색은 필수입니다.")
         @Size(max = User.BACKGROUND_COLOR_MAX_LENGTH, message = "배경색은 20자를 초과할 수 없습니다.")
+        @Schema(example = "#FDF6E3")
         String backgroundColor
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/UpdateNicknameRequest.java
@@ -1,12 +1,14 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
 import com.nexters.palang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateNicknameRequest(
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = User.NICKNAME_MAX_LENGTH, message = "닉네임은 15자를 초과할 수 없습니다.")
+        @Schema(example = "책읽는고양이")
         String nickname
 ) {
 }

--- a/src/main/java/com/nexters/palang/global/common/response/PageInfo.java
+++ b/src/main/java/com/nexters/palang/global/common/response/PageInfo.java
@@ -1,8 +1,15 @@
 package com.nexters.palang.global.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
-public record PageInfo(int page, int size, long totalElements, int totalPages, boolean hasNext) {
+public record PageInfo(
+        @Schema(example = "0") int page,
+        @Schema(example = "20") int size,
+        @Schema(example = "42") long totalElements,
+        @Schema(example = "3") int totalPages,
+        @Schema(example = "true") boolean hasNext
+) {
 
     public static PageInfo from(Page<?> page) {
         return new PageInfo(page.getNumber(), page.getSize(), page.getTotalElements(), page.getTotalPages(), page.hasNext());


### PR DESCRIPTION
## 📌 관련 이슈
- Close #35

## 🚀 개요
Swagger UI에 노출되는 `@Operation` 설명에서 내부 요구사항 ID(`(FR-XXX)`, `(NFR-XXX)`) 표기를 제거하고, 응답/요청 DTO의 Example Value가 `"string"`/`0` 같은 기본값 대신 실제 데이터처럼 보이도록 개선했습니다.

## 📄 작업 내용
- `@Operation(summary, description)`에서 `(FR-XXX)`/`(NFR-XXX)` 요구사항 ID 표기 제거
  - `BookApi`, `UserApi`, `OpinionApi`, `CommentApi`, `UserBookStatusApi`, `PassageControllerDocs`
  - 코드 내부 `// FR-XXX` 주석(Swagger에 노출되지 않음)은 그대로 유지
- 응답 DTO(`*Response.java`) 및 요청 DTO(`*Request.java`) 필드에 `@Schema(example = ...)` 추가
  - 예: `BookResponse.title → "채식주의자"`, `author → "한강"`, `MeResponse.nickname → "책읽는고양이"`, `OpinionSummaryResponse.content → "이 문장에서 작가의 의도가 느껴져서 좋았어요."`
  - enum 필드는 실제 값(`KAKAO`, `READING`, `HIGHLIGHT` 등)을 예시로 지정
  - 공통 `PageInfo`에도 예시값 추가 (page/size/totalElements/totalPages/hasNext)
  - `pageNumbers`처럼 리스트 필드는 `@ArraySchema`로 원소 예시 지정

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과
- 로컬로 앱 실행 후 `/v3/api-docs` 응답을 직접 확인: `(FR-`/`(NFR-` 워딩 0건, 각 스키마 Example Value가 실제 값처럼 렌더링되는 것 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `CreateOpinionRequest.passageId`, `ExternalBookResponse.pageCount`처럼 값이 없을 수 있는(nullable) 필드는 예시값 대신 `description + nullable=true`로만 표기했습니다 — 억지 예시보다 이 편이 낫다고 판단했는데 의견 부탁드립니다.
- 예시값 문구(책 제목/작성자/닉네임 등)는 실제 알라딘 API 응답과 무관한 가상의 값입니다. 다른 예시가 더 낫다고 생각되면 알려주세요.