### PR TITLE
🐛 fix: CD가 IMAGE_TAG를 .env에도 영구 반영하도록 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,12 @@ jobs:
             cat > .env <<'PALANG_ENV_EOF'
             ${{ secrets.APP_ENV_FILE }}
             PALANG_ENV_EOF
+            # IMAGE_TAG를 .env에도 남겨둔다. docker compose는 이 파일을 변수 치환에
+            # 자동으로 쓰므로, 나중에 사람이 export 없이 수동으로 docker compose 명령을
+            # 돌려도 항상 "마지막으로 CD가 배포한 태그"를 쓰게 되어 존재하지 않는
+            # latest 태그로 조용히 빠지는 사고를 막는다.
+            sed -i '/^IMAGE_TAG=/d' .env
+            echo "IMAGE_TAG=${IMAGE_TAG}" >> .env
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans
@@ -114,6 +120,9 @@ jobs:
             cat > .env <<'PALANG_ENV_EOF'
             ${{ secrets.APP_ENV_FILE }}
             PALANG_ENV_EOF
+            # IMAGE_TAG를 .env에도 남겨둔다 (deploy-dev와 동일한 이유).
+            sed -i '/^IMAGE_TAG=/d' .env
+            echo "IMAGE_TAG=${IMAGE_TAG}" >> .env
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose pull
             docker compose up -d --remove-orphans

--- a/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
+++ b/src/main/java/com/nexters/palang/global/security/HeaderCurrentUserProvider.java
@@ -11,8 +11,11 @@ import org.springframework.stereotype.Component;
  * local(개발자 PC)과 dev(배포된 개발 서버)에서만 활성화한다 — 검증 없이 헤더값을
  * 그대로 신뢰하므로, 실제 사용자가 붙는 prod에서는 반드시 실제 인증 구현으로
  * 교체된 뒤에만 배포해야 한다.
+ * "local"/"dev" 화이트리스트가 아니라 "!prod" 블랙리스트로 표현한다 — 화이트리스트면
+ * SPRING_PROFILES_ACTIVE=prod,dev 처럼 prod와 동시에 켜졌을 때도 이 빈이 활성화돼
+ * 검증 없는 헤더 인증이 실제 운영 환경에 뚫릴 수 있다.
  */
-@Profile({"local", "dev"})
+@Profile("!prod")
 @Component
 public class HeaderCurrentUserProvider implements CurrentUserProvider {
 


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (CodeRabbit 리뷰 반영 + 실제 dev 서버 배포 중 발견한 버그 수정 — 별도 트래킹 이슈 없음)

## 🚀 개요
CodeRabbit이 지적한 인증 우회 가능성을 수정하고, 실제 dev 서버 배포 중 반복적으로 겪었던 "수동으로 `docker compose` 실행 시 존재하지 않는 `latest` 태그로 빠지는" 문제의 근본 원인을 고친다.

## 📄 작업 내용
- `HeaderCurrentUserProvider`의 `@Profile({"local", "dev"})` 화이트리스트를 `@Profile("!prod")` 블랙리스트로 변경
  - 화이트리스트 방식은 `SPRING_PROFILES_ACTIVE=prod,dev`처럼 prod와 다른 프로파일이 동시에 켜지는 경우를 막지 못해, 검증 없는 헤더 기반 인증(`X-Debug-User-Id`)이 운영 환경에서 활성화될 여지가 있었음
  - `!prod`로 바꿔 prod가 활성 프로파일에 하나라도 포함되면 무조건 이 빈이 비활성화되도록 함
- `cd.yml`의 배포 스크립트가 `IMAGE_TAG`를 SSH 세션 안에서만 `export`하고 서버의 `.env`에는 남기지 않던 문제 수정
  - 이 때문에 CD 배포 자체는 성공해도, 이후 사람이 `export` 없이 수동으로 `docker compose up -d`/`pull`을 실행하면 존재하지 않는 `latest` 태그로 조용히 빠지면서 스테일 이미지로 재시작을 반복하는 사고가 실제로 여러 번 발생했음
  - 배포마다 `.env`에 `IMAGE_TAG`를 갱신해서 남기도록 수정해, 수동 개입 시에도 항상 마지막으로 CD가 배포한 태그를 기본으로 쓰게 함 (`deploy-dev`, `deploy-prod` 둘 다 동일하게 적용)

## 📸 스크린샷 / 테스트 결과 (선택)
- 실제 dev 서버(`ubuntu@pallang-backend`)에서 `IMAGE_TAG` 없이 `docker compose up -d`를 실행하면 `ghcr.io/nexters/pallang-server:latest`(존재하지 않는 태그)로 빠져 `Restarting` 상태가 반복되는 것을 여러 차례 재현·확인
- `./gradlew compileJava` 통과 확인
- workflow YAML 문법 검증 완료
- 이 PR 반영 후 실제 CD 재배포로 `.env`에 `IMAGE_TAG`가 자동으로 남는지는 머지 후 확인 예정

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요? (해당 없음 — 어노테이션/YAML 설정 변경)
- [ ] 테스트 통과 확인 (`./gradlew test`와는 무관한 변경이라 별도로 다시 돌리진 않음 — compileJava만 확인)
- [ ] 서버 실행 확인 (머지 후 CD 재배포로 `.env`에 `IMAGE_TAG`가 정상적으로 남는지 확인 예정)
- [ ] API 동작 확인 (위와 동일 — 실제 dev 서버에서 재확인 필요)