### PR TITLE
Feat/#72 유저 이메일 조회 - /api/users/me에 카카오 이메일 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
@@ -35,14 +35,17 @@ public class AuthService {
 
     @Transactional
     public AuthResult loginWithKakao(String kakaoAccessToken) {
-        String snsId = kakaoOAuthClient.getSnsId(kakaoAccessToken);
-        User user = userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, snsId).orElse(null);
+        KakaoOAuthClient.KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(kakaoAccessToken);
+        User user = userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, kakaoUserInfo.snsId()).orElse(null);
 
         boolean isNewUser = user == null;
         if (isNewUser) {
-            user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, snsId);
+            user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, kakaoUserInfo.snsId(), kakaoUserInfo.email());
         } else if (user.isWithdrawn()) {
             throw new AuthException(AuthErrorCode.WITHDRAWN_ACCOUNT);
+        } else if (kakaoUserInfo.email() != null) {
+            // 최초 로그인 시 이메일 동의를 거부했다가 나중에 동의하는 경우를 위해 갱신한다.
+            user.changeEmail(kakaoUserInfo.email());
         }
 
         return issueTokens(user, isNewUser);
@@ -59,7 +62,7 @@ public class AuthService {
     public AuthResult devLogin(Long userId) {
         boolean isNewUser = userId == null;
         User user = isNewUser
-                ? userRegistrationService.registerViaSns(SnsProvider.KAKAO, "dev-" + System.nanoTime())
+                ? userRegistrationService.registerViaSns(SnsProvider.KAKAO, "dev-" + System.nanoTime(), null)
                 : getActiveUser(userId);
         return issueTokens(user, isNewUser);
     }

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
@@ -14,7 +14,7 @@ public class KakaoOAuthClient {
     private final WebClient kakaoWebClient;
 
     // 모바일 앱이 카카오 SDK로 로그인 후 전달한 액세스 토큰을 카카오 서버에 직접 검증한다.
-    public String getSnsId(String kakaoAccessToken) {
+    public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         KakaoUserInfoResponse response;
         try {
             response = kakaoWebClient.get()
@@ -30,6 +30,11 @@ public class KakaoOAuthClient {
         if (response == null || response.id() == null) {
             throw new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED);
         }
-        return String.valueOf(response.id());
+        String email = response.kakaoAccount() == null ? null : response.kakaoAccount().email();
+        return new KakaoUserInfo(String.valueOf(response.id()), email);
+    }
+
+    // 이메일은 카카오계정(이메일) 동의항목을 거부했거나 미인증 상태면 null일 수 있다.
+    public record KakaoUserInfo(String snsId, String email) {
     }
 }

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/KakaoUserInfoResponse.java
@@ -1,8 +1,14 @@
 package com.nexters.palang.domain.auth.infrastructure.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-// 카카오 사용자 정보 조회 API(GET /v2/user/me) 응답 중 식별자만 사용한다.
+// 카카오 사용자 정보 조회 API(GET /v2/user/me) 응답 중 식별자와 이메일만 사용한다.
+// 이메일은 카카오계정(이메일) 동의항목을 거부했거나 미인증 상태면 kakao_account 자체가 없거나 email이 null일 수 있다.
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record KakaoUserInfoResponse(Long id) {
+public record KakaoUserInfoResponse(Long id, @JsonProperty("kakao_account") KakaoAccount kakaoAccount) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(String email) {
+    }
 }

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -18,7 +18,7 @@ public final class UserMapper {
 
     public static MeResponse toMeResponse(User user, long opinionCount) {
         return new MeResponse(
-                user.getId(), user.getNickname(), user.getProfileImageUrl(),
+                user.getId(), user.getNickname(), user.getEmail(), user.getProfileImageUrl(),
                 user.getBackgroundColor(), user.getSnsProvider(), opinionCount);
     }
 

--- a/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
@@ -27,12 +27,12 @@ public class UserRegistrationService {
     // FR-AUTH-04: 닉네임 유니크 제약 충돌은 사전 조회 대신 저장 시도 -> 실패 시 접미사를 붙여 재시도하는
     // 낙관적 방식으로 처리한다(사전 조회는 동시성에 취약). 각 시도를 REQUIRES_NEW로 독립된 트랜잭션에서
     // 실행해, 제약 위반 예외가 영속성 컨텍스트를 오염시켜 다음 시도까지 실패시키는 것을 막는다.
-    public User registerViaSns(SnsProvider snsProvider, String snsId) {
+    public User registerViaSns(SnsProvider snsProvider, String snsId, String email) {
         String base = nicknameGenerator.generateBase();
         for (int suffix = 0; suffix <= NicknameGenerator.MAX_SUFFIX_ATTEMPTS; suffix++) {
             String nickname = suffix == 0 ? base : nicknameGenerator.withSuffix(base, suffix);
             try {
-                return createUser(nickname, snsProvider, snsId);
+                return createUser(nickname, snsProvider, snsId, email);
             } catch (DataIntegrityViolationException e) {
                 if (!isNicknameConflict(e)) {
                     // 닉네임 충돌이 아닌 다른 무결성 위반을 닉네임 생성 실패로 오인해 삼키지 않는다 —
@@ -51,11 +51,12 @@ public class UserRegistrationService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public User createUser(String nickname, SnsProvider snsProvider, String snsId) {
+    public User createUser(String nickname, SnsProvider snsProvider, String snsId, String email) {
         User user = User.builder()
                 .nickname(nickname)
                 .snsProvider(snsProvider)
                 .snsId(snsId)
+                .email(email)
                 .build();
         return userRepository.saveAndFlush(user);
     }

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -48,6 +48,10 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_url", columnDefinition = "TEXT")
     private String profileImageUrl;
 
+    // 카카오계정(이메일) 동의항목을 거부했거나 미인증 상태면 null일 수 있어 nullable이다.
+    @Column(name = "email")
+    private String email;
+
     @Column(name = "background_color", length = BACKGROUND_COLOR_MAX_LENGTH)
     private String backgroundColor;
 
@@ -79,6 +83,7 @@ public class User extends BaseEntity {
             String backgroundColor,
             SnsProvider snsProvider,
             String snsId,
+            String email,
             LocalDateTime termsAgreedAt
     ) {
         this.nickname = nickname;
@@ -86,6 +91,7 @@ public class User extends BaseEntity {
         this.backgroundColor = backgroundColor;
         this.snsProvider = snsProvider;
         this.snsId = snsId;
+        this.email = email;
         this.termsAgreedAt = termsAgreedAt;
         this.hasCompletedOnboarding = false;
         this.isWithdrawn = false;
@@ -116,6 +122,11 @@ public class User extends BaseEntity {
 
     public void changeProfileImage(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    // 이메일 동의를 나중에 하는 경우가 있어, 로그인 시점마다 카카오가 내려준 값으로 갱신한다(멱등).
+    public void changeEmail(String email) {
+        this.email = email;
     }
 
     public void withdraw() {

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -23,8 +23,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "User", description = "마이페이지 API")
 public interface UserApi {
 
-    @Operation(summary = "내 프로필 조회", description = "닉네임, 프로필 이미지, 배경색, 가입 경로(SNS), "
-            + "지금까지 남긴 흔적 수를 조회합니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @Operation(summary = "내 프로필 조회", description = "닉네임, 이메일, 프로필 이미지, 배경색, 가입 경로(SNS), "
+            + "지금까지 남긴 흔적 수를 조회합니다. 이메일은 SNS 이메일 동의 여부에 따라 없을 수 있습니다(null). "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MeResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MeResponse(
         @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
         @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "reader@example.com", nullable = true) String email,
         @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
         @Schema(example = "#FDF6E3", nullable = true) String backgroundColor,
         @Schema(example = "KAKAO", requiredMode = Schema.RequiredMode.REQUIRED) SnsProvider snsProvider,

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -67,10 +67,12 @@ class AuthServiceTest {
     @Test
     @DisplayName("처음 로그인하는 카카오 사용자는 신규 가입되고 isNewUser가 true다")
     void loginWithKakaoSignsUpNewUser() {
-        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-100");
+        given(kakaoOAuthClient.getUserInfo("kakao-token"))
+                .willReturn(new KakaoOAuthClient.KakaoUserInfo("sns-100", "user100@example.com"));
         given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-100")).willReturn(Optional.empty());
         User newUser = user(100L);
-        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-100")).willReturn(newUser);
+        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-100", "user100@example.com"))
+                .willReturn(newUser);
         given(jwtTokenProvider.createAccessToken(100L)).willReturn("access-token");
         given(jwtTokenProvider.createRefreshToken(100L)).willReturn("refresh-token");
         given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
@@ -86,9 +88,10 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("이미 가입된 카카오 사용자가 로그인하면 isNewUser가 false다")
+    @DisplayName("이미 가입된 카카오 사용자가 로그인하면 isNewUser가 false이고 이메일이 갱신된다")
     void loginWithKakaoSignsInExistingUser() {
-        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-200");
+        given(kakaoOAuthClient.getUserInfo("kakao-token"))
+                .willReturn(new KakaoOAuthClient.KakaoUserInfo("sns-200", "user200@example.com"));
         User existingUser = user(200L);
         given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-200"))
                 .willReturn(Optional.of(existingUser));
@@ -99,13 +102,15 @@ class AuthServiceTest {
         AuthResult result = authService.loginWithKakao("kakao-token");
 
         assertThat(result.isNewUser()).isFalse();
-        verify(userRegistrationService, never()).registerViaSns(any(), anyString());
+        assertThat(existingUser.getEmail()).isEqualTo("user200@example.com");
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any());
     }
 
     @Test
     @DisplayName("탈퇴한 계정으로 로그인을 시도하면 예외가 발생한다")
     void loginWithKakaoFailsWhenAccountWithdrawn() {
-        given(kakaoOAuthClient.getSnsId("kakao-token")).willReturn("sns-300");
+        given(kakaoOAuthClient.getUserInfo("kakao-token"))
+                .willReturn(new KakaoOAuthClient.KakaoUserInfo("sns-300", null));
         User withdrawnUser = user(300L);
         withdrawnUser.withdraw();
         given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-300"))
@@ -118,7 +123,7 @@ class AuthServiceTest {
     @DisplayName("[개발용] userId 없이 devLogin을 호출하면 새 테스트 유저를 만들어 로그인 처리한다")
     void devLoginCreatesNewUserWhenUserIdOmitted() {
         User newUser = user(400L);
-        given(userRegistrationService.registerViaSns(eq(SnsProvider.KAKAO), anyString())).willReturn(newUser);
+        given(userRegistrationService.registerViaSns(eq(SnsProvider.KAKAO), anyString(), any())).willReturn(newUser);
         given(jwtTokenProvider.createAccessToken(400L)).willReturn("access-token");
         given(jwtTokenProvider.createRefreshToken(400L)).willReturn("refresh-token");
         given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
@@ -141,7 +146,7 @@ class AuthServiceTest {
         AuthResult result = authService.devLogin(500L);
 
         assertThat(result.isNewUser()).isFalse();
-        verify(userRegistrationService, never()).registerViaSns(any(), anyString());
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
@@ -44,11 +44,12 @@ class UserRegistrationServiceTest {
         given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
         given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-1");
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-1", "user1@example.com");
 
         assertThat(user.getNickname()).isEqualTo("고요한책갈피");
         assertThat(user.getSnsProvider()).isEqualTo(SnsProvider.KAKAO);
         assertThat(user.getSnsId()).isEqualTo("sns-1");
+        assertThat(user.getEmail()).isEqualTo("user1@example.com");
         verify(userRepository, times(1)).saveAndFlush(any());
     }
 
@@ -62,7 +63,7 @@ class UserRegistrationServiceTest {
         given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피1"))))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-2");
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-2", null);
 
         assertThat(user.getNickname()).isEqualTo("고요한책갈피1");
     }
@@ -76,7 +77,7 @@ class UserRegistrationServiceTest {
         given(userRepository.saveAndFlush(any(User.class)))
                 .willThrow(new DataIntegrityViolationException("Duplicate entry for key 'users.uq_users_nickname'"));
 
-        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3"))
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3", null))
                 .isInstanceOf(UserException.class);
     }
 
@@ -88,7 +89,7 @@ class UserRegistrationServiceTest {
                 .willThrow(new DataIntegrityViolationException(
                         "Column 'terms_agreed_at' cannot be null"));
 
-        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-4"))
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-4", null))
                 .isInstanceOf(DataIntegrityViolationException.class);
         verify(userRepository, times(1)).saveAndFlush(any());
     }

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -65,6 +65,7 @@ class UserControllerTest {
     private User user(Long id) {
         User user = User.builder()
                 .nickname("닉네임")
+                .email("user@example.com")
                 .profileImageUrl("cover")
                 .backgroundColor("#FFFFFF")
                 .snsProvider(SnsProvider.KAKAO)
@@ -84,6 +85,7 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.userId").value(1))
                 .andExpect(jsonPath("$.data.nickname").value("닉네임"))
+                .andExpect(jsonPath("$.data.email").value("user@example.com"))
                 .andExpect(jsonPath("$.data.opinionCount").value(5));
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #72

## 🚀 개요
> `/api/users/me`에서 유저 이메일(카카오계정 이메일)을 조회할 수 있도록 추가했습니다.

## 📄 작업 내용
- `KakaoUserInfoResponse`/`KakaoOAuthClient`: 카카오 사용자 정보 조회 시 `kakao_account.email`도 함께 받아오도록 확장 (`getUserInfo` → `KakaoUserInfo(snsId, email)`)
- `User` 엔티티: nullable `email` 컬럼과 `changeEmail()` 추가 (이메일 동의를 거부/미인증한 사용자가 있어 nullable)
- `AuthService.loginWithKakao`: 신규가입 시 이메일 저장, 기존 유저는 로그인할 때마다 최신 이메일로 갱신(나중에 동의하는 경우 대비)
- `MeResponse` / `UserMapper` / `UserApi` swagger 문서: `/api/users/me` 응답에 `email` 필드 추가
- 관련 단위 테스트 갱신 (`AuthServiceTest`, `UserRegistrationServiceTest`, `UserControllerTest`)

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과 (BUILD SUCCESSFUL)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 카카오 디벨로퍼스 콘솔의 "카카오계정(이메일)" 동의항목을 켜야 실제로 이메일이 내려옵니다(코드 배포와 별개 작업, 진행 중).
- 운영 DB는 `ddl-auto: validate`라 자동 마이그레이션이 안 됩니다. 배포 전 `ALTER TABLE users ADD COLUMN email VARCHAR(...)`를 수동으로 반영해야 합니다.
- 기존에 가입된 유저는 다음에 실제로 카카오 로그인을 다시 타야(=JWT refresh만으로는 안 됨) 이메일이 채워집니다. 기존 유저를 강제로 재로그인시킬지(refresh token 일괄 revoke 등)는 후속 논의로 남겨뒀습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 카카오 로그인 시 이메일 정보를 함께 수집하고 신규 가입 및 기존 계정에 저장·갱신합니다.
  - 내 프로필 조회 결과에 이메일이 포함됩니다.
  - 카카오 계정 설정에 따라 이메일이 없을 경우 `null`로 표시될 수 있습니다.

- **문서**
  - 프로필 API 설명에 이메일 제공 여부와 미제공 가능성을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->