### PR TITLE
Chore/#62 실제 서비스 도메인 CORS 설정

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -56,7 +56,7 @@ aladin:
 
 # 6. CORS 허용 origin (프론트엔드와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급됨)
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,http://localhost:3000}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -65,7 +65,7 @@ jwt:
 
 # CORS 허용 origin (운영 도메인)
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://www.pallang.co.kr}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://www.pallang.co.kr,https://pallang.co.kr}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -63,9 +63,9 @@ jwt:
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
   refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
 
-# CORS 허용 origin (운영 도메인이 정해지면 CORS_ALLOWED_ORIGINS 환경변수로 채운다)
+# CORS 허용 origin (운영 도메인)
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://www.pallang.co.kr}
 
 logging:
   level:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #62

## 🚀 개요
prod/dev 서버 CORS 허용 origin에 실제 서비스 도메인(`www.pallang.co.kr`, `pallang.co.kr`)을 추가한다.

## 📄 작업 내용
- `application-prod.yaml`: `cors.allowed-origins` 기본값에 `https://www.pallang.co.kr`, `https://pallang.co.kr` 추가 (`CORS_ALLOWED_ORIGINS` 환경변수 미설정 시 사용되는 기본값)
- `application-dev.yaml`: `cors.allowed-origins` 기본값에 `https://www.pallang.co.kr`, `https://pallang.co.kr` 추가
  - prod 백엔드가 아직 배포 전이라, 실서비스 도메인 프론트가 현재 dev API 서버를 호출하고 있어 dev 쪽에도 동일하게 반영

## 📸 스크린샷 / 테스트 결과 (선택)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요? (해당 없음 — 설정값 변경만 존재)
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 우선 dev 쪽에 실서비스 도메인을 임시로 허용해두겠습니다! (prod 배포 후 제거할지 등 논의 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 운영 및 개발 환경에서 공식 웹사이트 도메인의 정상적인 접근을 지원하도록 CORS 허용 범위를 확장했습니다.
  * 운영 환경에서 관련 환경변수가 설정되지 않아도 공식 도메인에서 서비스에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->