### PR TITLE
🔧 chore: local/dev/prod 3단계 프로파일 분리

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -2,6 +2,11 @@
 # 사용법: cp deploy/.env.example .env  (프로젝트 루트에 위치, docker compose가 자동으로 읽는다)
 # 절대 실제 값이 채워진 .env를 커밋하지 않는다 (.gitignore에 이미 제외됨).
 
+# ---- Spring 프로파일 ----
+# dev 서버라면 반드시 dev로 설정할 것 (기본값은 prod).
+# local: 개발자 PC, dev: 배포된 개발 서버, prod: 실사용자가 붙는 운영 서버.
+# SPRING_PROFILES_ACTIVE=dev
+
 # ---- MySQL ----
 MYSQL_DATABASE=pallang
 MYSQL_USER=pallang

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     env_file:
       - .env
     environment:
-      SPRING_PROFILES_ACTIVE: prod
+      # dev 서버는 .env에 SPRING_PROFILES_ACTIVE=dev를 넣어서 이 기본값을 덮어쓴다.
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
       DB_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       DB_USERNAME: ${MYSQL_USER}
       DB_PASSWORD: ${MYSQL_PASSWORD}

--- a/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
@@ -8,8 +8,11 @@ import org.springframework.stereotype.Component;
  * 인증(JWT) Phase 착수 전까지 사용하는 임시 인증 스탠드인.
  * X-Debug-User-Id 요청 헤더 값을 그대로 유저 ID로 사용한다.
  * 인증 Phase 착수 시 JwtCurrentUserProvider로 구현체만 교체한다.
+ * local(개발자 PC)과 dev(배포된 개발 서버)에서만 활성화한다 — 검증 없이 헤더값을
+ * 그대로 신뢰하므로, 실제 사용자가 붙는 prod에서는 반드시 실제 인증 구현으로
+ * 교체된 뒤에만 배포해야 한다.
  */
-@Profile("local")
+@Profile({"local", "dev"})
 @Component
 public class HeaderCurrentUserProvider implements CurrentUserProvider {
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -21,13 +21,12 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      # 운영에서는 스키마를 자동 변경하지 않는다. 마이그레이션 도구(Flyway/Liquibase) 도입 전까지는
-      # 스키마를 미리 반영해두고 검증만 수행한다. 스키마가 자주 바뀌는 환경은 application-dev.yaml을 쓸 것.
-      ddl-auto: validate
-    show-sql: false
+      # dev는 스키마가 자주 바뀌는 실험 환경이라 자동 반영한다 (prod는 validate 유지).
+      ddl-auto: update
+    show-sql: true
     properties:
       hibernate:
-        format_sql: false
+        format_sql: true
         jdbc:
           time_zone: Asia/Seoul
     open-in-view: false
@@ -58,4 +57,4 @@ aladin:
 logging:
   level:
     root: INFO
-    com.nexters.palang: INFO
+    com.nexters.palang: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (실제 dev 서버 배포 중 발견한 버그 수정 — 별도 트래킹 이슈 없음)

## 🚀 개요
배포된 모든 서버가 `prod` 프로파일을 공유하고 있어서 dev 서버가 아예 못 뜨던 문제를 해결한다. `local`/`dev`/`prod` 3단계로 프로파일을 분리해, dev 서버 전용 설정을 갖게 한다.

## 📄 작업 내용
- 배포된 모든 서버가 `prod` 프로파일을 공유하다 보니 두 가지 문제가 있었음:
  1. `HeaderCurrentUserProvider`가 `@Profile("local")`이라 dev 서버에서 `CurrentUserProvider` 빈을 찾지 못해 컨트롤러 생성이 실패
  2. dev 서버도 prod와 같은 `ddl-auto: validate`를 써서 스키마가 비어있는 새 환경마다 부팅이 실패
- `application-dev.yaml`을 추가해 dev 서버는 `ddl-auto: update`로 스키마를 자동 생성하게 하고, `HeaderCurrentUserProvider`를 `local`/`dev` 양쪽에서 활성화하도록 프로파일을 넓힘 (`prod`는 제외 유지 — 실사용자가 붙는 운영 서버에 검증 없는 헤더 인증이 살아있으면 안 되므로, 실제 JWT 인증 전까지는 `prod`에서 이 컨트롤러들이 못 뜨는 게 의도된 안전장치)
- `application-prod.yaml`은 원래 의도대로 `ddl-auto: validate` 유지
- `docker-compose.yml`의 `SPRING_PROFILES_ACTIVE`를 하드코딩(`prod`)에서 `.env`로 오버라이드 가능하게 변경 (기본값은 그대로 `prod`) — dev 서버는 `.env`에 `SPRING_PROFILES_ACTIVE=dev` 한 줄만 추가하면 됨
- `deploy/.env.example`에 이 옵션 문서화

## 📸 스크린샷 / 테스트 결과 (선택)
- 실제 dev 서버(`ubuntu@pallang-backend`)에서 `prod` 프로파일로 기동 시 아래 두 에러를 순서대로 재현:
  - `org.hibernate.tool.schema.spi.SchemaManagementException: Schema validation: missing table [books]`
  - `No qualifying bean of type 'com.nexters.palang.global.security.CurrentUserProvider' available` (BookController 등 6개 컨트롤러 전부 영향)
- `docker compose config`로 `SPRING_PROFILES_ACTIVE` 미지정 시 `prod`, 지정 시 override되는 것 확인:
  ```bash
  docker compose --env-file deploy/.env.example config | grep SPRING_PROFILES_ACTIVE
  #   SPRING_PROFILES_ACTIVE: prod
  SPRING_PROFILES_ACTIVE=dev docker compose --env-file deploy/.env.example config | grep SPRING_PROFILES_ACTIVE
  #   SPRING_PROFILES_ACTIVE: dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 개발 환경용 Spring 프로파일 설정을 추가했습니다.
  * 개발 환경에서 MySQL, Redis, 파일 업로드, OCR, 외부 API 및 로깅 설정을 사용할 수 있습니다.
  * 환경 변수로 활성 프로파일과 주요 연결 정보를 지정할 수 있습니다.
  * 개발 서버에서도 개발용 사용자 헤더 인증을 사용할 수 있습니다.

* **문서**
  * 개발·운영 프로파일의 사용 기준과 운영 환경 스키마 변경 주의사항을 보완했습니다.
  * 운영 환경에서는 실제 인증 방식을 사용해야 한다는 안내를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->