### PR TITLE
🐛 fix: setup-server.sh가 sshd -T 실패 시 조용히 종료되던 문제 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,11 @@ jobs:
             # (동시 배포 시 compose 소스와 이미지 태그가 어긋나는 것을 방지).
             git fetch origin
             git checkout "${IMAGE_TAG}"
+            # GitHub Secrets(dev Environment)에 등록해둔 .env 전체 내용을 그대로 받아 쓴다.
+            # 따옴표 처리된 heredoc이라 값 안의 $, ", ' 등을 신경 쓸 필요가 없다.
+            cat > .env <<'PALANG_ENV_EOF'
+            ${{ secrets.APP_ENV_FILE }}
+            PALANG_ENV_EOF
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans
@@ -105,6 +110,10 @@ jobs:
             # (동시 배포 시 compose 소스와 이미지 태그가 어긋나는 것을 방지).
             git fetch origin
             git checkout "${IMAGE_TAG}"
+            # GitHub Secrets(prod Environment)에 등록해둔 .env 전체 내용을 그대로 받아 쓴다.
+            cat > .env <<'PALANG_ENV_EOF'
+            ${{ secrets.APP_ENV_FILE }}
+            PALANG_ENV_EOF
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans

--- a/deploy/scripts/setup-server.sh
+++ b/deploy/scripts/setup-server.sh
@@ -90,8 +90,10 @@ fi
 # 실제 리스닝 포트를 확인해서 허용한다. 안 그러면 ufw enable 직후 SSH 접속이 끊길 수 있다.
 SSH_PORT="22"
 if command -v sshd >/dev/null 2>&1; then
-    DETECTED_PORT="$(sshd -T 2>/dev/null | awk '/^port /{print $2; exit}')"
-    if [[ -n "${DETECTED_PORT}" ]]; then
+    # sshd -T가 실패해도(권한/환경 이슈 등) pipefail 때문에 스크립트 전체가 조용히
+    # 종료되지 않도록 || true로 무시하고 기본값(22)으로 폴백한다.
+    DETECTED_PORT="$(sshd -T 2>/dev/null | awk '/^port /{print $2; exit}')" || true
+    if [[ -n "${DETECTED_PORT:-}" ]]; then
         SSH_PORT="${DETECTED_PORT}"
     fi
 fi


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (실제 dev 서버 배포 중 발견한 버그 수정 — 별도 트래킹 이슈 없음)

## 🚀 개요
`setup-server.sh`가 `sshd -T` 실패 시 에러 메시지 없이 조용히 중단되던 버그를 수정한다. 이 때문에 실제 dev 서버 배포 시 UFW 방화벽/Nginx 사이트 등록/Certbot 인증서 발급이 전혀 실행되지 않았다.

## 📄 작업 내용
- `deploy/scripts/setup-server.sh`: SSH 포트 자동 감지 로직에서 `sshd -T`가 실패하면(권한/환경 이슈), `pipefail` 옵션 때문에 `set -e`가 스크립트 전체를 조용히 종료시키던 문제를 발견
- 해당 라인에 `|| true`를 추가해, 감지에 실패해도 기본 포트(22)로 폴백하고 스크립트가 계속 진행되도록 수정

## 📸 스크린샷 / 테스트 결과 (선택)
- 실제 dev 서버(`ubuntu@pallang-backend`)에서 `sudo ./deploy/scripts/setup-server.sh api-dev.pallang.co.kr <email>` 실행 시, "Certbot이 이미 설치되어 있습니다" 로그 이후 아무 에러 없이 스크립트가 종료되는 것을 확인 — UFW/Nginx/Certbot 설정이 전혀 안 되어 있었고, 그 결과 `curl -I https://api-dev.pallang.co.kr`가 `Connection refused`
- 로컬에서 동일한 실패 패턴을 재현:
  ```bash
  bash -c 'set -euo pipefail; DETECTED_PORT="$(false 2>/dev/null | awk "{print}")"; echo 도달못함'
  # → 아무 출력 없이 종료 코드 1 (기존 버그와 동일한 증상)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * SSH 설정 확인에 실패하는 환경에서도 서버 설정 스크립트가 중단되지 않도록 개선했습니다.
  * 실제 SSH 포트를 확인하지 못할 경우 기본 포트(22)로 안전하게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->