### PR TITLE
🐛 fix: 알라딘 도서 검색 API에 Cover=Big 파라미터 추가하여 커버 이미지 화질 개선

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
@@ -44,6 +44,7 @@ public class AladinBookApiClient {
                             .queryParam("MaxResults", maxResults)
                             .queryParam("start", start)
                             .queryParam("SearchTarget", "Book")
+                            .queryParam("Cover", "Big")
                             .queryParam("output", "js")
                             .queryParam("Version", VERSION)
                             .build())

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
@@ -107,4 +107,16 @@ class AladinBookApiClientTest {
         String query = requestCaptor.getValue().url().getQuery();
         assertThat(query).contains("start=6").contains("MaxResults=5");
     }
+
+    @Test
+    @DisplayName("고화질 커버 이미지를 받기 위해 Cover=Big 파라미터를 함께 요청한다")
+    void searchRequestsBigCoverImage() {
+        ArgumentCaptor<ClientRequest> requestCaptor = ArgumentCaptor.forClass(ClientRequest.class);
+        given(exchangeFunction.exchange(requestCaptor.capture())).willReturn(Mono.just(jsonResponse("{}")));
+
+        aladinBookApiClient().search("프랑켄슈타인", PageRequest.of(0, 20));
+
+        String query = requestCaptor.getValue().url().getQuery();
+        assertThat(query).contains("Cover=Big");
+    }
 }


### PR DESCRIPTION
## Summary
- 프론트에서 도서 커버 이미지 화질이 낮다는 피드백을 받아, 알라딘 ItemSearch 요청에 `Cover=Big` 파라미터를 추가하여 알라딘이 제공하는 가장 큰 사이즈의 커버 이미지 URL을 받도록 수정
- 기존에는 Cover 파라미터를 지정하지 않아 알라딘 기본값(Mid, 소형 썸네일)이 내려오고 있었음

## Test plan
- [x] `AladinBookApiClientTest` 신규 테스트(`searchRequestsBigCoverImage`)로 요청 쿼리에 `Cover=Big`이 포함되는지 검증
- [x] 기존 테스트 전체 통과 확인

closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 도서 검색 결과에서 더 큰 크기의 표지 이미지가 제공되도록 개선했습니다.

* **테스트**
  * 검색 요청에 큰 표지 이미지 옵션이 포함되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->