### PR TITLE
Feat/#39 카카오 로그인/JWT 인증 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// Security & JWT
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
@@ -48,6 +54,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthMapper.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthMapper.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.auth.application;
+
+import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
+import com.nexters.palang.domain.auth.presentation.dto.TokenResponse;
+
+public final class AuthMapper {
+
+    private AuthMapper() {
+    }
+
+    public static LoginResponse toLoginResponse(AuthResult result) {
+        return new LoginResponse(
+                result.accessToken(), result.refreshToken(),
+                result.isNewUser(), result.termsAgreed(), result.hasCompletedOnboarding());
+    }
+
+    public static TokenResponse toTokenResponse(AuthResult result) {
+        return new TokenResponse(result.accessToken(), result.refreshToken());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthResult.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthResult.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.auth.application;
+
+public record AuthResult(
+        String accessToken,
+        String refreshToken,
+        boolean isNewUser,
+        boolean termsAgreed,
+        boolean hasCompletedOnboarding
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
@@ -53,6 +53,17 @@ public class AuthService {
         getActiveUser(userId).agreeToTerms();
     }
 
+    // local 프로파일 전용 개발 편의 기능(DevAuthController). 카카오 서버를 타지 않고 바로 JWT를 발급한다.
+    // userId가 주어지면 그 유저로, 없으면 매번 새 테스트 유저를 만들어 로그인 처리한다.
+    @Transactional
+    public AuthResult devLogin(Long userId) {
+        boolean isNewUser = userId == null;
+        User user = isNewUser
+                ? userRegistrationService.registerViaSns(SnsProvider.KAKAO, "dev-" + System.nanoTime())
+                : getActiveUser(userId);
+        return issueTokens(user, isNewUser);
+    }
+
     @Transactional
     public AuthResult refresh(String refreshToken) {
         Long userId = parseUserId(refreshToken);

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
@@ -1,0 +1,122 @@
+package com.nexters.palang.domain.auth.application;
+
+import com.nexters.palang.domain.auth.domain.RefreshToken;
+import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
+import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
+import com.nexters.palang.domain.user.application.UserRegistrationService;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.AuthErrorCode;
+import com.nexters.palang.global.security.AuthException;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final UserRegistrationService userRegistrationService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public AuthResult loginWithKakao(String kakaoAccessToken) {
+        String snsId = kakaoOAuthClient.getSnsId(kakaoAccessToken);
+        User user = userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, snsId).orElse(null);
+
+        boolean isNewUser = user == null;
+        if (isNewUser) {
+            user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, snsId);
+        } else if (user.isWithdrawn()) {
+            throw new AuthException(AuthErrorCode.WITHDRAWN_ACCOUNT);
+        }
+
+        return issueTokens(user, isNewUser);
+    }
+
+    @Transactional
+    public void agreeToTerms(Long userId) {
+        getActiveUser(userId).agreeToTerms();
+    }
+
+    @Transactional
+    public AuthResult refresh(String refreshToken) {
+        Long userId = parseUserId(refreshToken);
+        String tokenHash = hash(refreshToken);
+        RefreshToken stored = refreshTokenRepository.findByUserIdAndTokenHashAndRevokedFalse(userId, tokenHash)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+        if (stored.isExpired()) {
+            throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+        }
+        stored.revoke();
+
+        return issueTokens(getActiveUser(userId), false);
+    }
+
+    @Transactional
+    public void logout(Long userId, String refreshToken) {
+        refreshTokenRepository.findByUserIdAndTokenHash(userId, hash(refreshToken))
+                .ifPresent(RefreshToken::revoke);
+    }
+
+    private AuthResult issueTokens(User user, boolean isNewUser) {
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        RefreshToken token = RefreshToken.builder()
+                .userId(user.getId())
+                .tokenHash(hash(refreshToken))
+                .expiresAt(jwtTokenProvider.refreshTokenExpiryFromNow())
+                .build();
+        refreshTokenRepository.save(token);
+
+        return new AuthResult(
+                accessToken, refreshToken, isNewUser,
+                user.getTermsAgreedAt() != null, user.isHasCompletedOnboarding());
+    }
+
+    private Long parseUserId(String token) {
+        try {
+            return jwtTokenProvider.getUserId(token);
+        } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    // 탈퇴한 사용자는 더 이상 조작 대상이 아니므로 존재하지 않는 것과 동일하게 취급한다(UserService와 동일한 정책).
+    private User getActiveUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (user.isWithdrawn()) {
+            throw new UserException(UserErrorCode.USER_NOT_FOUND);
+        }
+        return user;
+    }
+
+    // 원문 리프레시 토큰을 DB에 그대로 저장하지 않기 위한 SHA-256 해시.
+    private String hash(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/nexters/palang/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,60 @@
+package com.nexters.palang.domain.auth.domain;
+
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// Redis는 도입하지 않고 DB 테이블로 관리한다(backend_plan.md §1).
+@Getter
+@Entity
+@Table(
+        name = "refresh_tokens",
+        indexes = @Index(name = "idx_refresh_tokens_user_hash", columnList = "user_id, token_hash")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 원문 토큰이 아니라 SHA-256 해시를 저장한다(DB 유출 시에도 토큰 자체는 복원 불가).
+    @Column(name = "token_hash", nullable = false, length = 64)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "revoked", nullable = false)
+    private boolean revoked;
+
+    @Builder
+    private RefreshToken(Long userId, String tokenHash, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.revoked = false;
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
@@ -1,0 +1,35 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import com.nexters.palang.domain.auth.infrastructure.dto.KakaoUserInfoResponse;
+import com.nexters.palang.global.security.AuthErrorCode;
+import com.nexters.palang.global.security.AuthException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final WebClient kakaoWebClient;
+
+    // 모바일 앱이 카카오 SDK로 로그인 후 전달한 액세스 토큰을 카카오 서버에 직접 검증한다.
+    public String getSnsId(String kakaoAccessToken) {
+        KakaoUserInfoResponse response;
+        try {
+            response = kakaoWebClient.get()
+                    .uri("/v2/user/me")
+                    .headers(headers -> headers.setBearerAuth(kakaoAccessToken))
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoResponse.class)
+                    .block();
+        } catch (RuntimeException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED);
+        }
+
+        if (response == null || response.id() == null) {
+            throw new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED);
+        }
+        return String.valueOf(response.id());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import com.nexters.palang.domain.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUserIdAndTokenHashAndRevokedFalse(Long userId, String tokenHash);
+
+    Optional<RefreshToken> findByUserIdAndTokenHash(Long userId, String tokenHash);
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,8 @@
+package com.nexters.palang.domain.auth.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+// 카카오 사용자 정보 조회 API(GET /v2/user/me) 응답 중 식별자만 사용한다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponse(Long id) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/AuthApi.java
@@ -1,0 +1,83 @@
+package com.nexters.palang.domain.auth.presentation;
+
+import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
+import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
+import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
+import com.nexters.palang.domain.auth.presentation.dto.TermsAgreementResponse;
+import com.nexters.palang.domain.auth.presentation.dto.TokenResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Auth", description = "카카오 로그인/인증 API")
+public interface AuthApi {
+
+    @Operation(summary = "카카오 로그인", description = "모바일 앱이 카카오 SDK로 로그인해 받은 카카오 액세스 토큰을 전달하면, "
+            + "카카오 사용자 정보 API로 직접 검증한 뒤 가입/로그인을 처리하고 서비스 자체 JWT를 발급합니다. "
+            + "처음 로그인하는 사용자는 닉네임이 자동 생성되며(isNewUser=true), 약관 동의는 별도로 POST /api/auth/terms를 호출해야 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인/가입 성공"),
+            @ApiResponse(responseCode = "400", description = "카카오 액세스 토큰 누락 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/kakao\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"카카오 액세스 토큰은 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "카카오 인증 실패, 만료/유효하지 않은 토큰 (AUTH_401_4)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/kakao\",\"title\":\"AUTH_401_4\","
+                                    + "\"status\":401,\"detail\":\"카카오 인증에 실패했습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "탈퇴한 계정으로 재로그인 시도 (AUTH_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/kakao\",\"title\":\"AUTH_403_1\","
+                                    + "\"status\":403,\"detail\":\"탈퇴한 계정입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<LoginResponse>> loginWithKakao(@Valid KakaoLoginRequest request);
+
+    @Operation(summary = "약관 동의", description = "이용약관 + 개인정보 수집·이용 동의를 1회 처리로 기록합니다(FR-AUTH-03). "
+            + "이미 동의한 사용자가 다시 호출해도 동의 시각만 갱신되며 에러는 발생하지 않습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "동의 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요함 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/terms\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<TermsAgreementResponse>> agreeToTerms();
+
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 새 액세스 토큰 + 리프레시 토큰을 발급합니다. "
+            + "기존 리프레시 토큰은 사용 즉시 폐기됩니다(재사용 불가).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @ApiResponse(responseCode = "400", description = "리프레시 토큰 누락 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/refresh\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"리프레시 토큰은 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "만료되었거나(AUTH_401_2) 유효하지 않은(AUTH_401_5) 리프레시 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "AUTH_401_2", value = "{\"type\":\"/api/auth/refresh\","
+                                    + "\"title\":\"AUTH_401_2\",\"status\":401,\"detail\":\"토큰이 만료되었습니다.\"}"),
+                            @ExampleObject(name = "AUTH_401_5", value = "{\"type\":\"/api/auth/refresh\","
+                                    + "\"title\":\"AUTH_401_5\",\"status\":401,"
+                                    + "\"detail\":\"유효하지 않은 리프레시 토큰입니다.\"}")
+                    }))
+    })
+    ResponseEntity<DataResponse<TokenResponse>> refresh(@Valid RefreshTokenRequest request);
+
+    @Operation(summary = "로그아웃", description = "전달한 리프레시 토큰을 폐기합니다. 액세스 토큰 자체는 만료 전까지 유효하지만, "
+            + "재발급에는 더 이상 사용할 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요함 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/logout\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> logout(@Valid RefreshTokenRequest request);
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/AuthController.java
@@ -1,0 +1,56 @@
+package com.nexters.palang.domain.auth.presentation;
+
+import com.nexters.palang.domain.auth.application.AuthMapper;
+import com.nexters.palang.domain.auth.application.AuthResult;
+import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
+import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
+import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
+import com.nexters.palang.domain.auth.presentation.dto.TermsAgreementResponse;
+import com.nexters.palang.domain.auth.presentation.dto.TokenResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+
+    private final AuthService authService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @PostMapping("/api/auth/kakao")
+    public ResponseEntity<DataResponse<LoginResponse>> loginWithKakao(@RequestBody @Valid KakaoLoginRequest request) {
+        AuthResult result = authService.loginWithKakao(request.kakaoAccessToken());
+        return ResponseEntity.ok(DataResponse.from(AuthMapper.toLoginResponse(result)));
+    }
+
+    @Override
+    @PostMapping("/api/auth/terms")
+    public ResponseEntity<DataResponse<TermsAgreementResponse>> agreeToTerms() {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        authService.agreeToTerms(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(new TermsAgreementResponse(true)));
+    }
+
+    @Override
+    @PostMapping("/api/auth/refresh")
+    public ResponseEntity<DataResponse<TokenResponse>> refresh(@RequestBody @Valid RefreshTokenRequest request) {
+        AuthResult result = authService.refresh(request.refreshToken());
+        return ResponseEntity.ok(DataResponse.from(AuthMapper.toTokenResponse(result)));
+    }
+
+    @Override
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<DataResponse<Void>> logout(@RequestBody @Valid RefreshTokenRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        authService.logout(currentUserId, request.refreshToken());
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/DevAuthController.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/DevAuthController.java
@@ -1,0 +1,51 @@
+package com.nexters.palang.domain.auth.presentation;
+
+import com.nexters.palang.domain.auth.application.AuthMapper;
+import com.nexters.palang.domain.auth.application.AuthResult;
+import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.DevLoginRequest;
+import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+// local 프로파일에서만 활성화된다 — 운영 환경에는 이 엔드포인트 자체가 존재하지 않는다.
+// 카카오 서버를 타지 않고 바로 우리 서비스 JWT를 발급해, 스웨거에서 "인증 필요" API를 빠르게 테스트할 수 있게 한다.
+@Profile("local")
+@Tag(name = "Auth (Dev)", description = "[개발용] local 프로파일 전용 — 실제 카카오 로그인 없이 JWT를 발급합니다. 운영에는 노출되지 않습니다.")
+@RestController
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "[개발용] 임의 유저로 즉시 로그인", description = "카카오 서버를 호출하지 않고 바로 JWT를 발급합니다. "
+            + "userId를 주면 해당 유저로 로그인하고, 생략하면 새 테스트 유저를 만들어 로그인 처리합니다. "
+            + "local 프로파일에서만 등록되는 개발 편의용 엔드포인트입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 userId (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/dev-login\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    @PostMapping("/api/auth/dev-login")
+    public ResponseEntity<DataResponse<LoginResponse>> devLogin(
+            @RequestBody(required = false) DevLoginRequest request) {
+        Long userId = request != null ? request.userId() : null;
+        AuthResult result = authService.devLogin(userId);
+        return ResponseEntity.ok(DataResponse.from(AuthMapper.toLoginResponse(result)));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/DevLoginRequest.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/DevLoginRequest.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// local 프로파일 전용 개발용 요청 — userId를 생략하면 새 테스트 유저를 만든다.
+public record DevLoginRequest(
+        @Schema(example = "1", description = "생략하면 새 테스트 유저를 만들어 로그인 처리한다.")
+        Long userId
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/KakaoLoginRequest.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
+        @Schema(example = "kakao-access-token")
+        String kakaoAccessToken
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access") String accessToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh") String refreshToken,
+        @Schema(example = "true") boolean isNewUser,
+        @Schema(example = "false") boolean termsAgreed,
+        @Schema(example = "false") boolean hasCompletedOnboarding
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TermsAgreementResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TermsAgreementResponse.java
@@ -1,0 +1,8 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TermsAgreementResponse(
+        @Schema(example = "true") boolean termsAgreed
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TokenResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TokenResponse.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenResponse(
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access") String accessToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh") String refreshToken
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -69,12 +69,12 @@ public interface BookApi {
 
     @Operation(summary = "내가 최근에 남긴 도서 목록",
             description = "현재 로그인한 사용자가 최근에 대목을 남긴 도서 목록입니다. "
-                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookListResponse>> getRecentBooks(

--- a/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 public interface UserBookStatusApi {
 
     @Operation(summary = "읽기상태/현재페이지 설정", description = "로그인한 사용자의 특정 도서에 대한 읽기상태와 현재 페이지를 설정합니다. "
-            + "기존 상태가 없으면 새로 생성합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "기존 상태가 없으면 새로 생성합니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "설정 성공"),
             @ApiResponse(responseCode = "400", description = "필수값 누락 또는 현재 페이지가 전체 페이지 수 초과(BOOK_400_2)",
@@ -29,7 +29,7 @@ public interface UserBookStatusApi {
                                     @ExampleObject(name = "BOOK_400_2: 페이지 초과", value = "{\"type\":\"/api/users/me/book-status\",\"title\":\"BOOK_400_2\",\"status\":400,\"detail\":\"현재 페이지는 도서의 전체 페이지 수를 초과할 수 없습니다.\"}")
                             })
             ),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = "{\"type\":\"/api/users/me/book-status\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
@@ -70,7 +70,7 @@ public interface CommentApi {
     @Operation(summary = "댓글/답글 작성",
             description = "흔적에 댓글 또는 답글을 작성합니다. parentCommentId가 없으면 원댓글, 있으면 답글로 생성됩니다. "
                     + "답글에는 다시 답글을 남길 수 없습니다(1-depth). 삭제된 댓글을 부모로 답글을 작성할 수 없습니다. "
-                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "작성 성공"),
             @ApiResponse(responseCode = "400", description = "내용 누락/500자 초과 (COMMON_400_1) "
@@ -83,7 +83,7 @@ public interface CommentApi {
                                     + "\"title\":\"COMMENT_400_1\",\"status\":400,"
                                     + "\"detail\":\"답글에는 답글을 남길 수 없습니다.\"}")
                     })),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -104,14 +104,14 @@ public interface CommentApi {
     );
 
     @Operation(summary = "댓글/답글 수정", description = "본인이 작성한 댓글/답글의 내용을 수정합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "내용 누락/500자 초과 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/comments/1\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"댓글 내용은 필수입니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/comments/1\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -130,10 +130,10 @@ public interface CommentApi {
     );
 
     @Operation(summary = "댓글/답글 삭제", description = "본인이 작성한 댓글/답글을 소프트 삭제합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/comments/1\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
@@ -26,7 +26,7 @@ public interface OpinionApi {
             description = "Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 원자적으로 생성합니다. "
                     + "passageId가 없으면 새 Passage를 만들고, 있으면 해당 Passage에 병합합니다(Q-06). "
                     + "OCR 입력은 별도 플로우이며 이 API는 직접 입력만 지원합니다. "
-                    + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "흔적 생성 성공"),
             @ApiResponse(responseCode = "400",
@@ -42,7 +42,7 @@ public interface OpinionApi {
                                     @ExampleObject(name = "DECORATION_400_2: 꾸밈 영역 겹침", value = "{\"type\":\"/api/opinions\",\"title\":\"DECORATION_400_2\",\"status\":400,\"detail\":\"같은 흔적 안에서는 꾸밈 효과 영역이 겹칠 수 없습니다.\"}")
                             })
             ),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = "{\"type\":\"/api/opinions\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))
@@ -95,7 +95,7 @@ public interface OpinionApi {
             @ApiResponse(responseCode = "400", description = "내용 누락/길이 초과 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"흔적 내용은 500자를 초과할 수 없습니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "OPINION_403_1: 본인이 작성한 흔적만 수정/삭제할 수 있습니다.",
@@ -113,7 +113,7 @@ public interface OpinionApi {
     @Operation(summary = "흔적 삭제", description = "본인이 작성한 흔적을 소프트 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "OPINION_403_1: 본인이 작성한 흔적만 수정/삭제할 수 있습니다.",

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -46,7 +46,7 @@ public interface PassageControllerDocs {
     );
 
     @Operation(summary = "유사 문장 후보 조회", description = "저장 전 같은 도서의 인접 페이지(±1)에서 정규화 해시가 같은 대목 후보를 조회합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (후보가 없으면 빈 배열)"),
             @ApiResponse(

--- a/src/main/java/com/nexters/palang/domain/user/application/NicknameGenerator.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/NicknameGenerator.java
@@ -1,0 +1,39 @@
+package com.nexters.palang.domain.user.application;
+
+import java.security.SecureRandom;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+// FR-AUTH-04: 형용사 30 x 명사 30 랜덤 조합(900개) + 숫자 접미사(1~100) = 90,000개.
+// 유니크 제약 충돌 처리(저장 시도 -> 재시도)는 UserRegistrationService가 담당한다.
+@Component
+public class NicknameGenerator {
+
+    public static final int MAX_SUFFIX_ATTEMPTS = 100;
+
+    private static final List<String> ADJECTIVES = List.of(
+            "고요한", "다정한", "따스한", "느긋한", "단단한", "반짝이는", "맑은", "포근한", "조용한", "용감한",
+            "성실한", "섬세한", "담백한", "신나는", "차분한", "자유로운", "깊은", "작은", "푸른", "은은한",
+            "따뜻한", "빛나는", "소박한", "여유로운", "성숙한", "솔직한", "정다운", "특별한", "평온한", "부지런한"
+    );
+
+    private static final List<String> NOUNS = List.of(
+            "책갈피", "문장", "연필", "서재", "별빛", "달빛", "숲길", "잉크", "종이", "다락방",
+            "찻잔", "산책자", "독서등", "노트", "고래", "나무", "파도", "구름", "여우", "다람쥐",
+            "등불", "우체통", "시계", "지도", "여정", "쉼표", "낙엽", "창가", "이야기", "여백"
+    );
+
+    private final SecureRandom random = new SecureRandom();
+
+    public String generateBase() {
+        return pick(ADJECTIVES) + pick(NOUNS);
+    }
+
+    public String withSuffix(String base, int suffix) {
+        return base + suffix;
+    }
+
+    private String pick(List<String> words) {
+        return words.get(random.nextInt(words.size()));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
@@ -1,0 +1,46 @@
+package com.nexters.palang.domain.user.application;
+
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserRegistrationService {
+
+    private final UserRepository userRepository;
+    private final NicknameGenerator nicknameGenerator;
+
+    // FR-AUTH-04: 닉네임 유니크 제약 충돌은 사전 조회 대신 저장 시도 -> 실패 시 접미사를 붙여 재시도하는
+    // 낙관적 방식으로 처리한다(사전 조회는 동시성에 취약). 각 시도를 REQUIRES_NEW로 독립된 트랜잭션에서
+    // 실행해, 제약 위반 예외가 영속성 컨텍스트를 오염시켜 다음 시도까지 실패시키는 것을 막는다.
+    public User registerViaSns(SnsProvider snsProvider, String snsId) {
+        String base = nicknameGenerator.generateBase();
+        for (int suffix = 0; suffix <= NicknameGenerator.MAX_SUFFIX_ATTEMPTS; suffix++) {
+            String nickname = suffix == 0 ? base : nicknameGenerator.withSuffix(base, suffix);
+            try {
+                return createUser(nickname, snsProvider, snsId);
+            } catch (DataIntegrityViolationException e) {
+                // 닉네임 충돌로 보고 다음 접미사로 재시도한다.
+            }
+        }
+        throw new UserException(UserErrorCode.NICKNAME_GENERATION_FAILED);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public User createUser(String nickname, SnsProvider snsProvider, String snsId) {
+        User user = User.builder()
+                .nickname(nickname)
+                .snsProvider(snsProvider)
+                .snsId(snsId)
+                .build();
+        return userRepository.saveAndFlush(user);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/application/UserService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserService.java
@@ -42,6 +42,12 @@ public class UserService {
         user.withdraw();
     }
 
+    @Transactional
+    public void completeOnboarding(Long userId) {
+        User user = getActiveUser(userId);
+        user.completeOnboarding();
+    }
+
     // 탈퇴한 사용자는 더 이상 조작 대상이 아니므로 존재하지 않는 것과 동일하게 취급한다.
     private User getActiveUser(Long userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_1", "해당 사용자를 찾을 수 없습니다."),
     NICKNAME_CHANGE_LIMITED(HttpStatus.BAD_REQUEST, "USER_400_1", "닉네임은 하루에 한 번만 변경할 수 있습니다."),
     NICKNAME_ALREADY_IN_USE(HttpStatus.CONFLICT, "USER_409_1", "이미 사용 중인 닉네임입니다."),
+    NICKNAME_GENERATION_FAILED(HttpStatus.CONFLICT, "USER_409_2", "닉네임 자동 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -58,7 +58,9 @@ public class User extends BaseEntity {
     @Column(name = "sns_id", nullable = false)
     private String snsId;
 
-    @Column(name = "terms_agreed_at", nullable = false)
+    // SNS 로그인 시점에는 아직 약관에 동의하지 않았을 수 있어(FR-AUTH-03) nullable이다.
+    // POST /api/auth/terms 호출 시 agreeToTerms()로 채워진다.
+    @Column(name = "terms_agreed_at")
     private LocalDateTime termsAgreedAt;
 
     @Column(name = "has_completed_onboarding", nullable = false)
@@ -91,6 +93,11 @@ public class User extends BaseEntity {
 
     public void completeOnboarding() {
         this.hasCompletedOnboarding = true;
+    }
+
+    // 이용약관 동의(FR-AUTH-03): 재동의 요청이 와도 그냥 최신 시각으로 갱신한다(멱등).
+    public void agreeToTerms() {
+        this.termsAgreedAt = LocalDateTime.now();
     }
 
     // 하루 1회 제한(FR-MY-05): 마지막 변경일이 오늘이면 재변경을 막는다. 이 사용자 한 명의 상태만으로

--- a/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
@@ -1,9 +1,13 @@
 package com.nexters.palang.domain.user.infrastructure;
 
+import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNicknameAndIdNot(String nickname, Long id);
+
+    Optional<User> findBySnsProviderAndSnsId(SnsProvider snsProvider, String snsId);
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.user.presentation;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.OnboardingCompleteResponse;
 import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
 import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
 import com.nexters.palang.global.common.error.ErrorResponse;
@@ -22,10 +23,10 @@ import org.springframework.http.ResponseEntity;
 public interface UserApi {
 
     @Operation(summary = "내 프로필 조회", description = "닉네임, 프로필 이미지, 배경색, 가입 경로(SNS), "
-            + "지금까지 남긴 흔적 수를 조회합니다. X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "지금까지 남긴 흔적 수를 조회합니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -37,7 +38,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> getMe();
 
     @Operation(summary = "닉네임 변경", description = "최대 15자, 중복 불가, 하루 1회만 변경할 수 있습니다(달력일 기준). "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(responseCode = "400", description = "닉네임 누락/15자 초과 (COMMON_400_1) "
@@ -50,7 +51,7 @@ public interface UserApi {
                                     + "\"title\":\"USER_400_1\",\"status\":400,"
                                     + "\"detail\":\"닉네임은 하루에 한 번만 변경할 수 있습니다.\"}")
                     })),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/nickname\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -66,14 +67,14 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> modifyNickname(@Valid UpdateNicknameRequest request);
 
     @Operation(summary = "배경색 변경", description = "흔적 보기 화면의 배경색을 변경합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(responseCode = "400", description = "배경색 누락/20자 초과 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/background-color\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"배경색은 필수입니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/background-color\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -85,10 +86,10 @@ public interface UserApi {
     ResponseEntity<DataResponse<MeResponse>> modifyBackgroundColor(@Valid UpdateBackgroundColorRequest request);
 
     @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
-            + "공개된 발췌·의견·댓글은 남습니다). X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "공개된 발췌·의견·댓글은 남습니다). Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
@@ -99,15 +100,31 @@ public interface UserApi {
     })
     ResponseEntity<DataResponse<Void>> withdraw();
 
+    @Operation(summary = "온보딩 완료 처리", description = "로그인 직후 온보딩 4단계를 마치면 호출합니다(FR-AUTH-05). "
+            + "이미 완료한 사용자가 다시 호출해도 에러 없이 그대로 완료 상태를 유지합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/onboarding-complete\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음 (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/onboarding-complete\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<OnboardingCompleteResponse>> completeOnboarding();
+
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
@@ -119,14 +136,14 @@ public interface UserApi {
 
     @Operation(summary = "좋아요 누른 흔적 목록", description = "내가 좋아요를 누른 흔적을 좋아요 누른 순서대로(최신순) 조회합니다. "
             + "좋아요 취소는 이 API가 아니라 흔적 좋아요 토글 API가 담당합니다. "
-            + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/likes\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "X-Debug-User-Id 헤더 누락 (AUTH_401_1)",
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/likes\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -7,6 +7,7 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.OnboardingCompleteResponse;
 import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
 import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
 import com.nexters.palang.global.common.response.DataResponse;
@@ -66,6 +67,14 @@ public class UserController implements UserApi {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         userService.withdraw(currentUserId);
         return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @PatchMapping("/api/users/me/onboarding-complete")
+    public ResponseEntity<DataResponse<OnboardingCompleteResponse>> completeOnboarding() {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        userService.completeOnboarding(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(new OnboardingCompleteResponse(true)));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/OnboardingCompleteResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/OnboardingCompleteResponse.java
@@ -1,0 +1,8 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OnboardingCompleteResponse(
+        @Schema(example = "true") boolean hasCompletedOnboarding
+) {
+}

--- a/src/main/java/com/nexters/palang/global/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.nexters.palang.global.config;
+
+import com.nexters.palang.global.security.jwt.JwtAuthenticationFilter;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+// 인가는 Spring Security의 authorizeHttpRequests가 아니라 서비스 레이어의 CurrentUserProvider가 담당한다
+// (backend_plan.md §4.2 Soft Authentication). 그래서 여기서는 모든 요청을 permitAll로 통과시키고,
+// JwtAuthenticationFilter로 토큰이 있으면 유저 정보만 채워 넣는다.
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
@@ -19,6 +19,15 @@ public class WebClientConfig {
 
     @Bean
     public WebClient aladinWebClient(WebClient.Builder builder, @Value("${aladin.base-url}") String baseUrl) {
+        return webClient(builder, baseUrl);
+    }
+
+    @Bean
+    public WebClient kakaoWebClient(WebClient.Builder builder, @Value("${kakao.base-url}") String baseUrl) {
+        return webClient(builder, baseUrl);
+    }
+
+    private WebClient webClient(WebClient.Builder builder, String baseUrl) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
                 .responseTimeout(RESPONSE_TIMEOUT)

--- a/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
+++ b/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
@@ -10,6 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements BaseErrorCode {
 
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "로그인이 필요합니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_2", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_3", "유효하지 않은 토큰입니다."),
+    KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_4", "카카오 인증에 실패했습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_5", "유효하지 않은 리프레시 토큰입니다."),
+    WITHDRAWN_ACCOUNT(HttpStatus.FORBIDDEN, "AUTH_403_1", "탈퇴한 계정입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/global/security/AuthException.java
+++ b/src/main/java/com/nexters/palang/global/security/AuthException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.global.security;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class AuthException extends AppException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/nexters/palang/global/security/JwtCurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/JwtCurrentUserProvider.java
@@ -1,0 +1,32 @@
+package com.nexters.palang.global.security;
+
+import com.nexters.palang.global.security.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증 Phase의 실제 구현체. JwtAuthenticationFilter가 request attribute에 채워둔 유저 ID를 그대로 꺼낸다.
+ * HeaderCurrentUserProvider(local 프로파일 임시 스탠드인)보다 우선하도록 @Primary로 지정한다.
+ */
+@Primary
+@Component
+@RequiredArgsConstructor
+public class JwtCurrentUserProvider implements CurrentUserProvider {
+
+    private final HttpServletRequest request;
+
+    @Override
+    public Long getCurrentUserId() {
+        Object userId = request.getAttribute(JwtAuthenticationFilter.CURRENT_USER_ID_ATTRIBUTE);
+        if (userId != null) {
+            return (Long) userId;
+        }
+        Object authError = request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE);
+        if (authError instanceof AuthErrorCode errorCode) {
+            throw new AuthException(errorCode);
+        }
+        throw new LoginRequiredException();
+    }
+}

--- a/src/main/java/com/nexters/palang/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/nexters/palang/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.nexters.palang.global.security.jwt;
+
+import com.nexters.palang.global.security.AuthErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * OptionalAuthentication(backend_plan.md §4.2): 토큰이 없어도 요청을 막지 않고 통과시킨다.
+ * 토큰이 있으면 SecurityContext + request attribute에 유저 ID를 채우고,
+ * 유효하지 않으면 원인을 attribute에 남겨 CurrentUserProvider가 정확한 에러 코드로 변환하게 한다.
+ * 실제 "인증 필요" 차단은 이 필터가 아니라 서비스 레이어(CurrentUserProvider)가 담당한다.
+ *
+ * 일부러 @Component로 등록하지 않는다: Filter를 구현하는 @Component는 @WebMvcTest 슬라이스가
+ * 자동으로 스캔해 들여오는데, 그러면 JwtTokenProvider 빈이 없는 슬라이스 컨텍스트에서
+ * 생성자 주입이 깨진다. SecurityConfig가 직접 new로 생성해 필터 체인에 끼워 넣는다.
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String CURRENT_USER_ID_ATTRIBUTE = "currentUserId";
+    public static final String AUTH_ERROR_ATTRIBUTE = "authError";
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null) {
+            try {
+                Long userId = jwtTokenProvider.getUserId(token);
+                request.setAttribute(CURRENT_USER_ID_ATTRIBUTE, userId);
+                SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of()));
+            } catch (ExpiredJwtException e) {
+                request.setAttribute(AUTH_ERROR_ATTRIBUTE, AuthErrorCode.TOKEN_EXPIRED);
+            } catch (JwtException | IllegalArgumentException e) {
+                request.setAttribute(AUTH_ERROR_ATTRIBUTE, AuthErrorCode.INVALID_TOKEN);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/nexters/palang/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,62 @@
+package com.nexters.palang.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpirationMillis;
+    private final long refreshTokenExpirationMillis;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
+            @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpirationMillis = accessTokenExpirationSeconds * 1000;
+        this.refreshTokenExpirationMillis = refreshTokenExpirationSeconds * 1000;
+    }
+
+    public String createAccessToken(Long userId) {
+        return createToken(userId, accessTokenExpirationMillis);
+    }
+
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, refreshTokenExpirationMillis);
+    }
+
+    public LocalDateTime refreshTokenExpiryFromNow() {
+        return LocalDateTime.now().plusSeconds(refreshTokenExpirationMillis / 1000);
+    }
+
+    // 만료/서명 오류 시 io.jsonwebtoken의 ExpiredJwtException/JwtException을 그대로 던진다.
+    // 호출부(JwtAuthenticationFilter, AuthService)가 각자의 맥락에 맞는 에러 코드로 변환한다.
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return Long.valueOf(claims.getSubject());
+    }
+
+    private String createToken(Long userId, long expirationMillis) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMillis);
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -55,6 +55,14 @@ aladin:
   base-url: https://www.aladin.co.kr/ttb/api
   ttb-key: ${ALADIN_TTB_KEY:}
 
+kakao:
+  base-url: https://kapi.kakao.com
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
+  refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,3 +7,11 @@ spring:
 aladin:
   base-url: https://www.aladin.co.kr/ttb/api
   ttb-key: ${ALADIN_TTB_KEY:}
+
+kakao:
+  base-url: https://kapi.kakao.com
+
+jwt:
+  secret: ${JWT_SECRET:local-dev-jwt-secret-key-please-change-this-01234567890123456789}
+  access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
+  refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -111,6 +112,44 @@ class AuthServiceTest {
                 .willReturn(Optional.of(withdrawnUser));
 
         assertThatThrownBy(() -> authService.loginWithKakao("kakao-token")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("[개발용] userId 없이 devLogin을 호출하면 새 테스트 유저를 만들어 로그인 처리한다")
+    void devLoginCreatesNewUserWhenUserIdOmitted() {
+        User newUser = user(400L);
+        given(userRegistrationService.registerViaSns(eq(SnsProvider.KAKAO), anyString())).willReturn(newUser);
+        given(jwtTokenProvider.createAccessToken(400L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(400L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.devLogin(null);
+
+        assertThat(result.isNewUser()).isTrue();
+        assertThat(result.accessToken()).isEqualTo("access-token");
+    }
+
+    @Test
+    @DisplayName("[개발용] userId를 주고 devLogin을 호출하면 해당 유저로 로그인 처리한다")
+    void devLoginUsesExistingUserWhenUserIdGiven() {
+        User existingUser = user(500L);
+        given(userRepository.findById(500L)).willReturn(Optional.of(existingUser));
+        given(jwtTokenProvider.createAccessToken(500L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(500L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.devLogin(500L);
+
+        assertThat(result.isNewUser()).isFalse();
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("[개발용] 존재하지 않는 userId로 devLogin을 호출하면 예외가 발생한다")
+    void devLoginFailsWhenUserIdNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.devLogin(999L)).isInstanceOf(UserException.class);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -1,0 +1,222 @@
+package com.nexters.palang.domain.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.auth.domain.RefreshToken;
+import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
+import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
+import com.nexters.palang.domain.user.application.UserRegistrationService;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.AuthException;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserRegistrationService userRegistrationService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private KakaoOAuthClient kakaoOAuthClient;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+                userRepository, userRegistrationService, refreshTokenRepository, kakaoOAuthClient, jwtTokenProvider);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).snsProvider(SnsProvider.KAKAO).snsId("sns-" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("처음 로그인하는 카카오 사용자는 신규 가입되고 isNewUser가 true다")
+    void loginWithKakaoSignsUpNewUser() {
+        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-100");
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-100")).willReturn(Optional.empty());
+        User newUser = user(100L);
+        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-100")).willReturn(newUser);
+        given(jwtTokenProvider.createAccessToken(100L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(100L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithKakao("kakao-token");
+
+        assertThat(result.isNewUser()).isTrue();
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.termsAgreed()).isFalse();
+        assertThat(result.hasCompletedOnboarding()).isFalse();
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("이미 가입된 카카오 사용자가 로그인하면 isNewUser가 false다")
+    void loginWithKakaoSignsInExistingUser() {
+        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-200");
+        User existingUser = user(200L);
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-200"))
+                .willReturn(Optional.of(existingUser));
+        given(jwtTokenProvider.createAccessToken(200L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(200L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithKakao("kakao-token");
+
+        assertThat(result.isNewUser()).isFalse();
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("탈퇴한 계정으로 로그인을 시도하면 예외가 발생한다")
+    void loginWithKakaoFailsWhenAccountWithdrawn() {
+        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-300");
+        User withdrawnUser = user(300L);
+        withdrawnUser.withdraw();
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-300"))
+                .willReturn(Optional.of(withdrawnUser));
+
+        assertThatThrownBy(() -> authService.loginWithKakao("kakao-token")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("약관에 동의하면 사용자의 동의 시각이 기록된다")
+    void agreeToTermsUpdatesUser() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        authService.agreeToTerms(1L);
+
+        assertThat(user.getTermsAgreedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 약관에 동의하려 하면 예외가 발생한다")
+    void agreeToTermsFailsWhenUserNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.agreeToTerms(999L)).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰으로 재발급하면 기존 토큰은 폐기되고 새 토큰이 발급된다")
+    void refreshIssuesNewTokensAndRevokesOld() {
+        given(jwtTokenProvider.getUserId("old-refresh")).willReturn(1L);
+        RefreshToken stored = RefreshToken.builder()
+                .userId(1L).tokenHash(sha256("old-refresh")).expiresAt(LocalDateTime.now().plusDays(1)).build();
+        given(refreshTokenRepository.findByUserIdAndTokenHashAndRevokedFalse(1L, sha256("old-refresh")))
+                .willReturn(Optional.of(stored));
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("new-access");
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.refresh("old-refresh");
+
+        assertThat(result.accessToken()).isEqualTo("new-access");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh");
+        assertThat(stored.isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 액세스 토큰이 아니라 만료된 리프레시 토큰으로 재발급을 시도하면 예외가 발생한다")
+    void refreshFailsWhenStoredTokenExpired() {
+        given(jwtTokenProvider.getUserId("old-refresh")).willReturn(1L);
+        RefreshToken stored = RefreshToken.builder()
+                .userId(1L).tokenHash(sha256("old-refresh")).expiresAt(LocalDateTime.now().minusDays(1)).build();
+        given(refreshTokenRepository.findByUserIdAndTokenHashAndRevokedFalse(1L, sha256("old-refresh")))
+                .willReturn(Optional.of(stored));
+
+        assertThatThrownBy(() -> authService.refresh("old-refresh")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("저장된 적 없는(또는 이미 폐기된) 리프레시 토큰으로 재발급을 시도하면 예외가 발생한다")
+    void refreshFailsWhenTokenNotFound() {
+        given(jwtTokenProvider.getUserId("unknown-refresh")).willReturn(1L);
+        given(refreshTokenRepository.findByUserIdAndTokenHashAndRevokedFalse(anyLong(), anyString()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.refresh("unknown-refresh")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 JWT 형식의 리프레시 토큰이면 토큰 만료 예외가 발생한다")
+    void refreshFailsWhenTokenExpiredAtParseTime() {
+        given(jwtTokenProvider.getUserId("expired-jwt")).willThrow(new ExpiredJwtException(null, null, "expired"));
+
+        assertThatThrownBy(() -> authService.refresh("expired-jwt")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 리프레시 토큰이면 유효하지 않은 토큰 예외가 발생한다")
+    void refreshFailsWhenTokenMalformed() {
+        given(jwtTokenProvider.getUserId("malformed")).willThrow(new MalformedJwtException("malformed"));
+
+        assertThatThrownBy(() -> authService.refresh("malformed")).isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("로그아웃하면 해당 리프레시 토큰이 폐기된다")
+    void logoutRevokesRefreshToken() {
+        RefreshToken stored = RefreshToken.builder()
+                .userId(1L).tokenHash(sha256("refresh")).expiresAt(LocalDateTime.now().plusDays(1)).build();
+        given(refreshTokenRepository.findByUserIdAndTokenHash(1L, sha256("refresh"))).willReturn(Optional.of(stored));
+
+        authService.logout(1L, "refresh");
+
+        assertThat(stored.isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리프레시 토큰으로 로그아웃해도 에러 없이 무시된다")
+    void logoutIsNoOpWhenTokenNotFound() {
+        given(refreshTokenRepository.findByUserIdAndTokenHash(1L, sha256("refresh"))).willReturn(Optional.empty());
+
+        authService.logout(1L, "refresh");
+    }
+
+    private String sha256(String value) {
+        try {
+            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(hashBytes);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,154 @@
+package com.nexters.palang.domain.auth.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.auth.application.AuthResult;
+import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
+import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
+import com.nexters.palang.global.security.AuthErrorCode;
+import com.nexters.palang.global.security.AuthException;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @Test
+    @DisplayName("카카오 액세스 토큰으로 로그인하면 서비스 자체 JWT를 발급받는다")
+    void loginWithKakao() throws Exception {
+        given(authService.loginWithKakao("kakao-token"))
+                .willReturn(new AuthResult("access", "refresh", true, false, false));
+
+        mockMvc.perform(post("/api/auth/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest("kakao-token"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh"))
+                .andExpect(jsonPath("$.data.isNewUser").value(true));
+    }
+
+    @Test
+    @DisplayName("카카오 액세스 토큰 없이 로그인을 요청하면 400 에러가 발생한다")
+    void loginWithKakaoFailsWhenTokenBlank() throws Exception {
+        mockMvc.perform(post("/api/auth/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest(""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("카카오 인증에 실패하면 401 에러가 발생한다")
+    void loginWithKakaoFailsWhenKakaoAuthFails() throws Exception {
+        given(authService.loginWithKakao("invalid-token"))
+                .willThrow(new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED));
+
+        mockMvc.perform(post("/api/auth/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest("invalid-token"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_4"));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 약관에 동의하면 성공한다")
+    void agreeToTerms() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(post("/api/auth/terms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.termsAgreed").value(true));
+
+        verify(authService).agreeToTerms(1L);
+    }
+
+    @Test
+    @DisplayName("인증 없이 약관 동의를 요청하면 401 에러가 발생한다")
+    void agreeToTermsFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/auth/terms"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 재발급하면 새 토큰 쌍을 반환한다")
+    void refresh() throws Exception {
+        given(authService.refresh("old-refresh"))
+                .willReturn(new AuthResult("new-access", "new-refresh", false, true, true));
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest("old-refresh"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("new-access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 리프레시 토큰으로 재발급을 요청하면 401 에러가 발생한다")
+    void refreshFailsWhenTokenInvalid() throws Exception {
+        given(authService.refresh("invalid"))
+                .willThrow(new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest("invalid"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_5"));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 로그아웃하면 서비스에 위임한다")
+    void logout() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest("refresh"))))
+                .andExpect(status().isOk());
+
+        verify(authService).logout(eq(1L), eq("refresh"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 로그아웃을 요청하면 401 에러가 발생한다")
+    void logoutFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new RefreshTokenRequest("refresh"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/auth/presentation/DevAuthControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/presentation/DevAuthControllerTest.java
@@ -1,0 +1,90 @@
+package com.nexters.palang.domain.auth.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.auth.application.AuthResult;
+import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.DevLoginRequest;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+// DevAuthController는 @Profile("local")이라 local 프로파일을 활성화해야 빈이 등록된다.
+@WebMvcTest(DevAuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("local")
+class DevAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private AuthService authService;
+
+    @Test
+    @DisplayName("userId 없이 요청하면 새 테스트 유저로 로그인 처리한다")
+    void devLoginWithoutUserId() throws Exception {
+        given(authService.devLogin(isNull()))
+                .willReturn(new AuthResult("access", "refresh", true, false, false));
+
+        mockMvc.perform(post("/api/auth/dev-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new DevLoginRequest(null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access"))
+                .andExpect(jsonPath("$.data.isNewUser").value(true));
+    }
+
+    @Test
+    @DisplayName("본문 없이 요청해도 새 테스트 유저로 로그인 처리한다")
+    void devLoginWithoutBody() throws Exception {
+        given(authService.devLogin(isNull()))
+                .willReturn(new AuthResult("access", "refresh", true, false, false));
+
+        mockMvc.perform(post("/api/auth/dev-login"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access"));
+    }
+
+    @Test
+    @DisplayName("userId를 주면 해당 유저로 로그인 처리한다")
+    void devLoginWithUserId() throws Exception {
+        given(authService.devLogin(eq(7L)))
+                .willReturn(new AuthResult("access-7", "refresh-7", false, true, true));
+
+        mockMvc.perform(post("/api/auth/dev-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new DevLoginRequest(7L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access-7"))
+                .andExpect(jsonPath("$.data.isNewUser").value(false));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId면 404 에러가 발생한다")
+    void devLoginFailsWhenUserNotFound() throws Exception {
+        given(authService.devLogin(eq(999L))).willThrow(new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(post("/api/auth/dev-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new DevLoginRequest(999L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("USER_404_1"));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -34,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(BookController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class BookControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/book/presentation/UserBookStatusControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/UserBookStatusControllerTest.java
@@ -19,6 +19,7 @@ import com.nexters.palang.global.security.LoginRequiredException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -26,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserBookStatusController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class UserBookStatusControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -41,6 +42,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CommentController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class CommentControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/notice/presentation/NoticeControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/notice/presentation/NoticeControllerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(NoticeController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class NoticeControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/opinion/OpinionWriteFlowIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/OpinionWriteFlowIntegrationTest.java
@@ -11,6 +11,7 @@ import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,9 @@ class OpinionWriteFlowIntegrationTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private Long bookId;
@@ -54,6 +58,10 @@ class OpinionWriteFlowIntegrationTest {
         userId = user.getId();
     }
 
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
     @Test
     @DisplayName("직접 입력으로 흔적을 작성하면 새 Passage가 생성되고, 인접 페이지에서 유사 문장으로 조회되며, 병합 흔적을 남길 수 있고, 겹치는 꾸밈은 거부된다")
     void directEntryWriteFlow() throws Exception {
@@ -65,7 +73,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         String createResponse = mockMvc.perform(post("/api/opinions")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(createBody))
                 .andExpect(status().isOk())
@@ -79,7 +87,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         mockMvc.perform(post("/api/passages/similar-check")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(similarCheckBody))
                 .andExpect(status().isOk())
@@ -93,7 +101,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId, passageId);
 
         mockMvc.perform(post("/api/opinions")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mergeBody))
                 .andExpect(status().isOk())
@@ -111,7 +119,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         mockMvc.perform(post("/api/opinions")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(overlappingBody))
                 .andExpect(status().isBadRequest())
@@ -123,7 +131,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         mockMvc.perform(put("/api/users/me/book-status")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(bookStatusBody))
                 .andExpect(status().isOk())
@@ -135,7 +143,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         mockMvc.perform(put("/api/users/me/book-status")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(bookStatusUpdateBody))
                 .andExpect(status().isOk())
@@ -147,7 +155,7 @@ class OpinionWriteFlowIntegrationTest {
                 """.formatted(bookId);
 
         mockMvc.perform(put("/api/users/me/book-status")
-                        .header("X-Debug-User-Id", userId)
+                        .header("Authorization", bearerToken(userId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(bookStatusOverflowBody))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -40,6 +41,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(OpinionController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class OpinionControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/PassageReadFlowIntegrationTest.java
@@ -17,6 +17,7 @@ import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +52,9 @@ class PassageReadFlowIntegrationTest {
     @Autowired
     private OpinionRepository opinionRepository;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     private Long bookId;
     private Long writerId;
     private Long readerId;
@@ -79,6 +83,10 @@ class PassageReadFlowIntegrationTest {
         page6 = passageRepository.save(Passage.builder()
                 .book(book).creator(writer).pageNumber(6).quotedText("6페이지 문장").isSpoiler(false)
                 .normalizedHash("hash-6").build());
+    }
+
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
     }
 
     private Opinion opinion(Passage passage, Long userId, String content, int likeCount) {
@@ -115,18 +123,18 @@ class PassageReadFlowIntegrationTest {
     @DisplayName("읽는 중(READING) 상태의 로그인 사용자는 현재 페이지까지의 대목을 볼 수 있다 (스포일러 포함)")
     void readingUserSeesUpToCurrentPage() throws Exception {
         mockMvc.perform(put("/api/users/me/book-status")
-                        .header("X-Debug-User-Id", readerId)
+                        .header("Authorization", bearerToken(readerId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"bookId\": " + bookId + ", \"status\": \"READING\", \"currentPage\": 6}"))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(get("/api/books/" + bookId + "/passages").header("X-Debug-User-Id", readerId))
+        mockMvc.perform(get("/api/books/" + bookId + "/passages").header("Authorization", bearerToken(readerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.pageNumbers[0]").value(1))
                 .andExpect(jsonPath("$.data.pageNumbers[1]").value(3))
                 .andExpect(jsonPath("$.data.pageNumbers[2]").value(6));
 
-        mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages").header("X-Debug-User-Id", readerId))
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/6/passages").header("Authorization", bearerToken(readerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].passageId").value(page6.getId()))
                 .andExpect(jsonPath("$.data.passages[0].quotedText").value("6페이지 문장"));
@@ -143,12 +151,12 @@ class PassageReadFlowIntegrationTest {
         decoration(another, 10, 15);
 
         mockMvc.perform(put("/api/users/me/book-status")
-                        .header("X-Debug-User-Id", readerId)
+                        .header("Authorization", bearerToken(readerId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"bookId\": " + bookId + ", \"status\": \"READING\", \"currentPage\": 6}"))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages").header("X-Debug-User-Id", readerId))
+        mockMvc.perform(get("/api/books/" + bookId + "/pages/3/passages").header("Authorization", bearerToken(readerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].decorations.length()").value(2))
                 .andExpect(jsonPath("$.data.passages[0].decorations[0].startOffset").value(3))

--- a/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +34,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PassageController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class PassageControllerTest {
 
     @Autowired

--- a/src/test/java/com/nexters/palang/domain/user/application/NicknameGeneratorTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/NicknameGeneratorTest.java
@@ -1,0 +1,29 @@
+package com.nexters.palang.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class NicknameGeneratorTest {
+
+    private final NicknameGenerator nicknameGenerator = new NicknameGenerator();
+
+    @RepeatedTest(20)
+    @DisplayName("기본 닉네임은 형용사와 명사를 이어붙인 형태다")
+    void generateBaseProducesAdjectiveNounCombination() {
+        String base = nicknameGenerator.generateBase();
+
+        assertThat(base).isNotBlank();
+        assertThat(base).doesNotContainAnyWhitespaces();
+    }
+
+    @Test
+    @DisplayName("접미사를 붙이면 기본 닉네임 뒤에 숫자가 그대로 붙는다")
+    void withSuffixAppendsNumberToBase() {
+        String result = nicknameGenerator.withSuffix("고요한책갈피", 7);
+
+        assertThat(result).isEqualTo("고요한책갈피7");
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
@@ -1,0 +1,82 @@
+package com.nexters.palang.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class UserRegistrationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NicknameGenerator nicknameGenerator;
+
+    private UserRegistrationService userRegistrationService;
+
+    @BeforeEach
+    void setUp() {
+        userRegistrationService = new UserRegistrationService(userRepository, nicknameGenerator);
+    }
+
+    @Test
+    @DisplayName("닉네임이 충돌하지 않으면 처음 생성한 닉네임 그대로 저장된다")
+    void registerViaSnsSucceedsOnFirstAttempt() {
+        given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
+        given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-1");
+
+        assertThat(user.getNickname()).isEqualTo("고요한책갈피");
+        assertThat(user.getSnsProvider()).isEqualTo(SnsProvider.KAKAO);
+        assertThat(user.getSnsId()).isEqualTo("sns-1");
+        verify(userRepository, times(1)).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("닉네임이 충돌하면 숫자 접미사를 붙여 재시도한다")
+    void registerViaSnsRetriesWithSuffixOnConflict() {
+        given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
+        given(nicknameGenerator.withSuffix("고요한책갈피", 1)).willReturn("고요한책갈피1");
+        given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피"))))
+                .willThrow(new DataIntegrityViolationException("duplicate"));
+        given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피1"))))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-2");
+
+        assertThat(user.getNickname()).isEqualTo("고요한책갈피1");
+    }
+
+    @Test
+    @DisplayName("100번 재시도까지 모두 충돌하면 닉네임 생성 실패 예외가 발생한다")
+    void registerViaSnsFailsWhenAllAttemptsConflict() {
+        given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
+        given(nicknameGenerator.withSuffix(eq("고요한책갈피"), anyInt()))
+                .willAnswer(invocation -> "고요한책갈피" + invocation.<Integer>getArgument(1));
+        given(userRepository.saveAndFlush(any(User.class)))
+                .willThrow(new DataIntegrityViolationException("duplicate"));
+
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3"))
+                .isInstanceOf(UserException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
@@ -136,4 +136,15 @@ class UserServiceTest {
 
         assertThatThrownBy(() -> userService.withdraw(1L)).isInstanceOf(UserException.class);
     }
+
+    @Test
+    @DisplayName("온보딩 완료를 요청하면 반영된다")
+    void completeOnboardingMarksUserCompleted() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        userService.completeOnboarding(1L);
+
+        assertThat(user.isHasCompletedOnboarding()).isTrue();
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
@@ -55,4 +55,44 @@ class UserTest {
 
         assertThat(user.getBackgroundColor()).isEqualTo("#FFFFFF");
     }
+
+    @Test
+    @DisplayName("가입 직후에는 약관에 동의하지 않은 상태다")
+    void termsAgreedAtIsNullRightAfterSignUp() {
+        User user = user();
+
+        assertThat(user.getTermsAgreedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("약관에 동의하면 동의 시각이 기록된다")
+    void agreeToTermsRecordsTimestamp() {
+        User user = user();
+
+        user.agreeToTerms();
+
+        assertThat(user.getTermsAgreedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 약관에 동의한 사용자가 다시 동의해도 에러 없이 시각만 갱신된다")
+    void agreeToTermsIsIdempotent() {
+        User user = user();
+        user.agreeToTerms();
+        LocalDateTime firstAgreedAt = user.getTermsAgreedAt();
+
+        user.agreeToTerms();
+
+        assertThat(user.getTermsAgreedAt()).isNotNull().isAfterOrEqualTo(firstAgreedAt);
+    }
+
+    @Test
+    @DisplayName("온보딩을 완료하면 완료 상태가 된다")
+    void completeOnboardingMarksCompleted() {
+        User user = user();
+
+        user.completeOnboarding();
+
+        assertThat(user.isHasCompletedOnboarding()).isTrue();
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class UserControllerTest {
 
     @Autowired
@@ -203,6 +205,28 @@ class UserControllerTest {
         mockMvc.perform(delete("/api/users/me"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value("USER_404_1"));
+    }
+
+    @Test
+    @DisplayName("온보딩 완료를 요청하면 완료 상태를 반환한다")
+    void completeOnboarding() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/users/me/onboarding-complete"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasCompletedOnboarding").value(true));
+
+        verify(userService).completeOnboarding(1L);
+    }
+
+    @Test
+    @DisplayName("인증 없이 온보딩 완료를 요청하면 401 에러가 발생한다")
+    void completeOnboardingFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(patch("/api/users/me/onboarding-complete"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/global/security/JwtCurrentUserProviderTest.java
+++ b/src/test/java/com/nexters/palang/global/security/JwtCurrentUserProviderTest.java
@@ -1,0 +1,44 @@
+package com.nexters.palang.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class JwtCurrentUserProviderTest {
+
+    @Test
+    @DisplayName("request attribute에 유저 ID가 있으면 그대로 반환한다")
+    void returnsUserIdFromAttribute() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(JwtAuthenticationFilter.CURRENT_USER_ID_ATTRIBUTE, 1L);
+        JwtCurrentUserProvider provider = new JwtCurrentUserProvider(request);
+
+        assertThat(provider.getCurrentUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("토큰이 만료/유효하지 않아 에러가 채워져 있으면 그 에러로 예외가 발생한다")
+    void throwsAuthExceptionWhenAuthErrorPresent() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE, AuthErrorCode.TOKEN_EXPIRED);
+        JwtCurrentUserProvider provider = new JwtCurrentUserProvider(request);
+
+        assertThatThrownBy(provider::getCurrentUserId)
+                .isInstanceOf(AuthException.class)
+                .extracting(e -> ((AuthException) e).getErrorCode())
+                .isEqualTo(AuthErrorCode.TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("토큰이 아예 없으면 로그인 필요 예외가 발생한다")
+    void throwsLoginRequiredWhenNothingPresent() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        JwtCurrentUserProvider provider = new JwtCurrentUserProvider(request);
+
+        assertThatThrownBy(provider::getCurrentUserId).isInstanceOf(LoginRequiredException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/global/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/nexters/palang/global/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,84 @@
+package com.nexters.palang.global.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.global.security.AuthErrorCode;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET = "test-jwt-secret-key-for-unit-test-01234567890123456789";
+
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET, 3600, 1209600);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("유효한 토큰이 있으면 request attribute와 SecurityContext에 유저 ID가 채워진다")
+    void setsUserIdWhenTokenValid() throws Exception {
+        String token = jwtTokenProvider.createAccessToken(1L);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> { };
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(JwtAuthenticationFilter.CURRENT_USER_ID_ATTRIBUTE)).isEqualTo(1L);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("토큰이 없으면 아무 attribute도 채우지 않고 통과시킨다")
+    void passesThroughWhenNoToken() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> { };
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(JwtAuthenticationFilter.CURRENT_USER_ID_ATTRIBUTE)).isNull();
+        assertThat(request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE)).isNull();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰이면 TOKEN_EXPIRED 에러를 attribute에 남긴다")
+    void marksExpiredTokenError() throws Exception {
+        JwtTokenProvider expiringProvider = new JwtTokenProvider(SECRET, -1, -1);
+        JwtAuthenticationFilter expiringFilter = new JwtAuthenticationFilter(expiringProvider);
+        String expiredToken = expiringProvider.createAccessToken(1L);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + expiredToken);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> { };
+
+        expiringFilter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE))
+                .isEqualTo(AuthErrorCode.TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 토큰이면 INVALID_TOKEN 에러를 attribute에 남긴다")
+    void marksInvalidTokenError() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer not-a-jwt");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (req, res) -> { };
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE))
+                .isEqualTo(AuthErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/test/java/com/nexters/palang/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/nexters/palang/global/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,55 @@
+package com.nexters.palang.global.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "test-jwt-secret-key-for-unit-test-01234567890123456789";
+
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(SECRET, 3600, 1209600);
+
+    @Test
+    @DisplayName("액세스 토큰을 발급하면 같은 유저 ID로 파싱된다")
+    void createAccessTokenRoundTrips() {
+        String token = jwtTokenProvider.createAccessToken(1L);
+
+        assertThat(jwtTokenProvider.getUserId(token)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰을 발급하면 같은 유저 ID로 파싱된다")
+    void createRefreshTokenRoundTrips() {
+        String token = jwtTokenProvider.createRefreshToken(42L);
+
+        assertThat(jwtTokenProvider.getUserId(token)).isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰을 파싱하면 ExpiredJwtException이 발생한다")
+    void getUserIdFailsWhenTokenExpired() {
+        JwtTokenProvider expiringProvider = new JwtTokenProvider(SECRET, -1, -1);
+        String expiredToken = expiringProvider.createAccessToken(1L);
+
+        assertThatThrownBy(() -> expiringProvider.getUserId(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    @DisplayName("형식이 올바르지 않은 토큰을 파싱하면 JwtException이 발생한다")
+    void getUserIdFailsWhenTokenMalformed() {
+        assertThatThrownBy(() -> jwtTokenProvider.getUserId("not-a-jwt"))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 만료 시각은 현재 시각보다 미래다")
+    void refreshTokenExpiryFromNowIsInFuture() {
+        assertThat(jwtTokenProvider.refreshTokenExpiryFromNow()).isAfter(java.time.LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #39

## 🚀 개요
backend_plan.md §4/§5.1/§6 Phase 3 기준으로 카카오 로그인 + JWT 인증을 구현하고, §4.3 임시 인증 스탠드인(`X-Debug-User-Id`)이 기본으로 쓰이던 `CurrentUserProvider`를 실제 JWT 기반 구현체로 교체했습니다.

## 📄 작업 내용
- `POST /api/auth/kakao`: 카카오 액세스 토큰을 `KakaoOAuthClient`(WebClient)로 검증 → snsProvider+snsId로 User 조회, 없으면 `UserRegistrationService`가 `NicknameGenerator`로 닉네임 자동 생성 후 가입 → JWT AccessToken/RefreshToken 발급
- `POST /api/auth/terms`: 약관 동의 기록 (`User.agreeToTerms()`, 재호출해도 멱등)
- `POST /api/auth/refresh`, `POST /api/auth/logout`: 리프레시 토큰 재발급/폐기 (`RefreshToken` 엔티티, DB 테이블로 관리 — Redis 미사용)
- `PATCH /api/users/me/onboarding-complete`: 온보딩 완료 처리
- `global/security/jwt`: `JwtTokenProvider`, `JwtAuthenticationFilter`(OptionalAuthentication — 토큰 없어도 통과, 있으면 유저 정보만 채움), `SecurityConfig`(모든 요청 permitAll, 실제 인가는 서비스 레이어의 `CurrentUserProvider`가 담당)
- `JwtCurrentUserProvider`를 `@Primary`로 등록해 기본 구현체로 교체. `HeaderCurrentUserProvider`(`X-Debug-User-Id`)는 `local` 프로파일 전용으로 유지하되 더 이상 기본으로 선택되지 않음
- `User.termsAgreedAt`을 nullable로 변경(기존엔 가입 시점에 즉시 채워야 했으나, 실제로는 로그인 → 약관 동의가 분리된 플로우라 컬럼 제약과 충돌 — backend_plan.md §3에서 "확정 필요"로 남겨뒀던 부분)
- 기존 Swagger 문서(`UserApi`, `OpinionApi`, `CommentApi`, `BookApi`, `UserBookStatusApi`, `PassageControllerDocs`)의 "X-Debug-User-Id 헤더로 인증" 문구를 "Authorization: Bearer 헤더로 인증"으로 갱신
- Spring Security 도입으로 영향받는 기존 `@WebMvcTest` 슬라이스 7개에 `@AutoConfigureMockMvc(addFilters = false)` 추가
- 기존 통합 테스트(`OpinionWriteFlowIntegrationTest`, `PassageReadFlowIntegrationTest`)가 쓰던 `X-Debug-User-Id` 헤더를 실제 JWT `Authorization` 헤더로 전환

## 📸 스크린샷 / 테스트 결과 (선택)
`./gradlew build` 성공 (271개 테스트 전체 통과)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인 (카카오 개발자 콘솔 테스트 앱 키로 실제 로그인 E2E는 별도 수동 검증 필요 — backend_plan.md §10)

---
## 🔍 리뷰 포인트 (Review Points)
- `User.termsAgreedAt`을 nullable로 바꾸면서 컬럼 제약이 변경됩니다. 이 프로젝트는 아직 Flyway/Liquibase가 없고 prod는 `ddl-auto: validate`라, 배포 전 prod DB에 `ALTER TABLE users MODIFY terms_agreed_at DATETIME NULL`(또는 동등한 마이그레이션)을 수동으로 반영해야 합니다.
- 탈퇴한 계정이 같은 카카오 계정으로 재로그인을 시도하면 `AUTH_403_1`(탈퇴한 계정)로 막았습니다. 재가입을 허용할지, 막을지는 기획 확인이 필요할 수 있습니다.
- 닉네임 생성 재시도(`UserRegistrationService`)는 각 시도를 `REQUIRES_NEW`로 독립 트랜잭션 처리했습니다 — 같은 트랜잭션에서 재시도하면 제약 위반 예외로 영속성 컨텍스트가 오염되는 문제가 있어 이렇게 설계했는데, 이 방식이 맞는지 확인 부탁드립니다.
- `JwtAuthenticationFilter`를 의도적으로 `@Component`로 등록하지 않고 `SecurityConfig`가 직접 `new`로 생성합니다(Filter를 구현한 `@Component`는 `@WebMvcTest`가 자동으로 끌어와서 슬라이스 테스트가 깨지는 문제가 있었습니다). 이 패턴이 괜찮은지 봐주세요.