### PR TITLE
fix: Swagger 명세 스펙 위반 및 응답 필드 required 누락 수정

### DIFF
--- a/.claude/skills/swagger-docs/SKILL.md
+++ b/.claude/skills/swagger-docs/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: swagger-docs
+description: Use whenever writing or reviewing Swagger/OpenAPI annotations (@Schema, SecurityScheme) on request/response DTOs in this repository, or when a frontend report says a field's required/optional-ness or a security scheme doesn't match reality. Captures springdoc-openapi behavior discovered while fixing issue #48 that isn't obvious from the springdoc docs.
+---
+
+# Swagger/OpenAPI 작성 시 주의사항
+
+이슈 #48(FE의 orval 코드젠 실패, 스펙 위반 리포트)을 고치면서 확인된, springdoc-openapi 기본 동작 중 직관과 다른 부분을 정리합니다.
+
+## 1. springdoc은 primitive 타입도 자동으로 required 처리하지 않는다
+
+**틀리기 쉬운 가정:** "`int`/`long`/`boolean`은 null이 될 수 없으니 springdoc이 알아서 required로 표시해주겠지."
+
+**실제로는 아니다.** `int pageCount`, `long opinionCount`, `boolean isDeleted` 같은 필드도 `@Schema`에 `requiredMode`를 명시하지 않으면 생성된 스펙의 `required` 배열에서 빠진다. 이 프로젝트에서 실제로 `PageInfo`, `LoginResponse`, `OpinionResponse` 등 거의 모든 응답 DTO가 이 문제를 겪고 있었다.
+
+**결론: 응답 DTO에서 백엔드가 항상 값을 채워주는 필드는 타입(primitive/객체 불문)에 관계없이 전부 명시적으로 표시한다.**
+
+```java
+// 항상 채워지는 필드
+@Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+@Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
+@Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isDeleted,
+
+// DB 컬럼이 nullable이거나, 비즈니스 로직상 실제로 null/미제공일 수 있는 필드
+@Schema(example = "...", nullable = true) String profileImageUrl,
+```
+
+리스트 필드(`List<T>`)나 중첩 객체 필드(`PageInfo` 등)도 항상 채워진다면 동일하게 `requiredMode = REQUIRED`를 붙인다. `@ArraySchema`를 쓰는 원시 타입 리스트(`List<Integer>` 등)는 `arraySchema` 속성에 붙여야 한다:
+
+```java
+@ArraySchema(schema = @Schema(example = "3"), arraySchema = @Schema(requiredMode = Schema.RequiredMode.REQUIRED))
+List<Integer> pageNumbers,
+```
+
+## 2. 응답 DTO를 전수조사할 때 파일 경로 패턴을 하나로 단정하지 않는다
+
+대부분의 응답 DTO는 `domain/**/presentation/dto/*Response.java`에 있지만, 예외가 있다(예: `domain/passage/presentation/response/PassageResponse.java` — 내부에 여러 record가 중첩된 형태). 경로/네이밍 패턴 하나만 보고 전수조사했다고 판단하지 말고, 다음처럼 실제 컨트롤러가 반환하는 타입을 기준으로 넓게 검색한다:
+
+```bash
+grep -rln "@Schema" src/main/java --include="*.java" | grep -i "presentation"
+```
+
+## 3. SecurityScheme: `type: http`에는 `.name()`을 붙이지 않는다
+
+`name` 속성은 OpenAPI 3.0 스펙상 `type: apiKey`에서만 허용된다. JWT Bearer 토큰처럼 `type: http` + `scheme: bearer`를 쓰는 경우 `.name(...)`을 호출하면 스펙 위반이 되어 프론트 코드젠 도구(orval 등)의 스펙 검증이 실패한다.
+
+```java
+// 올바른 예 (SwaggerConfig)
+new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("JWT");
+        // .name(...) 금지 — apiKey 타입 전용
+```
+
+## 4. 가정하지 말고 `/v3/api-docs`로 직접 검증한다
+
+springdoc의 기본 동작(무엇을 자동으로 required 처리하는지, nullable을 어떻게 반영하는지 등)은 문서만 보고 단정하면 틀리기 쉽다. 변경 후에는 로컬로 앱을 띄워 실제 생성된 스펙을 확인한다:
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local' &
+curl -s http://localhost:8080/v3/api-docs > api-docs.json
+# 이후 node/jq 등으로 components.schemas.<이름>.required, components.securitySchemes 확인
+```

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
@@ -3,8 +3,8 @@ package com.nexters.palang.domain.auth.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LoginResponse(
-        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access") String accessToken,
-        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh") String refreshToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access", requiredMode = Schema.RequiredMode.REQUIRED) String accessToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh", requiredMode = Schema.RequiredMode.REQUIRED) String refreshToken,
         @Schema(example = "true") boolean isNewUser,
         @Schema(example = "false") boolean termsAgreed,
         @Schema(example = "false") boolean hasCompletedOnboarding

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/LoginResponse.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record LoginResponse(
         @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access", requiredMode = Schema.RequiredMode.REQUIRED) String accessToken,
         @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh", requiredMode = Schema.RequiredMode.REQUIRED) String refreshToken,
-        @Schema(example = "true") boolean isNewUser,
-        @Schema(example = "false") boolean termsAgreed,
-        @Schema(example = "false") boolean hasCompletedOnboarding
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean isNewUser,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean termsAgreed,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasCompletedOnboarding
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TermsAgreementResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TermsAgreementResponse.java
@@ -3,6 +3,6 @@ package com.nexters.palang.domain.auth.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TermsAgreementResponse(
-        @Schema(example = "true") boolean termsAgreed
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean termsAgreed
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TokenResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/TokenResponse.java
@@ -3,7 +3,7 @@ package com.nexters.palang.domain.auth.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TokenResponse(
-        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access") String accessToken,
-        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh") String refreshToken
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.access", requiredMode = Schema.RequiredMode.REQUIRED) String accessToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.refresh", requiredMode = Schema.RequiredMode.REQUIRED) String refreshToken
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/application/BookMapper.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookMapper.java
@@ -27,8 +27,7 @@ public final class BookMapper {
 
     public static ExternalBookResponse toExternalResponse(ExternalBookResult result) {
         return new ExternalBookResponse(
-                result.title(), result.author(), result.publisher(),
-                result.pageCount(), result.isbn(), result.coverImageUrl());
+                result.title(), result.author(), result.publisher(), result.isbn(), result.coverImageUrl());
     }
 
     public static ExternalBookListResponse toExternalListResponse(Page<ExternalBookResult> results) {

--- a/src/main/java/com/nexters/palang/domain/book/application/ExternalBookResult.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/ExternalBookResult.java
@@ -4,7 +4,6 @@ public record ExternalBookResult(
         String title,
         String author,
         String publisher,
-        Integer pageCount,
         String isbn,
         String coverImageUrl
 ) {

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
@@ -27,7 +27,7 @@ public class AladinBookApiClient {
     }
 
     // 결과마다 ItemLookUp을 추가 호출해 페이지수를 채우던 방식은 검색 1회당 응답이 수 초씩 걸려 제거했다.
-    // pageCount는 항상 null로 내려가며, 필요하면 도서 상세 조회 시점에 별도로 채우는 것을 후속 과제로 검토한다.
+    // pageCount는 검색 응답에서 아예 제공하지 않으며, 필요하면 도서 상세 조회 시점에 별도로 채우는 것을 후속 과제로 검토한다.
     public Page<ExternalBookResult> search(String keyword, Pageable pageable) {
         // 알라딘 start는 1부터 시작하는 인덱스
         int start = (int) pageable.getOffset() + 1;
@@ -64,6 +64,6 @@ public class AladinBookApiClient {
     }
 
     private ExternalBookResult toExternalBookResult(AladinItem item) {
-        return new ExternalBookResult(item.title(), item.author(), item.publisher(), null, item.isbn13(), item.cover());
+        return new ExternalBookResult(item.title(), item.author(), item.publisher(), item.isbn13(), item.cover());
     }
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -21,7 +21,8 @@ import org.springframework.http.ResponseEntity;
 public interface BookApi {
 
     @Operation(summary = "도서 외부 검색",
-            description = "알라딘 Open API로 도서를 검색합니다. 응답 속도를 위해 pageCount는 채우지 않으며 항상 null입니다.")
+            description = "알라딘 Open API로 도서를 검색합니다. 응답 속도를 위해 pageCount는 내려주지 않으며, "
+                    + "등록 시 사용자가 직접 입력합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),
             @ApiResponse(responseCode = "400", description = "keyword 누락, page/size 형식 오류(COMMON_400_1) "

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record BookActivityListResponse(List<BookActivityResponse> books, PageInfo pageInfo) {
+public record BookActivityListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookActivityResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
@@ -3,10 +3,10 @@ package com.nexters.palang.domain.book.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record BookActivityResponse(
-        @Schema(example = "1") Long bookId,
-        @Schema(example = "채식주의자") String title,
-        @Schema(example = "한강") String author,
-        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String coverImageUrl,
         @Schema(example = "12") long passageCount,
         @Schema(example = "34") long opinionCount
 ) {

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookActivityResponse.java
@@ -7,7 +7,7 @@ public record BookActivityResponse(
         @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String title,
         @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String coverImageUrl,
-        @Schema(example = "12") long passageCount,
-        @Schema(example = "34") long opinionCount
+        @Schema(example = "12", requiredMode = Schema.RequiredMode.REQUIRED) long passageCount,
+        @Schema(example = "34", requiredMode = Schema.RequiredMode.REQUIRED) long opinionCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record BookListResponse(List<BookResponse> books, PageInfo pageInfo) {
+public record BookListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
@@ -4,13 +4,13 @@ import com.nexters.palang.domain.book.domain.BookSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record BookResponse(
-        @Schema(example = "1") Long bookId,
-        @Schema(example = "채식주의자") String title,
-        @Schema(example = "한강") String author,
-        @Schema(example = "창비") String publisher,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
+        @Schema(example = "창비", requiredMode = Schema.RequiredMode.REQUIRED) String publisher,
         @Schema(example = "268") int pageCount,
-        @Schema(example = "9788936434120") String isbn,
-        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl,
-        @Schema(example = "API") BookSource source
+        @Schema(example = "9788936434120", nullable = true) String isbn,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String coverImageUrl,
+        @Schema(example = "API", requiredMode = Schema.RequiredMode.REQUIRED) BookSource source
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookResponse.java
@@ -8,7 +8,7 @@ public record BookResponse(
         @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String title,
         @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
         @Schema(example = "창비", requiredMode = Schema.RequiredMode.REQUIRED) String publisher,
-        @Schema(example = "268") int pageCount,
+        @Schema(example = "268", requiredMode = Schema.RequiredMode.REQUIRED) int pageCount,
         @Schema(example = "9788936434120", nullable = true) String isbn,
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String coverImageUrl,
         @Schema(example = "API", requiredMode = Schema.RequiredMode.REQUIRED) BookSource source

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.book.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record ExternalBookListResponse(List<ExternalBookResponse> books, PageInfo pageInfo) {
+public record ExternalBookListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<ExternalBookResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/ExternalBookResponse.java
@@ -6,7 +6,6 @@ public record ExternalBookResponse(
         @Schema(example = "채식주의자") String title,
         @Schema(example = "한강") String author,
         @Schema(example = "창비") String publisher,
-        @Schema(description = "응답 속도를 위해 채우지 않으며 항상 null입니다.", nullable = true) Integer pageCount,
         @Schema(example = "9788936434120") String isbn,
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl
 ) {

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/UserBookStatusResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/UserBookStatusResponse.java
@@ -5,9 +5,9 @@ import com.nexters.palang.domain.book.domain.UserBookStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UserBookStatusResponse(
-        @Schema(example = "1") Long bookId,
-        @Schema(example = "READING") ReadingStatus status,
-        @Schema(example = "87") Integer currentPage
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "READING", requiredMode = Schema.RequiredMode.REQUIRED) ReadingStatus status,
+        @Schema(example = "87", nullable = true) Integer currentPage
 ) {
 
     public static UserBookStatusResponse from(UserBookStatus userBookStatus) {

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record CommentListResponse(List<CommentResponse> comments, PageInfo pageInfo) {
+public record CommentListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CommentResponse> comments,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
@@ -9,7 +9,7 @@ public record CommentResponse(
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
         @Schema(example = "저도 같은 생각이에요!", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "false") boolean isDeleted,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isDeleted,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/CommentResponse.java
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record CommentResponse(
-        @Schema(example = "1") Long commentId,
-        @Schema(example = "7") Long userId,
-        @Schema(example = "책읽는고양이") String nickname,
-        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
-        @Schema(example = "저도 같은 생각이에요!") String content,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long commentId,
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
+        @Schema(example = "저도 같은 생각이에요!", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "false") boolean isDeleted,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime updatedAt
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.comment.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record RootCommentListResponse(List<RootCommentResponse> comments, PageInfo pageInfo) {
+public record RootCommentListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<RootCommentResponse> comments,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
@@ -10,11 +10,11 @@ public record RootCommentResponse(
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
         @Schema(example = "저도 같은 생각이에요!", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "false") boolean isDeleted,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isDeleted,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime updatedAt,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CommentResponse> replies,
-        @Schema(example = "8") int replyCount,
-        @Schema(example = "true") boolean hasMoreReplies
+        @Schema(example = "8", requiredMode = Schema.RequiredMode.REQUIRED) int replyCount,
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasMoreReplies
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/dto/RootCommentResponse.java
@@ -5,15 +5,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record RootCommentResponse(
-        @Schema(example = "1") Long commentId,
-        @Schema(example = "7") Long userId,
-        @Schema(example = "책읽는고양이") String nickname,
-        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
-        @Schema(example = "저도 같은 생각이에요!") String content,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long commentId,
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
+        @Schema(example = "저도 같은 생각이에요!", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "false") boolean isDeleted,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime updatedAt,
-        List<CommentResponse> replies,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime updatedAt,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<CommentResponse> replies,
         @Schema(example = "8") int replyCount,
         @Schema(example = "true") boolean hasMoreReplies
 ) {

--- a/src/main/java/com/nexters/palang/domain/notice/presentation/dto/NoticeListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/notice/presentation/dto/NoticeListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.notice.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record NoticeListResponse(List<NoticeResponse> notices, PageInfo pageInfo) {
+public record NoticeListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<NoticeResponse> notices,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/notice/presentation/dto/NoticeResponse.java
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record NoticeResponse(
-        @Schema(example = "1") Long noticeId,
-        @Schema(example = "서비스 업데이트 안내") String title,
-        @Schema(example = "이용에 참고 부탁드립니다. 자세한 내용은 아래를 확인해주세요.") String content,
-        @Schema(example = "2026-07-20T10:15:30") LocalDateTime createdAt
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long noticeId,
+        @Schema(example = "서비스 업데이트 안내", requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(example = "이용에 참고 부탁드립니다. 자세한 내용은 아래를 확인해주세요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
+        @Schema(example = "2026-07-20T10:15:30", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
@@ -8,14 +8,14 @@ import java.util.List;
 
 // 흔적 상세(FR-OPINION-05): 해당 흔적 작성자가 기록한 꾸밈을 그대로 보여준다 (병합된 3개가 아니라 이 Opinion 자신의 전부).
 public record OpinionDetailResponse(
-        @Schema(example = "1") Long opinionId,
-        @Schema(example = "1") Long passageId,
-        @Schema(example = "7") Long userId,
-        @Schema(example = "책읽는고양이") String nickname,
-        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "5") int likeCount,
-        List<DecorationResponse> decorations,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<DecorationResponse> decorations,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
     public static OpinionDetailResponse from(Opinion opinion) {
         List<DecorationResponse> decorations = opinion.getDecorations().stream()

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionDetailResponse.java
@@ -13,7 +13,7 @@ public record OpinionDetailResponse(
         @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "5") int likeCount,
+        @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<DecorationResponse> decorations,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionLikeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionLikeResponse.java
@@ -4,7 +4,7 @@ import com.nexters.palang.domain.opinion.application.OpinionLikeResult;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record OpinionLikeResponse(
-        @Schema(example = "1") Long opinionId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
         @Schema(example = "true") boolean liked,
         @Schema(example = "42") int likeCount
 ) {

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionLikeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionLikeResponse.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record OpinionLikeResponse(
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
-        @Schema(example = "true") boolean liked,
-        @Schema(example = "42") int likeCount
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean liked,
+        @Schema(example = "42", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount
 ) {
 
     public static OpinionLikeResponse from(OpinionLikeResult result) {

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionListResponse.java
@@ -2,10 +2,14 @@ package com.nexters.palang.domain.opinion.presentation.dto;
 
 import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
-public record OpinionListResponse(List<OpinionSummaryResponse> opinions, PageInfo pageInfo) {
+public record OpinionListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<OpinionSummaryResponse> opinions,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
     public static OpinionListResponse from(Page<OpinionSummaryProjection> page) {
         List<OpinionSummaryResponse> opinions = page.getContent().stream()
                 .map(OpinionSummaryResponse::from)

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 public record OpinionResponse(
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
-        @Schema(example = "false") boolean merged,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean merged,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<DecorationResponse> decorations,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
@@ -32,8 +32,8 @@ public record OpinionResponse(
 
     public record DecorationResponse(
             @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long decorationId,
-            @Schema(example = "3") int startOffset,
-            @Schema(example = "12") int endOffset,
+            @Schema(example = "3", requiredMode = Schema.RequiredMode.REQUIRED) int startOffset,
+            @Schema(example = "12", requiredMode = Schema.RequiredMode.REQUIRED) int endOffset,
             @Schema(example = "HIGHLIGHT", requiredMode = Schema.RequiredMode.REQUIRED) EffectType effectType,
             @Schema(example = "#FFE08A", requiredMode = Schema.RequiredMode.REQUIRED) String color
     ) {

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionResponse.java
@@ -8,12 +8,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record OpinionResponse(
-        @Schema(example = "1") Long opinionId,
-        @Schema(example = "1") Long passageId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "false") boolean merged,
-        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
-        List<DecorationResponse> decorations,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<DecorationResponse> decorations,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
 
     public static OpinionResponse from(Opinion opinion, boolean merged) {
@@ -31,11 +31,11 @@ public record OpinionResponse(
     }
 
     public record DecorationResponse(
-            @Schema(example = "1") Long decorationId,
+            @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long decorationId,
             @Schema(example = "3") int startOffset,
             @Schema(example = "12") int endOffset,
-            @Schema(example = "HIGHLIGHT") EffectType effectType,
-            @Schema(example = "#FFE08A") String color
+            @Schema(example = "HIGHLIGHT", requiredMode = Schema.RequiredMode.REQUIRED) EffectType effectType,
+            @Schema(example = "#FFE08A", requiredMode = Schema.RequiredMode.REQUIRED) String color
     ) {
         public static DecorationResponse from(Decoration decoration) {
             return new DecorationResponse(

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record OpinionSummaryResponse(
-        @Schema(example = "1") Long opinionId,
-        @Schema(example = "7") Long userId,
-        @Schema(example = "책읽는고양이") String nickname,
-        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "5") int likeCount,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
     public static OpinionSummaryResponse from(OpinionSummaryProjection projection) {
         return new OpinionSummaryResponse(

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
@@ -9,7 +9,7 @@ public record OpinionSummaryResponse(
         @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "5") int likeCount,
+        @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
     public static OpinionSummaryResponse from(OpinionSummaryProjection projection) {

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -14,7 +14,9 @@ import org.springframework.data.domain.Page;
 
 public class PassageResponse {
 
-    public record SimilarCandidates(List<SimilarCandidate> passages) {
+    public record SimilarCandidates(
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<SimilarCandidate> passages
+    ) {
         public static SimilarCandidates from(List<SimilarPassageProjection> projections) {
             List<SimilarCandidate> candidates = projections.stream()
                     .map(SimilarCandidate::from)
@@ -25,8 +27,9 @@ public class PassageResponse {
 
     // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 발췌된 페이지 번호 목록.
     public record PageNumbers(
-            @ArraySchema(schema = @Schema(example = "3")) List<Integer> pageNumbers,
-            PageInfo pageInfo
+            @ArraySchema(schema = @Schema(example = "3"), arraySchema = @Schema(requiredMode = Schema.RequiredMode.REQUIRED))
+            List<Integer> pageNumbers,
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
     ) {
         public static PageNumbers from(Page<Integer> page) {
             return new PageNumbers(page.getContent(), PageInfo.from(page));
@@ -34,7 +37,9 @@ public class PassageResponse {
     }
 
     // 대목 전환(FR-VIEW-03 2-b) + 꾸밈 병합 결과(FR-VIEW-03 꾸밈 병합 표시).
-    public record PassagesByPage(List<Detail> passages) {
+    public record PassagesByPage(
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<Detail> passages
+    ) {
         public static PassagesByPage from(List<Passage> passages, Map<Long, List<DecorationMergeCandidate>> mergedByPassageId) {
             List<Detail> details = passages.stream()
                     .map(passage -> Detail.from(passage, mergedByPassageId.getOrDefault(passage.getId(), List.of())))
@@ -46,11 +51,11 @@ public class PassageResponse {
         // 블러 처리 + [버튼] 눌러야 확인 가능한 화면(FR-VIEW-03 스포일러 처리)은 즉시 반응해야 하는 순수 UI 동작이라
         // 프론트가 isSpoiler 플래그만 보고 클라이언트에서 처리한다 (서버 왕복 없이 버튼 클릭 즉시 확인 가능).
         public record Detail(
-                @Schema(example = "1") Long passageId,
-                @Schema(example = "87") int pageNumber,
-                @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
-                @Schema(example = "false") boolean isSpoiler,
-                List<DecorationResponse> decorations
+                @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+                @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
+                @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
+                @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isSpoiler,
+                @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<DecorationResponse> decorations
         ) {
             public static Detail from(Passage passage, List<DecorationMergeCandidate> merged) {
                 List<DecorationResponse> decorations = merged.stream()
@@ -65,10 +70,10 @@ public class PassageResponse {
     }
 
     public record SimilarCandidate(
-            @Schema(example = "1") Long passageId,
-            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
-            @Schema(example = "87") int pageNumber,
-            @Schema(example = "4") long opinionCount
+            @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
+            @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
+            @Schema(example = "4", requiredMode = Schema.RequiredMode.REQUIRED) long opinionCount
     ) {
         public static SimilarCandidate from(SimilarPassageProjection projection) {
             return new SimilarCandidate(
@@ -80,7 +85,9 @@ public class PassageResponse {
         }
     }
 
-    public record OcrRecognize(List<TextBlock> blocks) {
+    public record OcrRecognize(
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<TextBlock> blocks
+    ) {
         public static OcrRecognize from(List<OcrResultDto> blocks) {
             List<TextBlock> textBlockResponses = blocks.stream()
                     .map(TextBlock::from)
@@ -90,16 +97,18 @@ public class PassageResponse {
     }
 
     public record TextBlock(
-            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String text,
-            BoundingBox boundingBox,
-            @Schema(example = "true") boolean lineBreak
+            @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String text,
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) BoundingBox boundingBox,
+            @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean lineBreak
     ) {
         public static TextBlock from(OcrResultDto block) {
             return new TextBlock(block.text(), BoundingBox.from(block.boundingBox()), block.lineBreak());
         }
     }
 
-    public record BoundingBox(List<Point> vertices) {
+    public record BoundingBox(
+            @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<Point> vertices
+    ) {
         public static BoundingBox from(OcrResultDto.BoundingBox boundingBox) {
             List<Point> vertices = boundingBox.vertices().stream()
                     .map(point -> new Point(point.x(), point.y()))
@@ -108,6 +117,9 @@ public class PassageResponse {
         }
     }
 
-    public record Point(@Schema(example = "120.5") double x, @Schema(example = "48.0") double y) {
+    public record Point(
+            @Schema(example = "120.5", requiredMode = Schema.RequiredMode.REQUIRED) double x,
+            @Schema(example = "48.0", requiredMode = Schema.RequiredMode.REQUIRED) double y
+    ) {
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record LikedOpinionListResponse(List<LikedOpinionResponse> opinions, PageInfo pageInfo) {
+public record LikedOpinionListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<LikedOpinionResponse> opinions,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
@@ -10,9 +10,9 @@ public record LikedOpinionResponse(
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
-        @Schema(example = "87") int pageNumber,
+        @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "5") int likeCount,
+        @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
         @Schema(example = "2026-07-25T09:10:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime likedAt
 ) {

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
@@ -4,16 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record LikedOpinionResponse(
-        @Schema(example = "1") Long opinionId,
-        @Schema(example = "1") Long bookId,
-        @Schema(example = "채식주의자") String bookTitle,
-        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String bookCoverImageUrl,
-        @Schema(example = "1") Long passageId,
-        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
         @Schema(example = "87") int pageNumber,
-        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "5") int likeCount,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt,
-        @Schema(example = "2026-07-25T09:10:00") LocalDateTime likedAt
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
+        @Schema(example = "2026-07-25T09:10:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime likedAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
@@ -9,6 +9,6 @@ public record MeResponse(
         @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
         @Schema(example = "#FDF6E3", nullable = true) String backgroundColor,
         @Schema(example = "KAKAO", requiredMode = Schema.RequiredMode.REQUIRED) SnsProvider snsProvider,
-        @Schema(example = "23") long opinionCount
+        @Schema(example = "23", requiredMode = Schema.RequiredMode.REQUIRED) long opinionCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
@@ -4,11 +4,11 @@ import com.nexters.palang.domain.user.domain.SnsProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MeResponse(
-        @Schema(example = "7") Long userId,
-        @Schema(example = "책읽는고양이") String nickname,
-        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png") String profileImageUrl,
-        @Schema(example = "#FDF6E3") String backgroundColor,
-        @Schema(example = "KAKAO") SnsProvider snsProvider,
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
+        @Schema(example = "#FDF6E3", nullable = true) String backgroundColor,
+        @Schema(example = "KAKAO", requiredMode = Schema.RequiredMode.REQUIRED) SnsProvider snsProvider,
         @Schema(example = "23") long opinionCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionListResponse.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
 import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record MyOpinionListResponse(List<MyOpinionResponse> opinions, PageInfo pageInfo) {
+public record MyOpinionListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<MyOpinionResponse> opinions,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
@@ -10,9 +10,9 @@ public record MyOpinionResponse(
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
-        @Schema(example = "87") int pageNumber,
+        @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
-        @Schema(example = "5") int likeCount,
+        @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
@@ -4,15 +4,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 public record MyOpinionResponse(
-        @Schema(example = "1") Long opinionId,
-        @Schema(example = "1") Long bookId,
-        @Schema(example = "채식주의자") String bookTitle,
-        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String bookCoverImageUrl,
-        @Schema(example = "1") Long passageId,
-        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.") String quotedText,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
         @Schema(example = "87") int pageNumber,
-        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.") String content,
+        @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "5") int likeCount,
-        @Schema(example = "2026-07-20T14:32:00") LocalDateTime createdAt
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/OnboardingCompleteResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/OnboardingCompleteResponse.java
@@ -3,6 +3,6 @@ package com.nexters.palang.domain.user.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record OnboardingCompleteResponse(
-        @Schema(example = "true") boolean hasCompletedOnboarding
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasCompletedOnboarding
 ) {
 }

--- a/src/main/java/com/nexters/palang/global/common/response/PageInfo.java
+++ b/src/main/java/com/nexters/palang/global/common/response/PageInfo.java
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
 public record PageInfo(
-        @Schema(example = "0") int page,
-        @Schema(example = "20") int size,
-        @Schema(example = "42") long totalElements,
-        @Schema(example = "3") int totalPages,
-        @Schema(example = "true") boolean hasNext
+        @Schema(example = "0", requiredMode = Schema.RequiredMode.REQUIRED) int page,
+        @Schema(example = "20", requiredMode = Schema.RequiredMode.REQUIRED) int size,
+        @Schema(example = "42", requiredMode = Schema.RequiredMode.REQUIRED) long totalElements,
+        @Schema(example = "3", requiredMode = Schema.RequiredMode.REQUIRED) int totalPages,
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasNext
 ) {
 
     public static PageInfo from(Page<?> page) {

--- a/src/main/java/com/nexters/palang/global/config/SwaggerConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/SwaggerConfig.java
@@ -25,7 +25,6 @@ public class SwaggerConfig {
 
         Components components = new Components()
                 .addSecuritySchemes(securityScheme, new SecurityScheme()
-                        .name(securityScheme)
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -60,7 +60,7 @@ class BookServiceTest {
     void searchExternalBooks() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<ExternalBookResult> expected = new PageImpl<>(
-                List.of(new ExternalBookResult("제목", "작가", "출판사", 300, "isbn", "cover")), pageable, 1);
+                List.of(new ExternalBookResult("제목", "작가", "출판사", "isbn", "cover")), pageable, 1);
         given(aladinBookApiClient.search("제목", pageable)).willReturn(expected);
 
         Page<ExternalBookResult> results = bookService.searchExternalBooks("제목", pageable);

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
@@ -49,7 +49,7 @@ class AladinBookApiClientTest {
     }
 
     @Test
-    @DisplayName("검색 결과를 반환하며, 응답 속도를 위해 pageCount는 채우지 않고 항상 null이다")
+    @DisplayName("검색 결과를 반환하며, 응답 속도를 위해 pageCount는 포함하지 않는다")
     void searchDoesNotEnrichPageCount() {
         stubSearch("""
                 {
@@ -69,7 +69,7 @@ class AladinBookApiClientTest {
         Page<ExternalBookResult> results = aladinBookApiClient().search("프랑켄슈타인", PageRequest.of(0, 20));
 
         assertThat(results.getContent()).containsExactly(
-                new ExternalBookResult("프랑켄슈타인", "메리 셸리", "문학동네", null, "9788954429721",
+                new ExternalBookResult("프랑켄슈타인", "메리 셸리", "문학동네", "9788954429721",
                         "https://image.aladin.co.kr/cover.jpg"));
         assertThat(results.getTotalElements()).isEqualTo(1);
     }

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -67,13 +67,13 @@ class BookControllerTest {
     @DisplayName("키워드로 도서 외부 검색을 요청하면 결과 목록을 반환한다")
     void searchExternalBooks() throws Exception {
         given(bookService.searchExternalBooks(eq("제목"), any(Pageable.class))).willReturn(
-                new PageImpl<>(List.of(new ExternalBookResult("제목", "작가", "출판사", 300, "isbn", "cover")),
+                new PageImpl<>(List.of(new ExternalBookResult("제목", "작가", "출판사", "isbn", "cover")),
                         DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/books/search").param("keyword", "제목"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books[0].title").value("제목"))
-                .andExpect(jsonPath("$.data.books[0].pageCount").value(300))
+                .andExpect(jsonPath("$.data.books[0].pageCount").doesNotExist())
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(1));
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #48

## 🚀 개요
> OpenAPI 명세의 스펙 위반 및 응답 필드 required 누락 문제를 수정합니다.

## 📄 작업 내용
- `SwaggerConfig`의 `SecurityScheme` 빌더에서 `.name("Authorization")` 제거 (`type: http`에는 `name` 속성이 허용되지 않아 OpenAPI 3.0 스펙 위반이었음)
- 응답 DTO(auth/book/comment/notice/opinion/user 도메인, 24개 파일)에서 백엔드가 항상 채워주는 필드에 `@Schema(requiredMode = Schema.RequiredMode.REQUIRED)` 명시, 진짜 nullable한 필드(isbn, coverImageUrl, profileImageUrl 등)는 `nullable = true`로 구분

## 📸 스크린샷 / 테스트 결과 (선택)
> 로컬 서버 기동 후 `/v3/api-docs` 응답을 직접 확인해, `Authorization` 스킴에서 `name` 속성이 사라지고 대상 DTO들의 `required` 배열이 의도한 필드로 채워지는 것을 검증함.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- Response DTO별 required/nullable 분류가 실제 비즈니스 로직과 맞는지 확인 부탁드립니다 (예: `createdAt`/`updatedAt` 등 JPA auditing 필드는 항상 채워진다고 가정함).
- `ExternalBookResponse`(알라딘 외부 API 매핑)는 백엔드가 값 보장을 못하는 필드라 이번 작업 범위에서 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Swagger/OpenAPI 문서에서 주요 응답 필드의 필수 여부가 명확하게 표시됩니다.
  * 선택 가능한 값은 nullable로 표시되어 실제 응답 형식과 문서 간 일치성이 향상됩니다.
  * JWT 인증 방식이 API 문서에 더욱 정확하게 표현됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->