### PR TITLE
fix: OpinionLikeIntegrationTest를 JWT Authorization 헤더로 전환

### DIFF
--- a/src/test/java/com/nexters/palang/domain/opinion/OpinionLikeIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/OpinionLikeIntegrationTest.java
@@ -14,6 +14,7 @@ import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,6 +47,9 @@ class OpinionLikeIntegrationTest {
     @Autowired
     private OpinionRepository opinionRepository;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     private Long opinionId;
     private Long likerId;
     private Long anotherLikerId;
@@ -74,11 +78,15 @@ class OpinionLikeIntegrationTest {
         anotherLikerId = anotherLiker.getId();
     }
 
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
     @Test
     @DisplayName("좋아요를 누르면 likeCount가 1 증가하고, 다시 누르면 취소되며 0으로 돌아온다")
     void toggleLikeSyncsLikeCount() throws Exception {
         mockMvc.perform(post("/api/opinions/{opinionId}/like", opinionId)
-                        .header("X-Debug-User-Id", likerId))
+                        .header("Authorization", bearerToken(likerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.liked").value(true))
                 .andExpect(jsonPath("$.data.likeCount").value(1));
@@ -86,7 +94,7 @@ class OpinionLikeIntegrationTest {
         assertThat(opinionRepository.findById(opinionId).orElseThrow().getLikeCount()).isEqualTo(1);
 
         mockMvc.perform(post("/api/opinions/{opinionId}/like", opinionId)
-                        .header("X-Debug-User-Id", likerId))
+                        .header("Authorization", bearerToken(likerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.liked").value(false))
                 .andExpect(jsonPath("$.data.likeCount").value(0));
@@ -98,12 +106,12 @@ class OpinionLikeIntegrationTest {
     @DisplayName("서로 다른 두 사용자가 좋아요를 누르면 likeCount가 각각 반영되어 2가 된다")
     void multipleUsersLikeIncrementsLikeCountIndependently() throws Exception {
         mockMvc.perform(post("/api/opinions/{opinionId}/like", opinionId)
-                        .header("X-Debug-User-Id", likerId))
+                        .header("Authorization", bearerToken(likerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.likeCount").value(1));
 
         mockMvc.perform(post("/api/opinions/{opinionId}/like", opinionId)
-                        .header("X-Debug-User-Id", anotherLikerId))
+                        .header("Authorization", bearerToken(anotherLikerId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.likeCount").value(2));
 
@@ -114,7 +122,7 @@ class OpinionLikeIntegrationTest {
     @DisplayName("존재하지 않는 흔적에 좋아요를 시도하면 404 에러가 발생한다")
     void toggleLikeFailsWhenOpinionNotFound() throws Exception {
         mockMvc.perform(post("/api/opinions/{opinionId}/like", 999999L)
-                        .header("X-Debug-User-Id", likerId))
+                        .header("Authorization", bearerToken(likerId)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value("OPINION_404_1"));
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #46

## 🚀 개요
PR #41 이후 `develop` CI(`build-and-test`)가 실패하고 있어서 고칩니다.

## 📄 작업 내용
- `OpinionLikeIntegrationTest`에서 인증이 필요한 요청에 쓰던 `X-Debug-User-Id` 헤더를 `Authorization: Bearer ...`(JWT)로 교체
- `JwtTokenProvider`를 주입받아 `bearerToken(userId)` 헬퍼로 액세스 토큰 발급 — `OpinionWriteFlowIntegrationTest` 등 다른 통합 테스트와 동일한 패턴
- 인증 없이 요청해 401을 기대하는 `toggleLikeFailsWhenUnauthenticated`는 그대로 유지

## 🚨 원인
PR #41에서 `JwtCurrentUserProvider`가 `@Primary`로 등록되며 기본 인증 수단이 JWT로 바뀌었는데, 이 테스트만 예전 `X-Debug-User-Id` 방식으로 남아있어서 실제로는 인증이 안 된 채 요청이 가고, 200/404를 기대한 자리에 401(`AUTH_401_1`)이 발생했습니다.
- 실패 로그: https://github.com/Nexters/pallang-server/actions/runs/30204509559

## 📸 테스트 결과
- `OpinionLikeIntegrationTest` 단독 실행 통과
- 전체 `./gradlew test` 283개 중 이 파일 관련 테스트는 전부 통과 (별개로 `NoticeRepositoryTest`에 기존부터 있던 flaky 실패가 하나 있으나 이번 변경과 무관)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 테스트 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 좋아요 API 테스트가 디버그 사용자 헤더 대신 JWT 기반 인증 방식으로 검증되도록 변경되었습니다.
  * 좋아요 추가·취소, 여러 사용자의 동시 좋아요, 존재하지 않는 대상에 대한 실패 처리가 실제 인증 흐름에 맞게 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->