### PR TITLE
Feat/#69 책 표지/프로필 이미지 직접 업로드

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ WORKDIR /app
 
 RUN addgroup --system pallang && adduser --system --ingroup pallang pallang
 COPY --from=builder /workspace/build/libs/*.jar app.jar
-RUN chown pallang:pallang app.jar
+# uploads-data 볼륨이 마운트될 경로. 이미지에 먼저 만들어 소유권을 넘겨둬야
+# named volume이 최초 생성될 때 이 소유권/권한을 그대로 물려받아 pallang 사용자가 쓸 수 있다.
+RUN mkdir -p uploads && chown -R pallang:pallang app.jar uploads
 USER pallang
 
 ENV SPRING_PROFILES_ACTIVE=prod

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -22,3 +22,7 @@ ALADIN_TTB_KEY=
 # ---- 네이버 클로바 OCR ----
 CLOVA_OCR_INVOKE_URL=
 CLOVA_OCR_SECRET_KEY=
+
+# ---- 이미지 업로드 저장 경로 (가비아 상용 클라우드에는 오브젝트 스토리지가 없어 서버 디스크에 저장) ----
+# docker-compose의 uploads-data 볼륨과 맞춘 컨테이너 내부 경로. 보통 바꿀 필요 없음.
+IMAGE_UPLOAD_DIR=/app/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,14 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}
+      IMAGE_UPLOAD_DIR: ${IMAGE_UPLOAD_DIR:-/app/uploads}
     # deploy/nginx/pallang.conf.template의 upstream이 127.0.0.1:8080을 하드코딩하고 있으므로
     # 호스트 포트를 가변으로 두지 않는다 (바꾸려면 이 파일과 nginx 템플릿을 함께 수정할 것).
     ports:
       - "127.0.0.1:8080:8080"
+    volumes:
+      # 업로드된 이미지(책 표지, 프로필)를 컨테이너 재배포 후에도 유지한다.
+      - uploads-data:/app/uploads
     depends_on:
       mysql:
         condition: service_healthy
@@ -81,6 +85,7 @@ services:
 volumes:
   mysql-data:
   redis-data:
+  uploads-data:
 
 networks:
   pallang-net:

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -1,11 +1,15 @@
 package com.nexters.palang.domain.book.application;
 
+import com.nexters.palang.domain.book.common.error.BookErrorCode;
+import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
 import com.nexters.palang.domain.book.infrastructure.BookQueryRepository;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.book.presentation.dto.CreateBookRequest;
+import com.nexters.palang.global.storage.FileStorageService;
+import com.nexters.palang.global.storage.ImageMimeType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,15 +21,19 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BookService {
 
+    private static final String COVER_IMAGE_SUB_DIRECTORY = "book-covers";
+
     private final BookRepository bookRepository;
     private final BookQueryRepository bookQueryRepository;
     private final AladinBookApiClient aladinBookApiClient;
+    private final FileStorageService fileStorageService;
 
     // DB를 사용하지 않고 알라딘 API 호출(최대 수 초)만 하므로, DB 커넥션을 불필요하게 오래 붙잡지 않도록 트랜잭션에서 제외한다.
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
@@ -38,17 +46,27 @@ public class BookService {
     }
 
     @Transactional
-    public Book createBook(CreateBookRequest request) {
+    public Book createBook(CreateBookRequest request, MultipartFile coverImage) {
+        String coverImageUrl = coverImage != null && !coverImage.isEmpty()
+                ? storeCoverImage(coverImage)
+                : null;
         Book book = Book.builder()
                 .title(request.title())
                 .author(request.author())
                 .publisher(request.publisher())
                 .pageCount(request.pageCount())
                 .isbn(request.isbn())
-                .coverImageUrl(request.coverImageUrl())
+                .coverImageUrl(coverImageUrl)
                 .source(BookSource.MANUAL)
                 .build();
         return bookRepository.save(book);
+    }
+
+    private String storeCoverImage(MultipartFile coverImage) {
+        if (ImageMimeType.from(coverImage.getContentType()).isEmpty()) {
+            throw new BookException(BookErrorCode.INVALID_IMAGE_FILE);
+        }
+        return fileStorageService.store(coverImage, COVER_IMAGE_SUB_DIRECTORY);
     }
 
     // offset을 지정하지 않으면 전체 목록 중 가운데 책들을 반환한다. 좌우 스크롤 시에는 이전/다음 offset을 그대로 넘기면 된다.

--- a/src/main/java/com/nexters/palang/domain/book/common/error/BookErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/book/common/error/BookErrorCode.java
@@ -12,6 +12,7 @@ public enum BookErrorCode implements BaseErrorCode {
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_404_1", "해당 도서를 찾을 수 없습니다."),
     EXTERNAL_SEARCH_FAILED(HttpStatus.BAD_REQUEST, "BOOK_400_1", "외부 도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요."),
     INVALID_CURRENT_PAGE(HttpStatus.BAD_REQUEST, "BOOK_400_2", "현재 페이지는 도서의 전체 페이지 수를 초과할 수 없습니다."),
+    INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "BOOK_400_3", "이미지 파일만 업로드할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -12,12 +12,15 @@ import com.nexters.palang.global.common.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Book", description = "도서 API")
 public interface BookApi {
@@ -51,14 +54,25 @@ public interface BookApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "도서 직접 등록", description = "검색 결과에 없는 도서를 직접 등록합니다. 인증 불필요.")
+    @Operation(summary = "도서 직접 등록", description = "검색 결과에 없는 도서를 직접 등록합니다. 인증 불필요. "
+            + "multipart/form-data로 요청하며, coverImage는 선택 항목입니다.")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    // book 파트는 JSON 객체다. springdoc이 encoding을 자동으로 채워주지 않아
+                    // 명시하지 않으면 Swagger UI가 application/octet-stream으로 보내 400/415가 난다.
+                    encoding = @Encoding(name = "book", contentType = MediaType.APPLICATION_JSON_VALUE)
+            )
+    )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "등록 성공"),
-            @ApiResponse(responseCode = "400", description = "필수값 누락 또는 페이지수가 1 미만 (COMMON_400_1)",
+            @ApiResponse(responseCode = "400", description = "필수값 누락, 페이지수가 1 미만 (COMMON_400_1) "
+                    + "또는 이미지 파일이 아님 (BOOK_400_3)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookResponse>> createBook(
-            @Valid CreateBookRequest request
+            @Valid CreateBookRequest request,
+            @Parameter(description = "책 표지 이미지 파일 (jpeg/png, 선택)") MultipartFile coverImage
     );
 
     @Operation(summary = "홈 캐러셀 도서 목록",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -16,12 +16,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -55,9 +57,11 @@ public class BookController implements BookApi {
     }
 
     @Override
-    @PostMapping("/api/books")
-    public ResponseEntity<DataResponse<BookResponse>> createBook(@RequestBody @Valid CreateBookRequest request) {
-        Book book = bookService.createBook(request);
+    @PostMapping(path = "/api/books", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DataResponse<BookResponse>> createBook(
+            @RequestPart("book") @Valid CreateBookRequest request,
+            @RequestPart(value = "coverImage", required = false) MultipartFile coverImage) {
+        Book book = bookService.createBook(request, coverImage);
         return ResponseEntity.ok(DataResponse.from(BookMapper.toResponse(book)));
     }
 

--- a/src/main/java/com/nexters/palang/domain/book/presentation/dto/CreateBookRequest.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/dto/CreateBookRequest.java
@@ -9,7 +9,6 @@ public record CreateBookRequest(
         @NotBlank(message = "지은이는 필수입니다.") @Schema(example = "한강") String author,
         @NotBlank(message = "출판사는 필수입니다.") @Schema(example = "창비") String publisher,
         @Positive(message = "페이지수는 1 이상이어야 합니다.") @Schema(example = "268") int pageCount,
-        @Schema(example = "9788936434120") String isbn,
-        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg") String coverImageUrl
+        @Schema(example = "9788936434120") String isbn
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/application/UserService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserService.java
@@ -4,16 +4,22 @@ import com.nexters.palang.domain.user.common.error.UserErrorCode;
 import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.storage.FileStorageService;
+import com.nexters.palang.global.storage.ImageMimeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
 
+    private static final String PROFILE_IMAGE_SUB_DIRECTORY = "profile-images";
+
     private final UserRepository userRepository;
+    private final FileStorageService fileStorageService;
 
     public User getMe(Long userId) {
         return getActiveUser(userId);
@@ -33,6 +39,17 @@ public class UserService {
     public User modifyBackgroundColor(Long userId, String backgroundColor) {
         User user = getActiveUser(userId);
         user.changeBackgroundColor(backgroundColor);
+        return user;
+    }
+
+    @Transactional
+    public User modifyProfileImage(Long userId, MultipartFile image) {
+        if (ImageMimeType.from(image.getContentType()).isEmpty()) {
+            throw new UserException(UserErrorCode.INVALID_IMAGE_FILE);
+        }
+        User user = getActiveUser(userId);
+        String profileImageUrl = fileStorageService.store(image, PROFILE_IMAGE_SUB_DIRECTORY);
+        user.changeProfileImage(profileImageUrl);
         return user;
     }
 

--- a/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/user/common/error/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements BaseErrorCode {
     NICKNAME_CHANGE_LIMITED(HttpStatus.BAD_REQUEST, "USER_400_1", "닉네임은 하루에 한 번만 변경할 수 있습니다."),
     NICKNAME_ALREADY_IN_USE(HttpStatus.CONFLICT, "USER_409_1", "이미 사용 중인 닉네임입니다."),
     NICKNAME_GENERATION_FAILED(HttpStatus.CONFLICT, "USER_409_2", "닉네임 자동 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
+    INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "USER_400_2", "이미지 파일만 업로드할 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -114,6 +114,10 @@ public class User extends BaseEntity {
         this.backgroundColor = backgroundColor;
     }
 
+    public void changeProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void withdraw() {
         this.isWithdrawn = true;
         this.withdrawnAt = LocalDateTime.now();

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User", description = "마이페이지 API")
 public interface UserApi {
@@ -84,6 +85,27 @@ public interface UserApi {
                                     + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<MeResponse>> modifyBackgroundColor(@Valid UpdateBackgroundColorRequest request);
+
+    @Operation(summary = "프로필 이미지 변경", description = "프로필 이미지를 업로드하여 변경합니다(jpeg/png). "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "이미지 파일이 아님 (USER_400_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/profile-image\",\"title\":\"USER_400_2\","
+                                    + "\"status\":400,\"detail\":\"이미지 파일만 업로드할 수 있습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/profile-image\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음 (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/profile-image\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MeResponse>> modifyProfileImage(
+            @Parameter(description = "프로필 이미지 파일 (jpeg/png)", required = true) MultipartFile image
+    );
 
     @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
             + "공개된 발췌·의견·댓글은 남습니다). Authorization: Bearer {accessToken} 헤더로 인증합니다.")

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -16,13 +16,16 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -58,6 +61,15 @@ public class UserController implements UserApi {
             @RequestBody @Valid UpdateBackgroundColorRequest request) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         User user = userService.modifyBackgroundColor(currentUserId, request.backgroundColor());
+        return ResponseEntity.ok(DataResponse.from(toMeResponse(currentUserId, user)));
+    }
+
+    @Override
+    @PatchMapping(path = "/api/users/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DataResponse<MeResponse>> modifyProfileImage(
+            @RequestPart("image") MultipartFile image) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        User user = userService.modifyProfileImage(currentUserId, image);
         return ResponseEntity.ok(DataResponse.from(toMeResponse(currentUserId, user)));
     }
 

--- a/src/main/java/com/nexters/palang/global/config/WebStorageConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/WebStorageConfig.java
@@ -1,0 +1,30 @@
+package com.nexters.palang.global.config;
+
+import java.nio.file.Path;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+// 업로드된 이미지(book-covers, profile-images 등)를 정적 리소스로 서빙한다.
+// nginx는 전체 트래픽을 앱으로 프록시하므로 별도 nginx 설정 없이 이 핸들러가 처리한다.
+@Configuration
+public class WebStorageConfig implements WebMvcConfigurer {
+
+    private final String uploadDir;
+    private final String baseUrl;
+
+    public WebStorageConfig(
+            @Value("${storage.upload-dir}") String uploadDir,
+            @Value("${storage.base-url}") String baseUrl) {
+        this.uploadDir = uploadDir;
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String location = Path.of(uploadDir).toAbsolutePath().normalize() + "/";
+        registry.addResourceHandler(baseUrl + "/**")
+                .addResourceLocations("file:" + location);
+    }
+}

--- a/src/main/java/com/nexters/palang/global/storage/FileStorageService.java
+++ b/src/main/java/com/nexters/palang/global/storage/FileStorageService.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.global.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+
+    // 파일을 저장하고, 외부에서 접근 가능한 공개 URL을 반환합니다.
+    String store(MultipartFile file, String subDirectory);
+}

--- a/src/main/java/com/nexters/palang/global/storage/ImageMimeType.java
+++ b/src/main/java/com/nexters/palang/global/storage/ImageMimeType.java
@@ -1,0 +1,31 @@
+package com.nexters.palang.global.storage;
+
+import java.util.Arrays;
+import java.util.Optional;
+import org.springframework.http.MediaType;
+
+// 이미지 업로드를 지원하는 도메인(Book, User 등)에서 공통으로 쓰는 콘텐츠 타입 검증/확장자 매핑입니다.
+public enum ImageMimeType {
+
+    JPEG(MediaType.IMAGE_JPEG_VALUE, "jpg"),
+    PNG(MediaType.IMAGE_PNG_VALUE, "png"),
+    ;
+
+    private final String contentType;
+    private final String extension;
+
+    ImageMimeType(String contentType, String extension) {
+        this.contentType = contentType;
+        this.extension = extension;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    public static Optional<ImageMimeType> from(String contentType) {
+        return Arrays.stream(values())
+                .filter(type -> type.contentType.equals(contentType))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/nexters/palang/global/storage/LocalFileStorageService.java
+++ b/src/main/java/com/nexters/palang/global/storage/LocalFileStorageService.java
@@ -1,0 +1,42 @@
+package com.nexters.palang.global.storage;
+
+import com.nexters.palang.global.common.error.AppException;
+import com.nexters.palang.global.common.error.GlobalErrorCode;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class LocalFileStorageService implements FileStorageService {
+
+    private final Path uploadDir;
+    private final String baseUrl;
+
+    public LocalFileStorageService(
+            @Value("${storage.upload-dir}") String uploadDir,
+            @Value("${storage.base-url}") String baseUrl) {
+        this.uploadDir = Path.of(uploadDir).toAbsolutePath().normalize();
+        this.baseUrl = baseUrl;
+    }
+
+    @Override
+    public String store(MultipartFile file, String subDirectory) {
+        ImageMimeType mimeType = ImageMimeType.from(file.getContentType())
+                .orElseThrow(() -> new AppException(GlobalErrorCode.INVALID_INPUT_VALUE));
+        String filename = UUID.randomUUID() + "." + mimeType.extension();
+
+        try {
+            Path targetDir = uploadDir.resolve(subDirectory).normalize();
+            Files.createDirectories(targetDir);
+            file.transferTo(targetDir.resolve(filename));
+        } catch (IOException e) {
+            throw new AppException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return baseUrl + "/" + subDirectory + "/" + filename;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,3 +18,9 @@ jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-please-change-this-01234567890123456789}
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
   refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
+
+# 이미지 업로드 저장 경로. 가비아 상용 클라우드에는 오브젝트 스토리지 상품이 없어
+# 서버(Docker volume)에 직접 저장하고 /images/** 경로로 서빙한다.
+storage:
+  upload-dir: ${IMAGE_UPLOAD_DIR:./uploads}
+  base-url: /images

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -10,7 +10,9 @@ import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
 import com.nexters.palang.domain.book.infrastructure.BookQueryRepository;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.presentation.dto.CreateBookRequest;
+import com.nexters.palang.global.storage.FileStorageService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,11 +40,14 @@ class BookServiceTest {
     @Mock
     private AladinBookApiClient aladinBookApiClient;
 
+    @Mock
+    private FileStorageService fileStorageService;
+
     private BookService bookService;
 
     @BeforeEach
     void setUp() {
-        bookService = new BookService(bookRepository, bookQueryRepository, aladinBookApiClient);
+        bookService = new BookService(bookRepository, bookQueryRepository, aladinBookApiClient, fileStorageService);
     }
 
     private Book book(Long id, String title) {
@@ -84,17 +90,41 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("도서를 직접 등록하면 출처가 MANUAL인 도서로 저장된다")
+    @DisplayName("표지 이미지 없이 도서를 직접 등록하면 출처가 MANUAL이고 coverImageUrl은 null이다")
     void createBook() {
-        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn", "cover");
+        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn");
         given(bookRepository.save(any(Book.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        Book created = bookService.createBook(request);
+        Book created = bookService.createBook(request, null);
 
         ArgumentCaptor<Book> captor = ArgumentCaptor.forClass(Book.class);
         verify(bookRepository).save(captor.capture());
         assertThat(captor.getValue().getSource()).isEqualTo(BookSource.MANUAL);
         assertThat(created.getTitle()).isEqualTo("제목");
+        assertThat(created.getCoverImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("표지 이미지를 함께 등록하면 저장소에 업로드하고 반환된 URL을 coverImageUrl로 저장한다")
+    void createBookWithCoverImage() {
+        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn");
+        MockMultipartFile coverImage = new MockMultipartFile("coverImage", "cover.jpg", "image/jpeg", "data".getBytes());
+        given(fileStorageService.store(coverImage, "book-covers")).willReturn("https://storage.example.com/book-covers/uuid.jpg");
+        given(bookRepository.save(any(Book.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        Book created = bookService.createBook(request, coverImage);
+
+        assertThat(created.getCoverImageUrl()).isEqualTo("https://storage.example.com/book-covers/uuid.jpg");
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일을 표지로 올리면 예외가 발생한다")
+    void createBookWithInvalidImageFileThrows() {
+        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn");
+        MockMultipartFile invalidFile = new MockMultipartFile("coverImage", "cover.txt", "text/plain", "data".getBytes());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> bookService.createBook(request, invalidFile))
+                .isInstanceOf(BookException.class);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,7 +33,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -116,12 +116,27 @@ class BookControllerTest {
     @Test
     @DisplayName("필수 항목을 채워 도서를 직접 등록하면 등록된 도서를 반환한다")
     void createBook() throws Exception {
-        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn", "cover");
-        given(bookService.createBook(any())).willReturn(book(1L, "제목"));
+        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn");
+        MockMultipartFile bookPart = new MockMultipartFile(
+                "book", "book", "application/json", objectMapper.writeValueAsString(request).getBytes());
+        given(bookService.createBook(any(), any())).willReturn(book(1L, "제목"));
 
-        mockMvc.perform(post("/api/books")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(multipart("/api/books").file(bookPart))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookId").value(1));
+    }
+
+    @Test
+    @DisplayName("표지 이미지와 함께 도서를 직접 등록하면 등록된 도서를 반환한다")
+    void createBookWithCoverImage() throws Exception {
+        CreateBookRequest request = new CreateBookRequest("제목", "작가", "출판사", 300, "isbn");
+        MockMultipartFile bookPart = new MockMultipartFile(
+                "book", "book", "application/json", objectMapper.writeValueAsString(request).getBytes());
+        MockMultipartFile coverImagePart = new MockMultipartFile(
+                "coverImage", "cover.jpg", "image/jpeg", "image-bytes".getBytes());
+        given(bookService.createBook(any(), any())).willReturn(book(1L, "제목"));
+
+        mockMvc.perform(multipart("/api/books").file(bookPart).file(coverImagePart))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.bookId").value(1));
     }
@@ -129,11 +144,11 @@ class BookControllerTest {
     @Test
     @DisplayName("필수 항목이 비어 있는 상태로 도서 등록을 요청하면 400 에러가 발생한다")
     void createBookFailsWhenRequiredFieldIsBlank() throws Exception {
-        CreateBookRequest request = new CreateBookRequest("", "작가", "출판사", 300, null, null);
+        CreateBookRequest request = new CreateBookRequest("", "작가", "출판사", 300, null);
+        MockMultipartFile bookPart = new MockMultipartFile(
+                "book", "book", "application/json", objectMapper.writeValueAsString(request).getBytes());
 
-        mockMvc.perform(post("/api/books")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(multipart("/api/books").file(bookPart))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
     }

--- a/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.storage.FileStorageService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,11 +24,14 @@ class UserServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private FileStorageService fileStorageService;
+
     private UserService userService;
 
     @BeforeEach
     void setUp() {
-        userService = new UserService(userRepository);
+        userService = new UserService(userRepository, fileStorageService);
     }
 
     private User user(Long id) {
@@ -114,6 +119,28 @@ class UserServiceTest {
         User result = userService.modifyBackgroundColor(1L, "#000000");
 
         assertThat(result.getBackgroundColor()).isEqualTo("#000000");
+    }
+
+    @Test
+    @DisplayName("프로필 이미지를 업로드하면 저장소 URL로 반영된다")
+    void modifyProfileImageSucceeds() {
+        User user = user(1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        MockMultipartFile image = new MockMultipartFile("image", "profile.png", "image/png", "data".getBytes());
+        given(fileStorageService.store(image, "profile-images"))
+                .willReturn("https://storage.example.com/profile-images/uuid.png");
+
+        User result = userService.modifyProfileImage(1L, image);
+
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://storage.example.com/profile-images/uuid.png");
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일로 프로필 이미지를 변경하려 하면 예외가 발생한다")
+    void modifyProfileImageFailsWhenNotImage() {
+        MockMultipartFile file = new MockMultipartFile("image", "profile.txt", "text/plain", "data".getBytes());
+
+        assertThatThrownBy(() -> userService.modifyProfileImage(1L, file)).isInstanceOf(UserException.class);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,7 +35,9 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -183,6 +186,32 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(new UpdateBackgroundColorRequest(""))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("프로필 이미지를 변경하면 변경된 프로필을 반환한다")
+    void modifyProfileImage() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyProfileImage(eq(1L), any())).willReturn(user(1L));
+        given(opinionService.getMyOpinionCount(1L)).willReturn(0L);
+        MockMultipartFile image = new MockMultipartFile("image", "profile.png", "image/png", "data".getBytes());
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/users/me/profile-image").file(image))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1));
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 파일로 프로필 이미지를 변경하려 하면 400 에러가 발생한다")
+    void modifyProfileImageFailsWhenNotImage() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(userService.modifyProfileImage(eq(1L), any()))
+                .willThrow(new UserException(UserErrorCode.INVALID_IMAGE_FILE));
+        MockMultipartFile file = new MockMultipartFile("image", "profile.txt", "text/plain", "data".getBytes());
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/users/me/profile-image").file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("USER_400_2"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/global/storage/LocalFileStorageServiceTest.java
+++ b/src/test/java/com/nexters/palang/global/storage/LocalFileStorageServiceTest.java
@@ -1,0 +1,41 @@
+package com.nexters.palang.global.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.global.common.error.AppException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+
+class LocalFileStorageServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("이미지를 저장하면 하위 디렉터리에 파일이 생기고 base-url 기준 URL을 반환한다")
+    void storeSavesFileAndReturnsUrl() throws IOException {
+        LocalFileStorageService storageService = new LocalFileStorageService(tempDir.toString(), "/images");
+        MockMultipartFile file = new MockMultipartFile("coverImage", "cover.jpg", "image/jpeg", "data".getBytes());
+
+        String url = storageService.store(file, "book-covers");
+
+        assertThat(url).startsWith("/images/book-covers/").endsWith(".jpg");
+        String filename = url.substring(url.lastIndexOf('/') + 1);
+        assertThat(Files.exists(tempDir.resolve("book-covers").resolve(filename))).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미지 타입이 아니면 예외가 발생하고 파일을 저장하지 않는다")
+    void storeFailsWhenContentTypeIsNotImage() {
+        LocalFileStorageService storageService = new LocalFileStorageService(tempDir.toString(), "/images");
+        MockMultipartFile file = new MockMultipartFile("coverImage", "cover.txt", "text/plain", "data".getBytes());
+
+        assertThatThrownBy(() -> storageService.store(file, "book-covers")).isInstanceOf(AppException.class);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #69

## 🚀 개요
책 직접 등록 API가 `coverImageUrl` 문자열만 받던 것을 파일 업로드로 대체하고, 프로필 이미지 변경 API를 새로 추가했습니다. 가비아 클라우드에는 오브젝트 스토리지 상품이 없어(공공기관 전용 클라우드에만 존재) 서버 디스크(Docker volume)에 저장하고 `/images/**`로 서빙하는 방식으로 구현했습니다.

## 📄 작업 내용
- `global/storage`: `FileStorageService` 인터페이스 + `LocalFileStorageService` 구현체 추가 (UUID 파일명, book-covers/profile-images 하위 디렉터리 분리)
- `global/config/WebStorageConfig`: 업로드 디렉터리를 `/images/**`로 정적 서빙
- `POST /api/books`: multipart/form-data로 변경, `coverImageUrl` 문자열 입력 제거 → `coverImage` 파일 업로드(선택)로 대체
- `PATCH /api/users/me/profile-image` 신규 추가: 프로필 이미지 업로드
- `BookErrorCode`/`UserErrorCode`에 `INVALID_IMAGE_FILE` 추가 (jpeg/png 외 파일 업로드 시 400)
- `docker-compose.yml`에 `uploads-data` volume 추가 (재배포해도 업로드 파일 유지), `Dockerfile`에서 비루트 유저가 볼륨을 쓸 수 있도록 소유권 설정
- Swagger 문서 갱신 (springdoc이 multipart의 JSON 파트 `encoding.contentType`을 자동으로 안 채워주는 이슈를 발견해 `@RequestBody(encoding=...)`로 명시 처리)
- 관련 테스트 추가/수정 (`LocalFileStorageServiceTest`, `BookServiceTest`, `UserServiceTest`, 컨트롤러 멀티파트 테스트 등)

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과
- 로컬(`local` 프로파일, 내장 H2)로 앱을 띄워 Swagger UI에서 `POST /api/books`, `PATCH /api/users/me/profile-image` 둘 다 "Try it out"으로 실제 파일 업로드 → 200 응답 및 `/images/...` URL 정상 서빙 확인
  ```
  POST /api/books 응답 예시
  {
    "data": {
      "bookId": 1,
      "title": "채식주의자",
      ...
      "coverImageUrl": "/images/book-covers/1caa4766-4835-4cba-904b-61297ffdd127.jpg",
      "source": "MANUAL"
    }
  }
  ```

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `coverImageUrl` 문자열 입력을 완전히 제거하고 파일 업로드로만 받도록 했는데, 기존/외부 클라이언트가 링크로도 등록할 필요가 있는지 확인 부탁드립니다 (필요하면 선택적으로 되살릴 수 있습니다).
- 가비아에 오브젝트 스토리지가 없어 서버 로컬 디스크(volume)에 저장하는 방식으로 갔습니다. 서버를 여러 대로 확장하게 되면 이 방식이 깨지므로, 그때는 MinIO 자체 호스팅이나 다른 클라우드의 오브젝트 스토리지로 전환이 필요합니다 — 지금 단계에서 이 방향이 맞는지 의견 부탁드립니다.
- 이미지 업로드 크기 제한을 OCR용으로 이미 설정돼 있던 `spring.servlet.multipart.max-file-size: 10MB`를 그대로 공유해서 씁니다. 책 표지/프로필 이미지에도 10MB가 적절한지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 도서 등록 시 선택적으로 표지 이미지를 업로드할 수 있습니다.
  * 사용자 프로필 이미지를 업로드하고 변경할 수 있습니다.
  * 업로드된 이미지는 외부에서 접근 가능한 이미지 URL로 제공됩니다.
  * JPEG·PNG 이미지만 업로드할 수 있으며, 업로드 파일은 재배포 후에도 유지됩니다.

* **문서**
  * 이미지 업로드 경로와 multipart 요청 형식에 대한 API 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->