### PR TITLE
Feat/#56 홈 캐러셀 API 가운데 offset 조회 지원

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookCarouselPage.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookCarouselPage.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.book.application;
+
+import java.util.List;
+
+public record BookCarouselPage(
+        List<BookActivityProjection> books,
+        long offset,
+        int size,
+        long totalElements
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/book/application/BookMapper.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookMapper.java
@@ -3,13 +3,16 @@ package com.nexters.palang.domain.book.application;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityResponse;
+import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookSearchListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookSearchResponse;
 import com.nexters.palang.domain.book.presentation.dto.ExternalBookListResponse;
 import com.nexters.palang.domain.book.presentation.dto.ExternalBookResponse;
+import com.nexters.palang.global.common.response.CarouselPageInfo;
 import com.nexters.palang.global.common.response.PageInfo;
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public final class BookMapper {
@@ -58,5 +61,11 @@ public final class BookMapper {
     public static BookActivityListResponse toActivityListResponse(Page<BookActivityProjection> projections) {
         return new BookActivityListResponse(
                 projections.map(BookMapper::toActivityResponse).getContent(), PageInfo.from(projections));
+    }
+
+    public static BookCarouselListResponse toCarouselListResponse(BookCarouselPage page) {
+        List<BookActivityResponse> books = page.books().stream().map(BookMapper::toActivityResponse).toList();
+        CarouselPageInfo pageInfo = CarouselPageInfo.of(page.offset(), page.size(), books.size(), page.totalElements());
+        return new BookCarouselListResponse(books, pageInfo);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -51,8 +51,16 @@ public class BookService {
         return bookRepository.save(book);
     }
 
-    public Page<BookActivityProjection> getHomeCarouselBooks(Pageable pageable) {
-        return bookQueryRepository.findCarouselBooks(pageable);
+    // offset을 지정하지 않으면 전체 목록 중 가운데 책들을 반환한다. 좌우 스크롤 시에는 이전/다음 offset을 그대로 넘기면 된다.
+    public BookCarouselPage getHomeCarouselBooks(Long offset, int size) {
+        long total = bookQueryRepository.countCarouselBooks();
+        long resolvedOffset = offset != null ? Math.max(0, offset) : centerOffset(total, size);
+        List<BookActivityProjection> books = bookQueryRepository.findCarouselBooks(resolvedOffset, size);
+        return new BookCarouselPage(books, resolvedOffset, size, total);
+    }
+
+    private long centerOffset(long total, int size) {
+        return Math.max(0, (total - size) / 2);
     }
 
     public Page<Book> getRecentBooks(Long userId, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -56,12 +56,14 @@ public class BookQueryRepository {
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    public Page<BookActivityProjection> findCarouselBooks(Pageable pageable) {
+    // 홈 캐러셀은 전체 목록 중 임의의 가운데 offset에서 좌우로 조회해야 해서, page*size로 offset이
+    // 고정되는 Pageable 대신 offset/limit을 직접 받는다.
+    public List<BookActivityProjection> findCarouselBooks(long offset, int limit) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinion = QOpinion.opinion;
 
-        List<BookActivityProjection> content = queryFactory
+        return queryFactory
                 .select(Projections.constructor(BookActivityProjection.class,
                         book.id, book.title, book.author, book.coverImageUrl,
                         passage.countDistinct(), opinion.countDistinct()))
@@ -70,11 +72,13 @@ public class BookQueryRepository {
                 .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .groupBy(book.id, book.title, book.author, book.coverImageUrl)
                 .orderBy(passage.createdAt.max().desc(), book.id.asc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .offset(offset)
+                .limit(limit)
                 .fetch();
+    }
 
-        return new PageImpl<>(content, pageable, countBooksWithPassages());
+    public long countCarouselBooks() {
+        return countBooksWithPassages();
     }
 
     public Page<BookActivityProjection> findPopularBooks(Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.book.presentation;
 
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
+import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookSearchListResponse;
@@ -60,15 +61,18 @@ public interface BookApi {
             @Valid CreateBookRequest request
     );
 
-    @Operation(summary = "홈 캐러셀 도서 목록", description = "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다.")
+    @Operation(summary = "홈 캐러셀 도서 목록",
+            description = "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다. offset을 생략하면 전체 목록 중 "
+                    + "정가운데 책들을 기준으로 조회하며, 좌우 스크롤 시에는 응답으로 받은 pageInfo를 참고해 "
+                    + "offset - size(이전) 또는 offset + size(다음)로 다시 요청하면 됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+            @ApiResponse(responseCode = "400", description = "offset/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<DataResponse<BookActivityListResponse>> getHomeCarouselBooks(
-            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
-            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    ResponseEntity<DataResponse<BookCarouselListResponse>> getHomeCarouselBooks(
+            @Parameter(description = "조회 시작 위치 (0부터 시작). 생략하면 전체 목록 중 가운데를 기준으로 조회") Long offset,
+            @Parameter(description = "조회 개수 (기본값 20, 최대 100)") int size
     );
 
     @Operation(summary = "내가 최근에 남긴 도서 목록",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -4,6 +4,7 @@ import com.nexters.palang.domain.book.application.BookMapper;
 import com.nexters.palang.domain.book.application.BookService;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
+import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookSearchListResponse;
@@ -62,11 +63,12 @@ public class BookController implements BookApi {
 
     @Override
     @GetMapping("/api/home/books")
-    public ResponseEntity<DataResponse<BookActivityListResponse>> getHomeCarouselBooks(
-            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+    public ResponseEntity<DataResponse<BookCarouselListResponse>> getHomeCarouselBooks(
+            @RequestParam(required = false) Long offset,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        int clampedSize = Math.clamp(size, 1, MAX_SIZE);
         return ResponseEntity.ok(DataResponse.from(
-                BookMapper.toActivityListResponse(bookService.getHomeCarouselBooks(pageable(page, size)))));
+                BookMapper.toCarouselListResponse(bookService.getHomeCarouselBooks(offset, clampedSize))));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookCarouselListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/BookCarouselListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.book.presentation.dto;
+
+import com.nexters.palang.global.common.response.CarouselPageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record BookCarouselListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookActivityResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) CarouselPageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/global/common/response/CarouselPageInfo.java
+++ b/src/main/java/com/nexters/palang/global/common/response/CarouselPageInfo.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.global.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CarouselPageInfo(
+        @Schema(example = "40", requiredMode = Schema.RequiredMode.REQUIRED) long offset,
+        @Schema(example = "20", requiredMode = Schema.RequiredMode.REQUIRED) int size,
+        @Schema(example = "100", requiredMode = Schema.RequiredMode.REQUIRED) long totalElements,
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasPrevious,
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasNext
+) {
+
+    public static CarouselPageInfo of(long offset, int size, int contentSize, long totalElements) {
+        boolean hasPrevious = offset > 0;
+        boolean hasNext = offset + contentSize < totalElements;
+        return new CarouselPageInfo(offset, size, totalElements, hasPrevious, hasNext);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -127,4 +127,40 @@ class BookServiceTest {
 
         assertThat(results).isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("offset을 지정하지 않으면 전체 목록 중 가운데 위치를 offset으로 계산한다")
+    void getHomeCarouselBooksResolvesCenterOffsetWhenOffsetIsNull() {
+        given(bookQueryRepository.countCarouselBooks()).willReturn(100L);
+        given(bookQueryRepository.findCarouselBooks(40L, 20))
+                .willReturn(List.of(new BookActivityProjection(1L, "책1", "작가", "cover", 5, 10)));
+
+        BookCarouselPage result = bookService.getHomeCarouselBooks(null, 20);
+
+        assertThat(result.offset()).isEqualTo(40L);
+        assertThat(result.totalElements()).isEqualTo(100L);
+        assertThat(result.books()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("offset을 직접 지정하면 그 값을 그대로 사용해 조회한다")
+    void getHomeCarouselBooksUsesGivenOffset() {
+        given(bookQueryRepository.countCarouselBooks()).willReturn(100L);
+        given(bookQueryRepository.findCarouselBooks(60L, 20)).willReturn(List.of());
+
+        BookCarouselPage result = bookService.getHomeCarouselBooks(60L, 20);
+
+        assertThat(result.offset()).isEqualTo(60L);
+    }
+
+    @Test
+    @DisplayName("전체 개수가 size보다 작으면 가운데 offset은 0이다")
+    void getHomeCarouselBooksClampsCenterOffsetToZero() {
+        given(bookQueryRepository.countCarouselBooks()).willReturn(5L);
+        given(bookQueryRepository.findCarouselBooks(0L, 20)).willReturn(List.of());
+
+        BookCarouselPage result = bookService.getHomeCarouselBooks(null, 20);
+
+        assertThat(result.offset()).isEqualTo(0L);
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -12,6 +12,7 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.global.config.JpaAuditingConfig;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -118,30 +119,47 @@ class BookQueryRepositoryTest {
         opinion(passage1, writer);
         opinion(passage1, writer);
 
-        Page<BookActivityProjection> results = bookQueryRepository.findCarouselBooks(PageRequest.of(0, 20));
+        List<BookActivityProjection> results = bookQueryRepository.findCarouselBooks(0, 20);
 
-        assertThat(results.getContent()).extracting(BookActivityProjection::bookId)
+        assertThat(results).extracting(BookActivityProjection::bookId)
                 .containsExactly(bookWithPassages.getId());
-        assertThat(results.getContent().get(0).passageCount()).isEqualTo(2);
-        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(2);
+        assertThat(results.get(0).passageCount()).isEqualTo(2);
+        assertThat(results.get(0).opinionCount()).isEqualTo(2);
         assertThat(bookWithoutPassages.getId()).isNotIn(
                 results.stream().map(BookActivityProjection::bookId).toList());
     }
 
     @Test
-    @DisplayName("캐러셀 조회는 요청한 페이지 크기만큼만 반환하고 전체 개수를 함께 알려준다")
-    void findCarouselBooksRespectsPageSize() {
+    @DisplayName("캐러셀 조회는 요청한 개수만큼만 반환하고 전체 개수를 별도로 알려준다")
+    void findCarouselBooksRespectsLimit() {
         User writer = user("writer-page");
         Book book1 = book("책1");
         Book book2 = book("책2");
         passage(book1, writer, 1);
         passage(book2, writer, 1);
 
-        Page<BookActivityProjection> firstPage = bookQueryRepository.findCarouselBooks(PageRequest.of(0, 1));
+        List<BookActivityProjection> firstBook = bookQueryRepository.findCarouselBooks(0, 1);
 
-        assertThat(firstPage.getContent()).hasSize(1);
-        assertThat(firstPage.getTotalElements()).isEqualTo(2);
-        assertThat(firstPage.hasNext()).isTrue();
+        assertThat(firstBook).hasSize(1);
+        assertThat(bookQueryRepository.countCarouselBooks()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("임의의 offset을 지정하면 전체 정렬 순서상 그 위치부터 도서를 반환한다")
+    void findCarouselBooksSupportsArbitraryOffset() {
+        User writer = user("writer-off");
+        Book book1 = book("책1");
+        Book book2 = book("책2");
+        Book book3 = book("책3");
+        passage(book1, writer, 1);
+        passage(book2, writer, 1);
+        passage(book3, writer, 1);
+
+        List<BookActivityProjection> all = bookQueryRepository.findCarouselBooks(0, 3);
+        List<BookActivityProjection> middle = bookQueryRepository.findCarouselBooks(1, 1);
+
+        assertThat(middle).extracting(BookActivityProjection::bookId)
+                .containsExactly(all.get(1).bookId());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -2,7 +2,9 @@ package com.nexters.palang.domain.book.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -12,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.application.BookActivityProjection;
+import com.nexters.palang.domain.book.application.BookCarouselPage;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookService;
 import com.nexters.palang.domain.book.application.ExternalBookResult;
@@ -138,14 +141,26 @@ class BookControllerTest {
     @Test
     @DisplayName("홈 캐러셀 도서 목록을 요청하면 대목/흔적 수와 함께 반환한다")
     void getHomeCarouselBooks() throws Exception {
-        given(bookService.getHomeCarouselBooks(any(Pageable.class))).willReturn(
-                new PageImpl<>(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)),
-                        DEFAULT_PAGEABLE, 1));
+        given(bookService.getHomeCarouselBooks(isNull(), anyInt())).willReturn(
+                new BookCarouselPage(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)), 0, 20, 1));
 
         mockMvc.perform(get("/api/home/books"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books[0].passageCount").value(3))
                 .andExpect(jsonPath("$.data.books[0].opinionCount").value(7));
+    }
+
+    @Test
+    @DisplayName("홈 캐러셀 도서 목록 조회 시 offset을 지정하면 그대로 전달하고, 응답에 이전/다음 여부를 함께 내려준다")
+    void getHomeCarouselBooksWithOffset() throws Exception {
+        given(bookService.getHomeCarouselBooks(eq(40L), anyInt())).willReturn(
+                new BookCarouselPage(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)), 40, 20, 100));
+
+        mockMvc.perform(get("/api/home/books").param("offset", "40").param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.pageInfo.offset").value(40))
+                .andExpect(jsonPath("$.data.pageInfo.hasPrevious").value(true))
+                .andExpect(jsonPath("$.data.pageInfo.hasNext").value(true));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #56

## 🚀 개요
홈 화면 책 캐러셀이 전체 도서 목록 중 정가운데 책을 기준으로 초기 진입할 수 있도록, `GET /api/home/books`를 page/size 기반에서 offset/size 기반으로 변경했습니다.

## 📄 작업 내용
- `GET /api/home/books` 요청 파라미터를 `page` → `offset`(nullable)으로 변경
  - `offset` 생략 시 서버가 `centerOffset = max(0, (total-size)/2)`로 전체 목록 기준 가운데 위치를 계산해서 반환
  - `offset`을 직접 지정하면 그 값 그대로 사용 (좌우 스크롤 시 `offset ± size`로 재요청)
- `BookQueryRepository.findCarouselBooks`가 `Pageable` 대신 임의의 raw `(offset, limit)`을 받도록 변경 (QueryDSL `.offset()/.limit()`이 원래 임의 offset을 지원)
- 양방향 스크롤을 표현하기 위한 응답 타입 `CarouselPageInfo`(offset/size/totalElements/hasPrevious/hasNext), `BookCarouselListResponse` 추가
  - 다른 엔드포인트(인기 도서 등)에서 쓰는 기존 `PageInfo`는 변경하지 않음
- Swagger 문서(`BookApi`) 및 관련 테스트(`BookServiceTest`, `BookQueryRepositoryTest`, `BookControllerTest`) 갱신

## 📸 스크린샷 / 테스트 결과 (선택)
`./gradlew test`, `./gradlew build -x test` 모두 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 캐러셀 전용으로 `PageInfo`를 그대로 확장하지 않고 `CarouselPageInfo`/`BookCarouselListResponse`를 새로 만들었는데, 다른 엔드포인트와의 일관성 측면에서 이 분리가 적절한지 확인 부탁드립니다.
- `centerOffset = max(0, (total-size)/2)` 계산 방식이 기획 의도(가운데 책)에 부합하는지, 특히 total이 홀수/짝수일 때의 경계값 처리가 맞는지 봐주세요.
- 프론트에서 실제로 좌우 스크롤 시 `offset ± size`를 재요청하는 흐름이 자연스러운지, 아니면 다른 커서 방식이 더 나을지 의견 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 홈 도서 캐러셀 응답에 전체 도서 수, 현재 위치, 페이지 크기, 이전·다음 페이지 여부를 제공합니다.
  - `offset` 기반으로 원하는 위치의 도서를 조회할 수 있습니다.
  - offset을 생략하면 전체 목록의 가운데 지점부터 표시됩니다.

- **개선 사항**
  - 요청한 도서 개수가 허용 범위를 벗어나지 않도록 자동 보정됩니다.
  - 홈 도서 목록 API 응답 형식이 캐러셀 전용 구조로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->