### PR TITLE
Chore/#58 dev API 서버 CORS 설정 추가

### DIFF
--- a/src/main/java/com/nexters/palang/global/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/SecurityConfig.java
@@ -2,7 +2,9 @@ package com.nexters.palang.global.config;
 
 import com.nexters.palang.global.security.jwt.JwtAuthenticationFilter;
 import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,6 +13,9 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 // 인가는 Spring Security의 authorizeHttpRequests가 아니라 서비스 레이어의 CurrentUserProvider가 담당한다
 // (backend_plan.md §4.2 Soft Authentication). 그래서 여기서는 모든 요청을 permitAll로 통과시키고,
@@ -22,6 +27,9 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Value("${cors.allowed-origins:}")
+    private List<String> allowedOrigins;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -29,8 +37,21 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    private CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -54,6 +54,10 @@ aladin:
   base-url: https://www.aladin.co.kr/ttb/api
   ttb-key: ${ALADIN_TTB_KEY:}
 
+# 6. CORS 허용 origin (프론트엔드와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급됨)
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,http://localhost:3000}
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -63,6 +63,10 @@ jwt:
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
   refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
 
+# CORS 허용 origin (운영 도메인이 정해지면 CORS_ALLOWED_ORIGINS 환경변수로 채운다)
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ aladin:
 kakao:
   base-url: https://kapi.kakao.com
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-please-change-this-01234567890123456789}
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #58

## 🚀 개요
dev API 서버가 프론트엔드(dev.pallang.co.kr)와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급되어 CORS 정책에 호출이 막히던 문제를 해결한다.

## 📄 작업 내용
- `SecurityConfig`에 `CorsConfigurationSource` 빈을 등록하고 `http.cors(...)`로 Security 필터체인에 적용 (WebMvcConfigurer가 아니라 Security 단에서 처리해야 필터가 먼저 요청을 막지 않음)
- 허용 origin: `https://dev.pallang.co.kr`, `http://localhost:3000` (환경변수 `CORS_ALLOWED_ORIGINS`로 오버라이드 가능)
- 허용 헤더: `Authorization`, `Content-Type`
- 허용 메서드: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`
- `application.yaml`(local), `application-dev.yaml`, `application-prod.yaml`에 `cors.allowed-origins` 프로퍼티 추가 (prod는 기본값 없음, 필요 시 환경변수로 채움)

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava` 컴파일 확인 완료

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- prod 환경의 허용 origin은 아직 미확정이라 기본값을 비워뒀습니다. 운영 도메인이 정해지면 별도 이슈로 `CORS_ALLOWED_ORIGINS` 값을 채울 예정인데, 이 방향이 맞는지 확인 부탁드립니다.
- `allowCredentials(true)`로 설정했는데, JWT를 쿠키가 아닌 Authorization 헤더로만 전달한다면 굳이 필요 없을 수도 있어 보입니다. 필요 여부 확인 부탁드립니다.