### PR TITLE
Fix/#52 카카오 로그인 닉네임 자동 생성 실패(USER_409_2) 오탐 수정

### DIFF
--- a/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
@@ -18,6 +18,12 @@ public class UserRegistrationService {
     private final UserRepository userRepository;
     private final NicknameGenerator nicknameGenerator;
 
+    // MySQL/H2 모두 제약 위반 예외 메시지에 제약 이름(User.uq_users_nickname)을 포함하므로, 이 문자열로
+    // "진짜 닉네임 충돌"과 그 외 무결성 위반(예: 컬럼 nullable 설정이 스키마와 어긋난 NOT NULL 위반)을 구분한다.
+    // (실제로 terms_agreed_at 컬럼이 엔티티는 nullable인데 DB에는 NOT NULL로 남아있던 사고에서, 이 구분이
+    // 없어 원인과 무관한 "닉네임 생성 실패"로 잘못 보고된 적이 있다.)
+    private static final String NICKNAME_UNIQUE_CONSTRAINT = "uq_users_nickname";
+
     // FR-AUTH-04: 닉네임 유니크 제약 충돌은 사전 조회 대신 저장 시도 -> 실패 시 접미사를 붙여 재시도하는
     // 낙관적 방식으로 처리한다(사전 조회는 동시성에 취약). 각 시도를 REQUIRES_NEW로 독립된 트랜잭션에서
     // 실행해, 제약 위반 예외가 영속성 컨텍스트를 오염시켜 다음 시도까지 실패시키는 것을 막는다.
@@ -28,10 +34,20 @@ public class UserRegistrationService {
             try {
                 return createUser(nickname, snsProvider, snsId);
             } catch (DataIntegrityViolationException e) {
+                if (!isNicknameConflict(e)) {
+                    // 닉네임 충돌이 아닌 다른 무결성 위반을 닉네임 생성 실패로 오인해 삼키지 않는다 —
+                    // 그대로 던져서 GlobalExceptionHandler가 500과 실제 원인을 로그로 남기게 한다.
+                    throw e;
+                }
                 // 닉네임 충돌로 보고 다음 접미사로 재시도한다.
             }
         }
         throw new UserException(UserErrorCode.NICKNAME_GENERATION_FAILED);
+    }
+
+    private boolean isNicknameConflict(DataIntegrityViolationException e) {
+        String message = String.valueOf(e.getMostSpecificCause().getMessage()).toLowerCase();
+        return message.contains(NICKNAME_UNIQUE_CONSTRAINT);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
@@ -58,7 +58,7 @@ class UserRegistrationServiceTest {
         given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
         given(nicknameGenerator.withSuffix("고요한책갈피", 1)).willReturn("고요한책갈피1");
         given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피"))))
-                .willThrow(new DataIntegrityViolationException("duplicate"));
+                .willThrow(new DataIntegrityViolationException("Duplicate entry for key 'users.uq_users_nickname'"));
         given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피1"))))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -74,9 +74,22 @@ class UserRegistrationServiceTest {
         given(nicknameGenerator.withSuffix(eq("고요한책갈피"), anyInt()))
                 .willAnswer(invocation -> "고요한책갈피" + invocation.<Integer>getArgument(1));
         given(userRepository.saveAndFlush(any(User.class)))
-                .willThrow(new DataIntegrityViolationException("duplicate"));
+                .willThrow(new DataIntegrityViolationException("Duplicate entry for key 'users.uq_users_nickname'"));
 
         assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3"))
                 .isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("닉네임 충돌이 아닌 다른 무결성 위반은 재시도하지 않고 그대로 던진다")
+    void registerViaSnsRethrowsNonNicknameViolation() {
+        given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
+        given(userRepository.saveAndFlush(any(User.class)))
+                .willThrow(new DataIntegrityViolationException(
+                        "Column 'terms_agreed_at' cannot be null"));
+
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-4"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        verify(userRepository, times(1)).saveAndFlush(any());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #52

## 🚀 개요
> `POST /api/auth/kakao`로 신규 회원가입 시 실제로는 닉네임 충돌이 아닌 다른 원인의 DB 오류까지도 전부 "닉네임 자동 생성 실패"(`USER_409_2`)로 오탐되던 버그를 고칩니다. 이번에 발견된 계기는 `terms_agreed_at` 컬럼의 스키마 드리프트였지만, 고친 대상은 그 자체가 아니라 **어떤 원인의 DB 오류든 전부 닉네임 문제로 둔갑시키던 예외 처리 로직**입니다.

## 🐛 원인 분석 (상세)

### 1) 신고된 증상
```json
{
  "detail": "닉네임 자동 생성에 실패했습니다. 잠시 후 다시 시도해주세요.",
  "status": 409,
  "title": "USER_409_2",
  "type": "/api/auth/kakao"
}
```
카카오 로그인 시 신규 유저를 만드는 과정에서 위 에러가 발생한다는 제보(@BE_백승주)가 있었습니다.

### 2) 코드 흐름 재구성
`UserRegistrationService.registerViaSns` (수정 전):
```java
public User registerViaSns(SnsProvider snsProvider, String snsId) {
    String base = nicknameGenerator.generateBase();
    for (int suffix = 0; suffix <= NicknameGenerator.MAX_SUFFIX_ATTEMPTS; suffix++) {
        String nickname = suffix == 0 ? base : nicknameGenerator.withSuffix(base, suffix);
        try {
            return createUser(nickname, snsProvider, snsId);
        } catch (DataIntegrityViolationException e) {
            // 닉네임 충돌로 보고 다음 접미사로 재시도한다.
        }
    }
    throw new UserException(UserErrorCode.NICKNAME_GENERATION_FAILED); // USER_409_2
}
```
이 코드는 FR-AUTH-04(닉네임 자동 생성) 요구사항대로, "닉네임 유니크 제약 위반 시 접미사를 붙여 재시도"하는 낙관적 동시성 처리 패턴입니다. **문제는 `catch (DataIntegrityViolationException e)` 블록이 "이 예외 = 닉네임 중복"이라고 무조건 가정한다는 점입니다.** `DataIntegrityViolationException`은 Spring이 JDBC/JPA 레이어에서 발생하는 **모든 종류의 무결성 제약 위반**(UNIQUE, NOT NULL, FK, CHECK 등)을 감싸는 공통 예외 타입이라, 닉네임 유니크 제약 위반과 그 외의 제약 위반을 구분하지 못합니다.

### 3) 실제로 터진 제약 위반
`User` 엔티티(`User.java`)의 `termsAgreedAt` 필드:
```java
// SNS 로그인 시점에는 아직 약관에 동의하지 않았을 수 있어(FR-AUTH-03) nullable이다.
@Column(name = "terms_agreed_at")
private LocalDateTime termsAgreedAt;
```
설계상 명시적으로 nullable입니다 (`nullable = false`가 없음 → JPA 기본값 nullable). 카카오 로그인으로 신규 유저를 만드는 시점(`UserRegistrationService.createUser`)에는 아직 약관 동의 전이므로 `termsAgreedAt`을 채우지 않고 `User.builder()`로 생성합니다.

그런데 **실제 DB(로컬/dev)의 `users.terms_agreed_at` 컬럼은 `NOT NULL`로 남아 있었습니다.** 이 프로젝트는 Flyway/Liquibase 같은 마이그레이션 도구 없이 Hibernate `ddl-auto`(dev: `update`, prod: `validate`)로만 스키마를 관리합니다(`application-dev.yaml`/`application-prod.yaml`). `ddl-auto: update`는 신규 컬럼/테이블은 추가해주지만 **기존 컬럼의 NOT NULL 제약을 완화(loosen)해주지는 않습니다.** 즉 이 컬럼이 과거 한 시점에 NOT NULL로 생성된 뒤, 엔티티 쪽만 nullable로 바뀌고 실제 DB 컬럼은 그대로 NOT NULL로 남아 스키마 드리프트가 발생한 것으로 추정됩니다.

### 4) 왜 "닉네임 생성 실패"로 둔갑했나
1. `createUser()`가 `termsAgreedAt=null`인 `User`를 저장 시도
2. DB가 NOT NULL 제약 위반으로 INSERT 거부 → `DataIntegrityViolationException` 발생 (닉네임과는 무관)
3. `registerViaSns`의 `catch` 블록이 이걸 "닉네임 충돌"로 오인하고 접미사를 바꿔 재시도
4. 접미사만 바뀔 뿐 `termsAgreedAt=null`인 건 동일하므로 **다시 같은 이유로 실패**
5. 이 과정이 `MAX_SUFFIX_ATTEMPTS = 100`번 반복된 뒤 (총 101번 INSERT 시도) 전부 실패
6. 루프가 끝나고 `NICKNAME_GENERATION_FAILED`(`USER_409_2`) 예외를 던짐 — **실제 원인(NOT NULL 위반)은 로그에도 남지 않고 완전히 삼켜짐**

즉 보고된 증상(`USER_409_2`)은 진짜 원인의 "곁다리 증상"이었고, 실제 원인은 스키마 드리프트였습니다. 로컬/dev에서 해당 컬럼을 nullable로 직접 바꿔보니 재현되지 않는 것도 이 분석과 일치합니다.

## ✅ 이번 PR에서 고친 것 / 안 고친 것

**고친 것 — 예외 처리의 근본적인 오류 처리 결함:**
```java
} catch (DataIntegrityViolationException e) {
    if (!isNicknameConflict(e)) {
        throw e; // 닉네임 충돌이 아니면 그대로 전파
    }
    // 닉네임 충돌일 때만 재시도
}
```
`isNicknameConflict()`는 예외의 근본 원인 메시지(`getMostSpecificCause().getMessage()`)에 닉네임 유니크 제약 이름(`uq_users_nickname`, `User.java`의 `@UniqueConstraint(name = "uq_users_nickname", ...)`)이 포함돼 있는지로 판별합니다. MySQL/H2 모두 제약 위반 시 에러 메시지에 제약 이름이 포함되므로(예: MySQL `Duplicate entry '...' for key 'users.uq_users_nickname'`, H2 `Unique index or primary key violation: "UQ_USERS_NICKNAME ...`) 두 환경 모두에서 동작합니다.

이렇게 하면:
- **진짜 닉네임 충돌**만 재시도 대상이 되고,
- **그 외의 모든 무결성 위반**(NOT NULL, FK, CHECK 등 무엇이든)은 그대로 상위로 던져져서 `GlobalExceptionHandler`의 catch-all(`Exception`) 핸들러가 **500 + 실제 예외 스택트레이스를 로그로 남깁니다.** 앞으로 비슷한 스키마 문제가 또 생기더라도 "닉네임 생성 실패"라는 엉뚱한 에러 대신 정확한 원인이 로그에 남게 됩니다.

**안 고친 것 (이 PR 범위 밖, 이슈 #52에 후속 작업으로 남겨둠):**
- `terms_agreed_at` 컬럼 자체의 스키마 드리프트 — dev DB는 이미 수동으로 nullable로 바꿔둔 상태(별도 조치)지만, **prod DB도 같은 문제가 있는지는 아직 확인 못함.** prod는 `ddl-auto: validate`라 스키마 불일치 시 기동 자체가 실패했어야 정상인데, 정말 그런지 재확인이 필요합니다.
- 근본 원인인 "마이그레이션 도구 없이 `ddl-auto`로만 스키마 관리" 자체 — Flyway 등 도입은 훨씬 큰 작업이라 별도 이슈 논의 필요.

## 📄 변경 파일
- `src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java` — `isNicknameConflict()` 판별 로직 추가, 닉네임 충돌이 아닌 경우 재던지기
- `src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java` — 기존 테스트의 mock 예외 메시지를 실제 제약 위반 메시지 형태(`... uq_users_nickname`)로 보정 + 회귀 테스트 1건 추가(`registerViaSnsRethrowsNonNicknameViolation`: 닉네임 충돌이 아닌 위반은 재시도 없이 즉시 전파되는지 검증)

## 📸 테스트 결과
```
UserRegistrationServiceTest > 닉네임이 충돌하지 않으면 처음 생성한 닉네임 그대로 저장된다 PASSED
UserRegistrationServiceTest > 닉네임이 충돌하면 숫자 접미사를 붙여 재시도한다 PASSED
UserRegistrationServiceTest > 100번 재시도까지 모두 충돌하면 닉네임 생성 실패 예외가 발생한다 PASSED
UserRegistrationServiceTest > 닉네임 충돌이 아닌 다른 무결성 위반은 재시도하지 않고 그대로 던진다 PASSED
```
전체 스위트(`./gradlew clean test`)도 이 변경과 무관한 기존 flaky 테스트(`NoticeRepositoryTest`, `createdAt` 밀리초 동률 정렬 이슈) 1건 제외하고 전부 통과.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인 (dev DB 재확인은 SSH 일시 장애로 보류 중)
- [ ] API 동작 확인 (카카오 개발자 계정 제약으로 dev에서 실제 로그인 E2E 미실시 — merge 전 재현 여부 확인 권장)

---
## 🔍 리뷰 포인트 (Review Points)
- 닉네임 충돌 판별을 문자열 포함 여부(`uq_users_nickname`)로 하는 방식이 다소 취약한 휴리스틱이라고 생각합니다. 더 견고한 대안으로 JDBC `SQLIntegrityConstraintViolationException`/Hibernate `ConstraintViolationException`의 `getConstraintName()`을 쓰는 방법도 있는데, DB 드라이버/버전에 따라 항상 채워지진 않아서 우선 메시지 매칭으로 갔습니다 — 의견 부탁드립니다.
- prod DB에 같은 `terms_agreed_at` 드리프트가 있는지 확인이 필요합니다 (본문 "안 고친 것" 참고). 확인해주실 수 있는 분 부탁드립니다.
- 이 PR은 오탐(mis-reporting) 자체를 고친 것이라, 실제 카카오 로그인 E2E로 "이제 정상적으로 유저가 생성되는지"는 아직 검증 못했습니다. dev 서버에서 실제 로그인 테스트 한 번 부탁드립니다.