### PR TITLE
Feat/#64 흔적 목록 화면 API Lazy-loading 500 오류 수정 및 응답 필드 보강

### DIFF
--- a/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
+++ b/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
@@ -11,6 +11,8 @@ import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.util.List;
@@ -58,7 +60,8 @@ public class CommentService {
     @Transactional
     public Comment createComment(Long opinionId, Long userId, CreateCommentRequest request) {
         Opinion opinion = getExistingOpinion(opinionId);
-        User user = userRepository.getReferenceById(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         if (request.parentCommentId() == null) {
             return commentRepository.save(Comment.root(opinion, user, request.content()));
@@ -100,7 +103,7 @@ public class CommentService {
     }
 
     private Comment getExistingComment(Long commentId) {
-        return commentRepository.findById(commentId)
+        return commentRepository.findByIdWithUser(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
     }
 

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepository.java
@@ -24,6 +24,7 @@ public class CommentQueryRepository {
 
         List<Comment> content = queryFactory
                 .selectFrom(comment)
+                .join(comment.user).fetchJoin()
                 .where(comment.opinion.id.eq(opinionId), comment.parentComment.isNull())
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .offset(pageable.getOffset())
@@ -70,6 +71,7 @@ public class CommentQueryRepository {
         for (Long parentId : parentIds) {
             List<Comment> preview = queryFactory
                     .selectFrom(comment)
+                    .join(comment.user).fetchJoin()
                     .where(comment.parentComment.id.eq(parentId))
                     .orderBy(comment.createdAt.asc(), comment.id.asc())
                     .limit(previewSize)
@@ -84,6 +86,7 @@ public class CommentQueryRepository {
 
         List<Comment> content = queryFactory
                 .selectFrom(comment)
+                .join(comment.user).fetchJoin()
                 .where(comment.parentComment.id.eq(parentCommentId))
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
@@ -1,7 +1,15 @@
 package com.nexters.palang.domain.comment.infrastructure;
 
 import com.nexters.palang.domain.comment.domain.Comment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    // open-in-view: false 환경에서 컨트롤러 단 Mapper가 comment.getUser()를 참조하므로
+    // 트랜잭션 안에서 user를 미리 로딩해야 LazyInitializationException을 피할 수 있다.
+    @Query("select c from Comment c join fetch c.user where c.id = :id")
+    Optional<Comment> findByIdWithUser(@Param("id") Long id);
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -40,12 +40,13 @@ public class OpinionService {
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
 
-    // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순.
-    public Page<OpinionSummaryProjection> getOpinions(Long passageId, OpinionSortType sortType, Pageable pageable) {
+    // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순. currentUserId는 비로그인 시 null(liked는 항상 false).
+    public Page<OpinionSummaryProjection> getOpinions(
+            Long passageId, OpinionSortType sortType, Pageable pageable, Long currentUserId) {
         if (!passageRepository.existsById(passageId)) {
             throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
         }
-        return opinionQueryRepository.findOpinions(passageId, sortType, pageable);
+        return opinionQueryRepository.findOpinions(passageId, sortType, pageable, currentUserId);
     }
 
     // 흔적 상세(FR-OPINION-05): 이 흔적 작성자가 기록한 꾸밈을 그대로 보여준다.
@@ -69,7 +70,7 @@ public class OpinionService {
     }
 
     private Opinion getExistingOpinion(Long opinionId) {
-        Opinion opinion = opinionRepository.findById(opinionId)
+        Opinion opinion = opinionRepository.findDetailById(opinionId)
                 .orElseThrow(() -> new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
         if (opinion.isDeleted()) {
             throw new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND);

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionSummaryProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionSummaryProjection.java
@@ -8,6 +8,8 @@ public record OpinionSummaryProjection(
         String nickname,
         String content,
         int likeCount,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        boolean liked,
+        long commentCount
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.book.domain.QBook;
+import com.nexters.palang.domain.comment.domain.QComment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
@@ -9,8 +10,11 @@ import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.opinion.domain.QOpinionLike;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.nexters.palang.domain.user.domain.QUser;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +30,30 @@ public class OpinionQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순, 삭제된 흔적 제외.
-    public Page<OpinionSummaryProjection> findOpinions(Long passageId, OpinionSortType sortType, Pageable pageable) {
+    // liked: 현재 로그인 사용자 기준(비로그인이면 false), commentCount: 답글 포함/삭제 댓글 제외.
+    public Page<OpinionSummaryProjection> findOpinions(
+            Long passageId, OpinionSortType sortType, Pageable pageable, Long currentUserId) {
         QOpinion opinion = QOpinion.opinion;
         QUser user = QUser.user;
+        QOpinionLike opinionLike = QOpinionLike.opinionLike;
+        QComment comment = QComment.comment;
+
+        Expression<Boolean> likedExpression = currentUserId != null
+                ? JPAExpressions.selectOne()
+                        .from(opinionLike)
+                        .where(opinionLike.opinion.id.eq(opinion.id), opinionLike.user.id.eq(currentUserId))
+                        .exists()
+                : Expressions.FALSE;
+
+        Expression<Long> commentCountExpression = JPAExpressions
+                .select(comment.count())
+                .from(comment)
+                .where(comment.opinion.id.eq(opinion.id), comment.deletedAt.isNull());
 
         List<OpinionSummaryProjection> content = queryFactory
                 .select(Projections.constructor(OpinionSummaryProjection.class,
-                        opinion.id, user.id, user.nickname, opinion.content, opinion.likeCount, opinion.createdAt))
+                        opinion.id, user.id, user.nickname, opinion.content, opinion.likeCount, opinion.createdAt,
+                        likedExpression, commentCountExpression))
                 .from(opinion)
                 .join(opinion.user, user)
                 .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -1,9 +1,17 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OpinionRepository extends JpaRepository<Opinion, Long> {
 
     long countByUserIdAndDeletedAtIsNull(Long userId);
+
+    // open-in-view: false 환경에서 컨트롤러 단 응답 매핑이 opinion.getUser()/getDecorations()를
+    // 참조하므로 트랜잭션 안에서 미리 로딩해야 LazyInitializationException을 피할 수 있다.
+    @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations where o.id = :id")
+    Optional<Opinion> findDetailById(@Param("id") Long id);
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
@@ -55,8 +55,9 @@ public class OpinionController implements OpinionApi {
             @RequestParam(defaultValue = "LATEST") OpinionSortType sortType,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        return ResponseEntity.ok(DataResponse.from(
-                OpinionListResponse.from(opinionService.getOpinions(passageId, sortType, pageable(page, size)))));
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        return ResponseEntity.ok(DataResponse.from(OpinionListResponse.from(
+                opinionService.getOpinions(passageId, sortType, pageable(page, size), currentUserId))));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/OpinionSummaryResponse.java
@@ -10,7 +10,9 @@ public record OpinionSummaryResponse(
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
         @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
-        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
+        @Schema(example = "true", requiredMode = Schema.RequiredMode.REQUIRED) boolean liked,
+        @Schema(example = "3", requiredMode = Schema.RequiredMode.REQUIRED) long commentCount
 ) {
     public static OpinionSummaryResponse from(OpinionSummaryProjection projection) {
         return new OpinionSummaryResponse(
@@ -19,7 +21,9 @@ public record OpinionSummaryResponse(
                 projection.nickname(),
                 projection.content(),
                 projection.likeCount(),
-                projection.createdAt()
+                projection.createdAt(),
+                projection.liked(),
+                projection.commentCount()
         );
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/application/PageNumbersResult.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PageNumbersResult.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.passage.application;
+
+import com.nexters.palang.domain.book.domain.Book;
+import org.springframework.data.domain.Page;
+
+public record PageNumbersResult(Book book, Page<Integer> pageNumbers) {
+}

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.passage.application;
 
 import com.nexters.palang.domain.book.common.error.BookErrorCode;
 import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.decoration.application.DecorationMergeSelector;
@@ -26,10 +27,12 @@ public class PassageService {
     private final DecorationQueryRepository decorationQueryRepository;
     private final BookRepository bookRepository;
 
-    // 대목/흔적 보기 페이지 네비게이션: 발췌된 페이지 번호 목록 (스포일러 포함).
-    public Page<Integer> getPageNumbers(Long bookId, Pageable pageable) {
-        validateBookExists(bookId);
-        return passageQueryRepository.findPageNumbers(bookId, pageable);
+    // 대목/흔적 보기 페이지 네비게이션: 발췌된 페이지 번호 목록 (스포일러 포함) + 헤더용 책 정보.
+    public PageNumbersResult getPageNumbers(Long bookId, Pageable pageable) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
+        Page<Integer> pageNumbers = passageQueryRepository.findPageNumbers(bookId, pageable);
+        return new PageNumbersResult(book, pageNumbers);
     }
 
     // 대목 전환: 특정 페이지의 대목들과 각 대목의 꾸밈 병합 결과.

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.passage.presentation;
 
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
+import com.nexters.palang.domain.passage.application.PageNumbersResult;
 import com.nexters.palang.domain.passage.application.PassageOcrService;
 import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.passage.application.SimilarPassageFinder;
@@ -16,7 +17,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -66,8 +66,8 @@ public class PassageController implements PassageControllerDocs {
             @PathVariable Long bookId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        Page<Integer> pageNumbers = passageService.getPageNumbers(bookId, pageable(page, size));
-        return DataResponse.from(PassageResponse.PageNumbers.from(pageNumbers));
+        PageNumbersResult result = passageService.getPageNumbers(bookId, pageable(page, size));
+        return DataResponse.from(PassageResponse.PageNumbers.from(result));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.passage.presentation.response;
 
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.opinion.presentation.dto.OpinionResponse.DecorationResponse;
+import com.nexters.palang.domain.passage.application.PageNumbersResult;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.application.dto.OcrResultDto;
 import com.nexters.palang.domain.passage.domain.Passage;
@@ -25,14 +26,20 @@ public class PassageResponse {
         }
     }
 
-    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 발췌된 페이지 번호 목록.
+    // 대목/흔적 보기 페이지 네비게이션(FR-VIEW-02): 발췌된 페이지 번호 목록 + 헤더용 책 정보.
     public record PageNumbers(
+            @Schema(example = "이방인", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+            @Schema(example = "https://example.com/cover.jpg") String coverImageUrl,
             @ArraySchema(schema = @Schema(example = "3"), arraySchema = @Schema(requiredMode = Schema.RequiredMode.REQUIRED))
             List<Integer> pageNumbers,
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
     ) {
-        public static PageNumbers from(Page<Integer> page) {
-            return new PageNumbers(page.getContent(), PageInfo.from(page));
+        public static PageNumbers from(PageNumbersResult result) {
+            return new PageNumbers(
+                    result.book().getTitle(),
+                    result.book().getCoverImageUrl(),
+                    result.pageNumbers().getContent(),
+                    PageInfo.from(result.pageNumbers()));
         }
     }
 

--- a/src/test/java/com/nexters/palang/domain/comment/CommentLazyLoadingIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/CommentLazyLoadingIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.nexters.palang.domain.comment;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
+import com.nexters.palang.domain.comment.presentation.dto.UpdateCommentRequest;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// open-in-view: false 환경에서 컨트롤러 단 Mapper가 lazy user를 참조해 LazyInitializationException(500)이
+// 나던 댓글 목록/답글/작성/수정 경로를, 실제 트랜잭션 경계를 넘는 end-to-end 테스트로 검증한다.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class CommentLazyLoadingIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Long opinionId;
+    private Long authorId;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("프랑켄슈타인").author("메리 셸리").publisher("문학동네").pageCount(300).build());
+        User author = userRepository.save(User.builder()
+                .nickname("작성자").snsProvider(SnsProvider.KAKAO).snsId("author-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        Passage passage = passageRepository.save(Passage.builder()
+                .book(book).creator(author).pageNumber(1).quotedText("문장")
+                .isSpoiler(false).normalizedHash("hash").build());
+        Opinion opinion = opinionRepository.save(Opinion.builder()
+                .passage(passage).user(author).content("흔적 내용").build());
+
+        opinionId = opinion.getId();
+        authorId = author.getId();
+    }
+
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
+    @Test
+    @DisplayName("댓글을 작성하면 닉네임이 포함된 응답이 정상적으로 내려온다")
+    void createCommentReturnsAuthorNickname() throws Exception {
+        CreateCommentRequest request = new CreateCommentRequest(null, "저도 같은 생각이에요!");
+
+        mockMvc.perform(post("/api/opinions/{opinionId}/comments", opinionId)
+                        .header("Authorization", bearerToken(authorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("작성자"))
+                .andExpect(jsonPath("$.data.content").value("저도 같은 생각이에요!"));
+    }
+
+    @Test
+    @DisplayName("원댓글과 답글이 있을 때 목록 조회 응답에 각각의 닉네임이 정상적으로 내려온다")
+    void getCommentsReturnsNicknamesForRootsAndReplies() throws Exception {
+        Comment root = commentRepository.save(
+                Comment.root(opinionRepository.findById(opinionId).orElseThrow(),
+                        userRepository.findById(authorId).orElseThrow(), "원댓글"));
+        commentRepository.save(Comment.reply(root, userRepository.findById(authorId).orElseThrow(), "답글"));
+
+        mockMvc.perform(get("/api/opinions/{opinionId}/comments", opinionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.comments[0].nickname").value("작성자"))
+                .andExpect(jsonPath("$.data.comments[0].replies[0].nickname").value("작성자"));
+
+        mockMvc.perform(get("/api/comments/{commentId}/replies", root.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.comments[0].nickname").value("작성자"));
+    }
+
+    @Test
+    @DisplayName("댓글을 수정하면 닉네임이 포함된 응답이 정상적으로 내려온다")
+    void modifyCommentReturnsAuthorNickname() throws Exception {
+        Comment root = commentRepository.save(
+                Comment.root(opinionRepository.findById(opinionId).orElseThrow(),
+                        userRepository.findById(authorId).orElseThrow(), "원댓글"));
+        UpdateCommentRequest request = new UpdateCommentRequest("다시 읽어보니 더 공감돼요.");
+
+        mockMvc.perform(patch("/api/comments/{commentId}", root.getId())
+                        .header("Authorization", bearerToken(authorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("작성자"))
+                .andExpect(jsonPath("$.data.content").value("다시 읽어보니 더 공감돼요."));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
@@ -139,7 +139,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("존재하지 않는 원댓글의 답글을 조회하면 예외가 발생한다")
     void getRepliesFailsWhenParentCommentNotFound() {
-        given(commentRepository.findById(999L)).willReturn(Optional.empty());
+        given(commentRepository.findByIdWithUser(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentService.getReplies(999L, PageRequest.of(0, 20)))
                 .isInstanceOf(CommentException.class);
@@ -149,7 +149,7 @@ class CommentServiceTest {
     @DisplayName("답글 더보기를 요청하면 해당 원댓글의 답글을 페이지네이션으로 반환한다")
     void getRepliesReturnsPageFromQueryRepository() {
         Comment root = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(root));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(root));
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
         Pageable pageable = PageRequest.of(0, 5);
         Page<Comment> expected = new PageImpl<>(List.of(replyComment(11L, root, writer)), pageable, 1);
@@ -164,7 +164,7 @@ class CommentServiceTest {
     @DisplayName("삭제된 흔적의 답글을 조회하면 예외가 발생한다")
     void getRepliesFailsWhenOpinionDeleted() {
         Comment root = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(root));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(root));
         opinion.delete();
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
 
@@ -176,7 +176,7 @@ class CommentServiceTest {
     @DisplayName("원댓글을 작성하면 부모 댓글 없이 저장된다")
     void createRootComment() {
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(userRepository.getReferenceById(10L)).willReturn(writer);
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
         given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         Comment created = commentService.createComment(1L, 10L, new CreateCommentRequest(null, "내용"));
@@ -200,8 +200,8 @@ class CommentServiceTest {
     void createReplyComment() {
         Comment root = rootComment(1L, opinion, writer);
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(commentRepository.findById(1L)).willReturn(Optional.of(root));
-        given(userRepository.getReferenceById(20L)).willReturn(otherUser);
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(root));
+        given(userRepository.findById(20L)).willReturn(Optional.of(otherUser));
         given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         Comment created = commentService.createComment(1L, 20L, new CreateCommentRequest(1L, "답글 내용"));
@@ -214,7 +214,8 @@ class CommentServiceTest {
     @DisplayName("존재하지 않는 부모 댓글에 답글을 작성하면 예외가 발생한다")
     void createReplyFailsWhenParentNotFound() {
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(commentRepository.findById(999L)).willReturn(Optional.empty());
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
+        given(commentRepository.findByIdWithUser(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentService.createComment(1L, 10L, new CreateCommentRequest(999L, "내용")))
                 .isInstanceOf(CommentException.class);
@@ -226,7 +227,8 @@ class CommentServiceTest {
         Opinion otherOpinion = opinion(2L);
         Comment parentOfOtherOpinion = rootComment(1L, otherOpinion, writer);
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(commentRepository.findById(1L)).willReturn(Optional.of(parentOfOtherOpinion));
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(parentOfOtherOpinion));
 
         assertThatThrownBy(() -> commentService.createComment(1L, 10L, new CreateCommentRequest(1L, "내용")))
                 .isInstanceOf(CommentException.class);
@@ -238,7 +240,8 @@ class CommentServiceTest {
         Comment root = rootComment(1L, opinion, writer);
         root.delete();
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(commentRepository.findById(1L)).willReturn(Optional.of(root));
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(root));
 
         assertThatThrownBy(() -> commentService.createComment(1L, 10L, new CreateCommentRequest(1L, "내용")))
                 .isInstanceOf(CommentException.class);
@@ -250,7 +253,8 @@ class CommentServiceTest {
         Comment root = rootComment(1L, opinion, writer);
         Comment reply = replyComment(2L, root, writer);
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
-        given(commentRepository.findById(2L)).willReturn(Optional.of(reply));
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
+        given(commentRepository.findByIdWithUser(2L)).willReturn(Optional.of(reply));
 
         assertThatThrownBy(() -> commentService.createComment(1L, 10L, new CreateCommentRequest(2L, "내용")))
                 .isInstanceOf(NestedReplyNotAllowedException.class);
@@ -259,7 +263,7 @@ class CommentServiceTest {
     @Test
     @DisplayName("존재하지 않는 댓글을 수정하면 예외가 발생한다")
     void modifyCommentFailsWhenNotFound() {
-        given(commentRepository.findById(999L)).willReturn(Optional.empty());
+        given(commentRepository.findByIdWithUser(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> commentService.modifyComment(999L, 10L, new UpdateCommentRequest("수정")))
                 .isInstanceOf(CommentException.class);
@@ -270,7 +274,7 @@ class CommentServiceTest {
     void modifyCommentFailsWhenAlreadyDeleted() {
         Comment comment = rootComment(1L, opinion, writer);
         comment.delete();
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
 
         assertThatThrownBy(() -> commentService.modifyComment(1L, 10L, new UpdateCommentRequest("수정")))
                 .isInstanceOf(CommentException.class);
@@ -280,7 +284,7 @@ class CommentServiceTest {
     @DisplayName("본인이 작성하지 않은 댓글을 수정하면 예외가 발생한다")
     void modifyCommentFailsWhenNotOwner() {
         Comment comment = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
 
         assertThatThrownBy(() -> commentService.modifyComment(1L, 20L, new UpdateCommentRequest("수정")))
                 .isInstanceOf(CommentException.class);
@@ -290,7 +294,7 @@ class CommentServiceTest {
     @DisplayName("본인이 작성한 댓글을 수정하면 내용이 변경된다")
     void modifyCommentUpdatesContent() {
         Comment comment = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
 
         Comment modified = commentService.modifyComment(1L, 10L, new UpdateCommentRequest("수정된 내용"));
 
@@ -301,7 +305,7 @@ class CommentServiceTest {
     @DisplayName("본인이 작성하지 않은 댓글을 삭제하면 예외가 발생한다")
     void removeCommentFailsWhenNotOwner() {
         Comment comment = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
 
         assertThatThrownBy(() -> commentService.removeComment(1L, 20L)).isInstanceOf(CommentException.class);
     }
@@ -310,7 +314,7 @@ class CommentServiceTest {
     @DisplayName("본인이 작성한 댓글을 삭제하면 소프트 삭제된다")
     void removeCommentSoftDeletesComment() {
         Comment comment = rootComment(1L, opinion, writer);
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
 
         commentService.removeComment(1L, 10L);
 

--- a/src/test/java/com/nexters/palang/domain/opinion/OpinionDetailIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/OpinionDetailIntegrationTest.java
@@ -1,0 +1,111 @@
+package com.nexters.palang.domain.opinion;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// open-in-view: false 환경에서 opinion.getUser()/getDecorations()가 컨트롤러 단 Mapper에서
+// lazy-load되어 LazyInitializationException(500)이 나던 흔적 상세/수정 경로를 검증한다.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class OpinionDetailIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Long opinionId;
+    private Long authorId;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("프랑켄슈타인").author("메리 셸리").publisher("문학동네").pageCount(300).build());
+        User author = userRepository.save(User.builder()
+                .nickname("작성자").snsProvider(SnsProvider.KAKAO).snsId("author-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        Passage passage = passageRepository.save(Passage.builder()
+                .book(book).creator(author).pageNumber(1).quotedText("우리는 모두 이야기를 찾아 헤맨다.")
+                .isSpoiler(false).normalizedHash("hash").build());
+        Opinion opinion = Opinion.builder()
+                .passage(passage).user(author).content("흔적 내용").build();
+        opinion.addDecoration(Decoration.builder()
+                .startOffset(0).endOffset(3).effectType(EffectType.UNDERLINE).color("#PRIMARY").build());
+        opinionRepository.save(opinion);
+
+        opinionId = opinion.getId();
+        authorId = author.getId();
+    }
+
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
+    @Test
+    @DisplayName("꾸밈이 있는 흔적을 상세 조회하면 닉네임과 꾸밈 목록이 정상적으로 내려온다")
+    void getOpinionReturnsNicknameAndDecorations() throws Exception {
+        mockMvc.perform(get("/api/opinions/{opinionId}", opinionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("작성자"))
+                .andExpect(jsonPath("$.data.decorations[0].effectType").value("UNDERLINE"));
+    }
+
+    @Test
+    @DisplayName("꾸밈이 있는 흔적을 수정하면 닉네임과 꾸밈 목록이 정상적으로 내려온다")
+    void modifyOpinionReturnsNicknameAndDecorations() throws Exception {
+        UpdateOpinionRequest request = new UpdateOpinionRequest("다시 읽어보니 더 와닿는 문장이었어요.");
+
+        mockMvc.perform(patch("/api/opinions/{opinionId}", opinionId)
+                        .header("Authorization", bearerToken(authorId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("작성자"))
+                .andExpect(jsonPath("$.data.content").value("다시 읽어보니 더 와닿는 문장이었어요."))
+                .andExpect(jsonPath("$.data.decorations[0].effectType").value("UNDERLINE"));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/OpinionListFieldsIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/OpinionListFieldsIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.nexters.palang.domain.opinion;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionLike;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// 흔적 목록 응답에 추가된 liked(로그인 사용자 기준, 비로그인은 false)와
+// commentCount(답글 포함, 삭제 댓글 제외)를 검증한다.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class OpinionListFieldsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    @Autowired
+    private OpinionLikeRepository opinionLikeRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Long passageId;
+    private Long opinionId;
+    private Long viewerId;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("프랑켄슈타인").author("메리 셸리").publisher("문학동네").pageCount(300).build());
+        User author = userRepository.save(User.builder()
+                .nickname("작성자").snsProvider(SnsProvider.KAKAO).snsId("author-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        User viewer = userRepository.save(User.builder()
+                .nickname("열람자").snsProvider(SnsProvider.KAKAO).snsId("viewer-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        Passage passage = passageRepository.save(Passage.builder()
+                .book(book).creator(author).pageNumber(1).quotedText("문장")
+                .isSpoiler(false).normalizedHash("hash").build());
+        Opinion opinion = opinionRepository.save(Opinion.builder()
+                .passage(passage).user(author).content("흔적 내용").build());
+        opinionLikeRepository.save(OpinionLike.builder().user(viewer).opinion(opinion).build());
+
+        Comment root = commentRepository.save(Comment.root(opinion, author, "원댓글"));
+        commentRepository.save(Comment.reply(root, author, "답글"));
+        Comment deletedRoot = commentRepository.save(Comment.root(opinion, author, "삭제될 댓글"));
+        deletedRoot.delete();
+
+        passageId = passage.getId();
+        opinionId = opinion.getId();
+        viewerId = viewer.getId();
+    }
+
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
+    @Test
+    @DisplayName("좋아요를 누른 로그인 사용자에게는 liked=true, commentCount는 답글 포함/삭제 제외로 내려온다")
+    void loggedInUserSeesLikedTrueAndCorrectCommentCount() throws Exception {
+        mockMvc.perform(get("/api/passages/{passageId}/opinions", passageId)
+                        .header("Authorization", bearerToken(viewerId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(opinionId))
+                .andExpect(jsonPath("$.data.opinions[0].liked").value(true))
+                .andExpect(jsonPath("$.data.opinions[0].commentCount").value(2));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 liked=false로 내려온다")
+    void anonymousUserSeesLikedFalse() throws Exception {
+        mockMvc.perform(get("/api/passages/{passageId}/opinions", passageId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].liked").value(false))
+                .andExpect(jsonPath("$.data.opinions[0].commentCount").value(2));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -154,9 +154,9 @@ class OpinionServiceTest {
         given(passageRepository.existsById(100L)).willReturn(true);
         Pageable pageable = PageRequest.of(0, 20);
 
-        opinionService.getOpinions(100L, OpinionSortType.LATEST, pageable);
+        opinionService.getOpinions(100L, OpinionSortType.LATEST, pageable, 1L);
 
-        verify(opinionQueryRepository).findOpinions(100L, OpinionSortType.LATEST, pageable);
+        verify(opinionQueryRepository).findOpinions(100L, OpinionSortType.LATEST, pageable, 1L);
     }
 
     @Test
@@ -164,7 +164,7 @@ class OpinionServiceTest {
     void getOpinionsThrowsExceptionWhenPassageDoesNotExist() {
         given(passageRepository.existsById(100L)).willReturn(false);
 
-        assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20), 1L))
                 .isInstanceOf(PassageException.class);
     }
 
@@ -172,7 +172,7 @@ class OpinionServiceTest {
     @DisplayName("존재하는 흔적을 조회하면 해당 흔적을 반환한다")
     void getOpinionReturnsExistingOpinion() {
         Opinion opinion = opinionOwnedBy(1L, 1L);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         Opinion result = opinionService.getOpinion(1L);
 
@@ -184,7 +184,7 @@ class OpinionServiceTest {
     void getOpinionThrowsExceptionWhenOpinionIsDeleted() {
         Opinion opinion = opinionOwnedBy(1L, 1L);
         opinion.delete();
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         assertThatThrownBy(() -> opinionService.getOpinion(1L))
                 .isInstanceOf(OpinionException.class);
@@ -194,7 +194,7 @@ class OpinionServiceTest {
     @DisplayName("본인이 작성한 흔적을 수정하면 내용이 변경된다")
     void modifyOpinionUpdatesContentWhenOwner() {
         Opinion opinion = opinionOwnedBy(1L, 10L);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         Opinion result = opinionService.modifyOpinion(1L, 10L, new UpdateOpinionRequest("수정된 내용"));
 
@@ -205,7 +205,7 @@ class OpinionServiceTest {
     @DisplayName("본인이 아닌 사용자가 흔적을 수정하려 하면 예외가 발생한다")
     void modifyOpinionThrowsExceptionWhenNotOwner() {
         Opinion opinion = opinionOwnedBy(1L, 10L);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         assertThatThrownBy(() -> opinionService.modifyOpinion(1L, 999L, new UpdateOpinionRequest("수정된 내용")))
                 .isInstanceOf(OpinionException.class);
@@ -215,7 +215,7 @@ class OpinionServiceTest {
     @DisplayName("본인이 작성한 흔적을 삭제하면 소프트 삭제된다")
     void removeOpinionDeletesWhenOwner() {
         Opinion opinion = opinionOwnedBy(1L, 10L);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         opinionService.removeOpinion(1L, 10L);
 
@@ -226,7 +226,7 @@ class OpinionServiceTest {
     @DisplayName("본인이 아닌 사용자가 흔적을 삭제하려 하면 예외가 발생한다")
     void removeOpinionThrowsExceptionWhenNotOwner() {
         Opinion opinion = opinionOwnedBy(1L, 10L);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
         assertThatThrownBy(() -> opinionService.removeOpinion(1L, 999L))
                 .isInstanceOf(OpinionException.class);

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.opinion.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionSummaryProjection;
@@ -91,7 +92,7 @@ class OpinionQueryRepositoryTest {
         Opinion popular = opinion(passage, writer, "많은 좋아요", 10);
 
         Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
-                passage.getId(), OpinionSortType.LIKES, PageRequest.of(0, 10));
+                passage.getId(), OpinionSortType.LIKES, PageRequest.of(0, 10), null);
 
         assertThat(result.getContent().get(0).opinionId()).isEqualTo(popular.getId());
     }
@@ -105,7 +106,7 @@ class OpinionQueryRepositoryTest {
         Opinion later = opinion(passage, writer, "나중에 작성", 1);
 
         Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
-                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
 
         assertThat(result.getContent().get(0).opinionId()).isEqualTo(later.getId());
     }
@@ -121,7 +122,7 @@ class OpinionQueryRepositoryTest {
         entityManager.persistAndFlush(deleted);
 
         Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
-                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
 
         assertThat(result.getContent()).extracting(OpinionSummaryProjection::opinionId)
                 .containsExactly(active.getId());
@@ -135,9 +136,47 @@ class OpinionQueryRepositoryTest {
         opinion(passage, writer, "흔적 내용", 0);
 
         Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
-                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10));
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
 
         assertThat(result.getContent().get(0).nickname()).isEqualTo(writer.getNickname());
+    }
+
+    @Test
+    @DisplayName("currentUserId가 좋아요를 눌렀으면 liked=true, 비로그인(null)이면 liked=false를 반환한다")
+    void findOpinionsReflectsLikedForCurrentUser() {
+        User writer = user("writer-5");
+        Passage passage = passage(writer);
+        Opinion opinion = opinion(passage, writer, "흔적 내용", 0);
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(opinion).build());
+
+        Page<OpinionSummaryProjection> likedResult = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), me.getId());
+        Page<OpinionSummaryProjection> anonymousResult = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
+        Page<OpinionSummaryProjection> otherResult = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), other.getId());
+
+        assertThat(likedResult.getContent().get(0).liked()).isTrue();
+        assertThat(anonymousResult.getContent().get(0).liked()).isFalse();
+        assertThat(otherResult.getContent().get(0).liked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("commentCount는 답글을 포함하고 삭제된 댓글은 제외한다")
+    void findOpinionsCountsCommentsIncludingRepliesExcludingDeleted() {
+        User writer = user("writer-6");
+        Passage passage = passage(writer);
+        Opinion opinion = opinion(passage, writer, "흔적 내용", 0);
+        Comment root = entityManager.persistAndFlush(Comment.root(opinion, writer, "원댓글"));
+        entityManager.persistAndFlush(Comment.reply(root, writer, "답글"));
+        Comment deletedRoot = entityManager.persistAndFlush(Comment.root(opinion, writer, "삭제될 댓글"));
+        deletedRoot.delete();
+        entityManager.persistAndFlush(deletedRoot);
+
+        Page<OpinionSummaryProjection> result = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
+
+        assertThat(result.getContent().get(0).commentCount()).isEqualTo(2L);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -130,8 +130,9 @@ class OpinionControllerTest {
     @Test
     @DisplayName("흔적 목록을 조회하면 정렬된 목록을 반환한다")
     void getOpinions() throws Exception {
-        OpinionSummaryProjection projection = new OpinionSummaryProjection(1L, 2L, "닉네임", "흔적 내용", 3, LocalDateTime.now());
-        given(opinionService.getOpinions(any(), any(), any()))
+        OpinionSummaryProjection projection =
+                new OpinionSummaryProjection(1L, 2L, "닉네임", "흔적 내용", 3, LocalDateTime.now(), false, 0L);
+        given(opinionService.getOpinions(any(), any(), any(), any()))
                 .willReturn(new PageImpl<>(List.of(projection), PageRequest.of(0, 20), 1));
 
         mockMvc.perform(get("/api/passages/100/opinions"))

--- a/src/test/java/com/nexters/palang/domain/passage/PassagePageNumbersBookInfoIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/PassagePageNumbersBookInfoIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.nexters.palang.domain.passage;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// 대목 페이지 목록(GET /api/books/{bookId}/passages) 응답에 헤더용 책 정보(bookTitle/coverImageUrl)가
+// 포함되는지, 존재하지 않는 책이면 404가 나는지 검증한다.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class PassagePageNumbersBookInfoIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    private Long bookId;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("프랑켄슈타인").author("메리 셸리").publisher("문학동네").pageCount(300)
+                .coverImageUrl("https://example.com/cover.jpg").build());
+        User creator = userRepository.save(User.builder()
+                .nickname("작성자").snsProvider(SnsProvider.KAKAO).snsId("author-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        passageRepository.save(Passage.builder()
+                .book(book).creator(creator).pageNumber(87).quotedText("우리는 모두 이야기를 찾아 헤맨다.")
+                .isSpoiler(false).normalizedHash("hash").build());
+
+        bookId = book.getId();
+    }
+
+    @Test
+    @DisplayName("대목 페이지 목록 조회 응답에 책 제목/커버 이미지가 포함된다")
+    void getPageNumbersReturnsBookInfo() throws Exception {
+        mockMvc.perform(get("/api/books/{bookId}/passages", bookId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"))
+                .andExpect(jsonPath("$.data.coverImageUrl").value("https://example.com/cover.jpg"))
+                .andExpect(jsonPath("$.data.pageNumbers[0]").value(87));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 책이면 404 에러가 발생한다")
+    void getPageNumbersFailsWhenBookNotFound() throws Exception {
+        mockMvc.perform(get("/api/books/{bookId}/passages", 999999L))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -14,6 +14,7 @@ import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,7 +52,7 @@ class PassageServiceTest {
     @Test
     @DisplayName("존재하지 않는 도서로 페이지 번호를 조회하면 예외가 발생한다")
     void getPageNumbersThrowsExceptionWhenBookDoesNotExist() {
-        given(bookRepository.existsById(1L)).willReturn(false);
+        given(bookRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> passageService.getPageNumbers(1L, PageRequest.of(0, 20)))
                 .isInstanceOf(BookException.class);

--- a/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.passage.application.PageNumbersResult;
 import com.nexters.palang.domain.passage.application.PassageOcrService;
 import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.passage.application.SimilarPassageFinder;
@@ -117,14 +119,22 @@ class PassageControllerTest {
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
     }
 
+    private Book book() {
+        return Book.builder()
+                .title("제목").author("작가").publisher("출판사").pageCount(300)
+                .coverImageUrl("https://example.com/cover.jpg").build();
+    }
+
     @Test
-    @DisplayName("페이지 번호 목록을 조회하면 오름차순으로 반환한다")
+    @DisplayName("페이지 번호 목록을 조회하면 오름차순으로, 책 정보와 함께 반환한다")
     void getPageNumbers() throws Exception {
-        given(passageService.getPageNumbers(any(), any()))
-                .willReturn(new PageImpl<>(List.of(2, 5), PageRequest.of(0, 20), 2));
+        given(passageService.getPageNumbers(any(), any())).willReturn(new PageNumbersResult(
+                book(), new PageImpl<>(List.of(2, 5), PageRequest.of(0, 20), 2)));
 
         mockMvc.perform(get("/api/books/1/passages"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookTitle").value("제목"))
+                .andExpect(jsonPath("$.data.coverImageUrl").value("https://example.com/cover.jpg"))
                 .andExpect(jsonPath("$.data.pageNumbers[0]").value(2))
                 .andExpect(jsonPath("$.data.pageNumbers[1]").value(5));
     }
@@ -132,8 +142,8 @@ class PassageControllerTest {
     @Test
     @DisplayName("비로그인 사용자로 페이지 번호를 조회해도 401 없이 조회된다 (soft auth)")
     void getPageNumbersDoesNotRequireAuthentication() throws Exception {
-        given(passageService.getPageNumbers(any(), any()))
-                .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+        given(passageService.getPageNumbers(any(), any())).willReturn(new PageNumbersResult(
+                book(), new PageImpl<>(List.of(), PageRequest.of(0, 20), 0)));
 
         mockMvc.perform(get("/api/books/1/passages"))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 📌 관련 이슈
- Close #64

## 🚀 개요
흔적 목록 화면 관련 API에서 발생하던 `LazyInitializationException` 500 오류를 전부 제거하고, FE가 흔적 목록 화면 구현에 필요하다고 요청한 응답 필드(책 정보, `liked`, `commentCount`)를 추가한다.

## 📄 작업 내용
- **[fix]** 댓글 목록/답글 미리보기/답글 더보기 조회에 `comment.user` fetch join 추가 (원 신고 건: `GET /api/opinions/{id}/comments` 500)
- **[fix]** `CommentService.createComment`의 `userRepository.getReferenceById` → `findById`로 교체 (댓글 작성 시 항상 500 나던 버그)
- **[fix]** 댓글 단건 조회(수정/삭제 경로)에 `CommentRepository.findByIdWithUser` fetch join 쿼리 신설
- **[fix]** 흔적 단건 조회(상세/수정/삭제 경로)에 `OpinionRepository.findDetailById`(`user`+`decorations` fetch join) 쿼리 신설
- **[feat]** `GET /api/books/{bookId}/passages` 응답에 `bookTitle`, `coverImageUrl` 추가
- **[feat]** `GET /api/passages/{passageId}/opinions` 응답에 `liked`(비로그인 시 false), `commentCount`(답글 포함, 삭제 댓글 제외) 추가
- 위 변경사항에 대한 통합 테스트 4건 신규 작성, 기존 단위/슬라이스 테스트 시그니처 반영

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과 (298개)
- 로컬 서버 기동 후 실제 데이터(책 → 흔적 → 댓글 → 좋아요)를 만들어 curl로 확인:
  - `GET /api/opinions/{id}/comments` → 200, 닉네임 정상 포함 (원래 500)
  - `GET /api/opinions/{id}` → 200, 닉네임 + 꾸밈 정상 포함
  - `GET /api/books/{id}/passages` → 200, `bookTitle`/`coverImageUrl` 포함
  - `GET /api/passages/{id}/opinions` → 로그인 시 `liked: true`, 비로그인 시 `liked: false`, `commentCount` 정상

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `commentCount`를 답글 포함/삭제 댓글 제외로 정의했습니다. FE 요구사항에서 답글 포함 여부는 서버 결정에 맞추기로 했는데, 이 기준이 맞는지 확인 부탁드립니다.
- 동일한 lazy-loading 패턴이 이번에 발견된 5곳 외에 더 없는지 전체 점검했지만, 향후 새로운 QueryDSL/JPA 조회 코드를 추가할 때도 `open-in-view: false` 환경에서 컨트롤러 단 Mapper가 엔티티의 lazy 연관관계를 참조하지 않는지 리뷰 시 체크가 필요해 보입니다.
- 책 단건 조회 API(`GET /api/books/{bookId}`)는 신설하지 않고 대목 목록 API에 필드를 얹는 방식으로 처리했는데, 이 방향이 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 의견 목록에 현재 사용자의 좋아요 여부와 댓글 수가 표시됩니다.
  * 페이지 번호 조회 시 책 제목과 표지 이미지가 함께 제공됩니다.

* **버그 수정**
  * 댓글 및 의견 상세·수정 조회에서 작성자와 관련 정보가 안정적으로 표시됩니다.
  * 존재하지 않는 사용자·도서 요청이 명확한 오류로 처리됩니다.

* **테스트**
  * 비로그인 상태의 의견 목록과 댓글 수, 상세 조회 응답에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->