### PR TITLE
🐛 fix: docker-compose.yml의 GHCR 이미지 이름을 저장소 실제 이름과 맞춤

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@
 #     (IMAGE_TAG 미지정 시 latest로 로컬 빌드)
 #   - CD(.github/workflows/cd.yml) 배포: 서버에서 IMAGE_TAG를 export한 뒤
 #     docker compose pull && docker compose up -d --remove-orphans 실행
-#     (ghcr.io/nexters/palang-server 이미지를 그대로 pull, 로컬 재빌드 없음)
+#     (ghcr.io/nexters/pallang-server 이미지를 그대로 pull, 로컬 재빌드 없음)
 
 services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/nexters/palang-server:${IMAGE_TAG:-latest}
+    image: ghcr.io/nexters/pallang-server:${IMAGE_TAG:-latest}
     container_name: pallang-app
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (실제 dev 서버 배포 중 발견한 버그 수정 — 별도 트래킹 이슈 없음)

## 🚀 개요
`docker-compose.yml`에 하드코딩된 GHCR 이미지 경로가 저장소 실제 이름과 어긋나 있어 CD 배포 시 이미지 pull이 항상 `not found`로 실패하던 문제를 수정한다.

## 📄 작업 내용
- 저장소 이름이 `Palang-Server`(L 1개)에서 `pallang-server`(L 2개)로 변경됐는데, `docker-compose.yml`의 app 서비스 `image`는 예전 이름(`ghcr.io/nexters/palang-server`)으로 하드코딩돼 있었음
- `cd.yml`은 `${{ github.repository }}`를 매 실행마다 동적으로 소문자 변환해서 쓰기 때문에 자동으로 새 이름(`pallang-server`)으로 push되고 있었고, 그 결과 실제 push된 이미지 경로와 `docker-compose.yml`이 pull하려는 경로가 어긋나 있었음
- `docker-compose.yml`의 이미지 경로를 `ghcr.io/nexters/pallang-server`로 수정해 실제 GHCR 패키지 경로와 일치시킴

## 📸 스크린샷 / 테스트 결과 (선택)
- 실제 dev 서버 배포 로그에서 `docker compose pull`이 `ghcr.io/nexters/palang-server:<tag>: not found`로 반복 실패하는 것을 확인
- GitHub Packages 페이지(`Nexters/pallang-server` 패키지)에서 해당 태그가 `pallang-server`(L 2개) 경로로 정상 push되어 있는 것을 직접 확인 — 경로 불일치가 원인임을 검증
- `docker compose config`로 `IMAGE_TAG` 지정 시 `image: ghcr.io/nexters/pallang-server:<tag>`로 올바르게 해석되는 것 확인
  ```bash
  IMAGE_TAG=6df391c1 docker compose --env-file deploy/.env.example config | grep image:
  #   image: ghcr.io/nexters/pallang-server:6df391c1