### PR TITLE
Feat/#71 Apple OAuth 소셜로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ out/
 *.jks
 *.pem
 *.key
+*.p8
 application-local.yaml
 application-local.yml
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -23,6 +23,14 @@ ALADIN_TTB_KEY=
 CLOVA_OCR_INVOKE_URL=
 CLOVA_OCR_SECRET_KEY=
 
+# ---- Apple 로그인 ----
+APPLE_WEB_CLIENT_ID=
+APPLE_APP_CLIENT_ID=
+
+APPLE_TEAM_ID=
+APPLE_KEY_ID=
+APPLE_PRIVATE_KEY=
+
 # ---- 이미지 업로드 저장 경로 (가비아 상용 클라우드에는 오브젝트 스토리지가 없어 서버 디스크에 저장) ----
 # docker-compose의 uploads-data 볼륨과 맞춘 컨테이너 내부 경로. 보통 바꿀 필요 없음.
 IMAGE_UPLOAD_DIR=/app/uploads

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
@@ -1,6 +1,8 @@
 package com.nexters.palang.domain.auth.application;
 
 import com.nexters.palang.domain.auth.domain.RefreshToken;
+import com.nexters.palang.domain.auth.infrastructure.AppleAuthClient;
+import com.nexters.palang.domain.auth.infrastructure.AppleOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
 import com.nexters.palang.domain.user.application.UserRegistrationService;
@@ -18,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +34,8 @@ public class AuthService {
     private final UserRegistrationService userRegistrationService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
+    private final AppleOAuthClient appleOAuthClient;
+    private final AppleAuthClient appleAuthClient;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -40,7 +45,8 @@ public class AuthService {
 
         boolean isNewUser = user == null;
         if (isNewUser) {
-            user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, kakaoUserInfo.snsId(), kakaoUserInfo.email());
+            user = userRegistrationService.registerViaSns(
+                    SnsProvider.KAKAO, kakaoUserInfo.snsId(), kakaoUserInfo.email(), null);
         } else if (user.isWithdrawn()) {
             throw new AuthException(AuthErrorCode.WITHDRAWN_ACCOUNT);
         } else if (kakaoUserInfo.email() != null) {
@@ -49,6 +55,42 @@ public class AuthService {
         }
 
         return issueTokens(user, isNewUser);
+    }
+
+    // authorizationCode는 최초 로그인뿐 아니라 매 로그인마다 전달되지만(프론트 계약), 발급 후 수 분 내에만
+    // Apple에 교환 가능해 매번 즉시 교환을 시도한다 — 실패해도 로그인 자체는 계속 진행한다(best-effort).
+    @Transactional
+    public AuthResult loginWithApple(String identityToken, String authorizationCode, String givenName, String familyName) {
+        AppleOAuthClient.AppleUserInfo appleUserInfo = appleOAuthClient.getUserInfo(identityToken);
+        User user = userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, appleUserInfo.snsId()).orElse(null);
+
+        boolean isNewUser = user == null;
+        if (isNewUser) {
+            user = userRegistrationService.registerViaSns(
+                    SnsProvider.APPLE, appleUserInfo.snsId(), appleUserInfo.email(), combineName(familyName, givenName));
+        } else if (user.isWithdrawn()) {
+            throw new AuthException(AuthErrorCode.WITHDRAWN_ACCOUNT);
+        } else if (appleUserInfo.email() != null) {
+            user.changeEmail(appleUserInfo.email());
+        }
+
+        if (authorizationCode != null) {
+            Optional<String> appleRefreshToken =
+                    appleAuthClient.exchangeForRefreshToken(authorizationCode, appleUserInfo.audience());
+            if (appleRefreshToken.isPresent()) {
+                user.updateAppleRefreshToken(appleRefreshToken.get());
+            }
+        }
+
+        return issueTokens(user, isNewUser);
+    }
+
+    // 애플은 성/이름을 따로 내려주고 최초 로그인에만 값이 있다. 한국어 서비스라 성+이름 순서로 붙인다.
+    private String combineName(String familyName, String givenName) {
+        if (familyName == null && givenName == null) {
+            return null;
+        }
+        return (familyName == null ? "" : familyName) + (givenName == null ? "" : givenName);
     }
 
     @Transactional
@@ -62,7 +104,7 @@ public class AuthService {
     public AuthResult devLogin(Long userId) {
         boolean isNewUser = userId == null;
         User user = isNewUser
-                ? userRegistrationService.registerViaSns(SnsProvider.KAKAO, "dev-" + System.nanoTime(), null)
+                ? userRegistrationService.registerViaSns(SnsProvider.KAKAO, "dev-" + System.nanoTime(), null, null)
                 : getActiveUser(userId);
         return issueTokens(user, isNewUser);
     }

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/AppleAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/AppleAuthClient.java
@@ -1,0 +1,110 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import com.nexters.palang.domain.auth.infrastructure.dto.AppleTokenResponse;
+import io.jsonwebtoken.Jwts;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+// 회원탈퇴 시 애플 연동 해제(revoke)에 쓸 refresh token을 미리 확보하기 위해, 로그인 시점에
+// authorizationCode를 Apple에 즉시 교환한다. authorizationCode는 발급 후 수 분 내에만 유효해
+// 탈퇴 시점에는 다시 교환할 방법이 없다 — 그래서 이 클라이언트가 반드시 로그인 흐름에서 호출돼야 한다.
+// 실패해도(키 미설정 포함) 로그인 자체는 계속 진행하는 best-effort 성격이다.
+@Slf4j
+@Component
+public class AppleAuthClient {
+
+    private static final String TOKEN_URI = "/auth/token";
+    private static final String AUDIENCE = "https://appleid.apple.com";
+    private static final Duration CLIENT_SECRET_TTL = Duration.ofMinutes(5);
+
+    private final WebClient appleWebClient;
+    private final String teamId;
+    private final String keyId;
+    private final PrivateKey privateKey;
+
+    public AppleAuthClient(
+            WebClient appleWebClient,
+            @Value("${apple.team-id}") String teamId,
+            @Value("${apple.key-id}") String keyId,
+            @Value("${apple.private-key}") String privateKeyPem) {
+        this.appleWebClient = appleWebClient;
+        this.teamId = teamId;
+        this.keyId = keyId;
+        // Sign in with Apple Key가 아직 발급/설정되지 않은 환경(로컬 등)에서도 앱이 정상 기동되도록,
+        // 비어 있으면 파싱을 건너뛰고 exchangeForRefreshToken을 무조건 no-op으로 만든다.
+        this.privateKey = (privateKeyPem == null || privateKeyPem.isBlank()) ? null : parsePrivateKey(privateKeyPem);
+    }
+
+    public Optional<String> exchangeForRefreshToken(String authorizationCode, String clientId) {
+        if (privateKey == null) {
+            log.debug("애플 Private Key가 설정되지 않아 authorizationCode 교환을 건너뜁니다.");
+            return Optional.empty();
+        }
+        try {
+            String clientSecret = buildClientSecret(clientId);
+
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("client_id", clientId);
+            form.add("client_secret", clientSecret);
+            form.add("code", authorizationCode);
+            form.add("grant_type", "authorization_code");
+
+            AppleTokenResponse response = appleWebClient.post()
+                    .uri(TOKEN_URI)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(form))
+                    .retrieve()
+                    .bodyToMono(AppleTokenResponse.class)
+                    .block();
+
+            return Optional.ofNullable(response).map(AppleTokenResponse::refreshToken);
+        } catch (RuntimeException e) {
+            log.warn("애플 authorizationCode 교환에 실패해 revoke용 refresh token을 확보하지 못했습니다.", e);
+            return Optional.empty();
+        }
+    }
+
+    // client_secret은 Apple이 요구하는 자체 서명 JWT다. iss=Team ID, sub=요청에 쓴 client id,
+    // aud는 항상 Apple 고정값이다. 요청마다 새로 만들어 짧게(5분) 만료시킨다.
+    String buildClientSecret(String clientId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .header().add("kid", keyId).and()
+                .issuer(teamId)
+                .subject(clientId)
+                .audience().add(AUDIENCE).and()
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + CLIENT_SECRET_TTL.toMillis()))
+                .signWith(privateKey, Jwts.SIG.ES256)
+                .compact();
+    }
+
+    private PrivateKey parsePrivateKey(String pem) {
+        try {
+            String sanitized = pem
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] derBytes = Base64.getDecoder().decode(sanitized);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(derBytes));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | IllegalArgumentException e) {
+            throw new IllegalStateException("failed to parse apple private key", e);
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/AppleOAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/AppleOAuthClient.java
@@ -1,0 +1,151 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.auth.infrastructure.dto.ApplePublicKeysResponse;
+import com.nexters.palang.global.security.AuthErrorCode;
+import com.nexters.palang.global.security.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+// 카카오와 달리 Apple에는 "액세스 토큰으로 사용자 정보 조회" REST API가 없어, 클라이언트가 전달한
+// identity token(JWT)의 서명을 Apple 공개키(JWKS)로 직접 검증해야 한다. 웹(Service ID)과 iOS 앱
+// (Bundle ID)의 aud 값이 서로 다르므로 둘 다 허용한다.
+@Component
+public class AppleOAuthClient {
+
+    private static final String ISSUER = "https://appleid.apple.com";
+    private static final Duration JWKS_CACHE_TTL = Duration.ofHours(1);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final WebClient appleWebClient;
+    private final List<String> allowedAudiences;
+
+    private volatile List<ApplePublicKeysResponse.ApplePublicKey> cachedKeys = List.of();
+    private volatile Instant cachedAt = Instant.EPOCH;
+
+    public AppleOAuthClient(
+            WebClient appleWebClient,
+            @Value("${apple.web-client-id}") String webClientId,
+            @Value("${apple.app-client-id}") String appClientId) {
+        this.appleWebClient = appleWebClient;
+        this.allowedAudiences = List.of(webClientId, appClientId);
+    }
+
+    public AppleUserInfo getUserInfo(String identityToken) {
+        try {
+            return verify(identityToken, currentKeys());
+        } catch (AppleKeyNotFoundException e) {
+            // Apple이 서명 키를 회전했을 수 있으니 캐시를 한 번 강제 갱신해 재시도한다.
+            try {
+                return verify(identityToken, refreshKeys());
+            } catch (RuntimeException retryFailure) {
+                throw new AuthException(AuthErrorCode.APPLE_AUTH_FAILED);
+            }
+        } catch (RuntimeException e) {
+            throw new AuthException(AuthErrorCode.APPLE_AUTH_FAILED);
+        }
+    }
+
+    // 네트워크 호출 없이 서명/iss/aud 검증만 수행한다. JWKS 목록을 인자로 받아 순수 로직만 단위 테스트한다.
+    AppleUserInfo verify(String identityToken, List<ApplePublicKeysResponse.ApplePublicKey> keys) {
+        PublicKey publicKey = resolvePublicKey(extractHeaderKid(identityToken), keys);
+
+        Claims claims = Jwts.parser()
+                .verifyWith(publicKey)
+                .requireIssuer(ISSUER)
+                .build()
+                .parseSignedClaims(identityToken)
+                .getPayload();
+
+        // 어느 client id(웹 Service ID/앱 Bundle ID)로 검증됐는지도 함께 반환한다 —
+        // authorizationCode 교환 시 client_secret의 sub로 동일한 client id를 써야 하기 때문이다.
+        String matchedAudience = allowedAudiences.stream()
+                .filter(aud -> claims.getAudience().contains(aud))
+                .findFirst()
+                .orElseThrow(() -> new JwtException("unexpected apple audience: " + claims.getAudience()));
+
+        return new AppleUserInfo(claims.getSubject(), claims.get("email", String.class), matchedAudience);
+    }
+
+    // jjwt는 서명 검증 없이 헤더만 읽는 API가 없어, kid를 얻기 위해 헤더 부분만 직접 디코딩한다.
+    private String extractHeaderKid(String token) {
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            throw new JwtException("malformed apple identity token");
+        }
+        try {
+            byte[] headerBytes = Base64.getUrlDecoder().decode(parts[0]);
+            Map<?, ?> header = OBJECT_MAPPER.readValue(headerBytes, Map.class);
+            Object kid = header.get("kid");
+            if (kid == null) {
+                throw new JwtException("apple identity token header has no kid");
+            }
+            return kid.toString();
+        } catch (IOException | IllegalArgumentException e) {
+            throw new JwtException("failed to parse apple identity token header", e);
+        }
+    }
+
+    private PublicKey resolvePublicKey(String kid, List<ApplePublicKeysResponse.ApplePublicKey> keys) {
+        ApplePublicKeysResponse.ApplePublicKey key = keys.stream()
+                .filter(k -> kid.equals(k.kid()))
+                .findFirst()
+                .orElseThrow(AppleKeyNotFoundException::new);
+        return toRsaPublicKey(key);
+    }
+
+    private PublicKey toRsaPublicKey(ApplePublicKeysResponse.ApplePublicKey key) {
+        try {
+            BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(key.n()));
+            BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(key.e()));
+            return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(modulus, exponent));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private List<ApplePublicKeysResponse.ApplePublicKey> currentKeys() {
+        if (cachedKeys.isEmpty() || Instant.now().isAfter(cachedAt.plus(JWKS_CACHE_TTL))) {
+            return refreshKeys();
+        }
+        return cachedKeys;
+    }
+
+    private synchronized List<ApplePublicKeysResponse.ApplePublicKey> refreshKeys() {
+        ApplePublicKeysResponse response = appleWebClient.get()
+                .uri("/auth/keys")
+                .retrieve()
+                .bodyToMono(ApplePublicKeysResponse.class)
+                .block();
+        if (response == null || response.keys() == null || response.keys().isEmpty()) {
+            throw new IllegalStateException("failed to fetch apple jwks");
+        }
+        cachedKeys = response.keys();
+        cachedAt = Instant.now();
+        return cachedKeys;
+    }
+
+    private static final class AppleKeyNotFoundException extends RuntimeException {
+    }
+
+    // 이메일은 Apple 계정 이메일 비공개 설정이나 최초 동의 거부 시 null일 수 있다.
+    // audience는 이 토큰 검증에 실제로 매칭된 client id(웹 Service ID 또는 앱 Bundle ID)다.
+    public record AppleUserInfo(String snsId, String email, String audience) {
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/ApplePublicKeysResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/ApplePublicKeysResponse.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.auth.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+// Apple JWKS(GET https://appleid.apple.com/auth/keys) 응답. RSA 공개키 재구성에 필요한 kid/n/e만 사용한다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ApplePublicKeysResponse(List<ApplePublicKey> keys) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ApplePublicKey(String kty, String kid, String use, String alg, String n, String e) {
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/AppleTokenResponse.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/dto/AppleTokenResponse.java
@@ -1,0 +1,14 @@
+package com.nexters.palang.domain.auth.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Apple 토큰 교환(POST /auth/token) 응답. authorizationCode를 refresh token으로 바꾸는 데만 쓰므로
+// refreshToken 외 나머지 필드는 참고용으로만 갖고 있는다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AppleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("id_token") String idToken
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/AuthApi.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/AuthApi.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.auth.presentation;
 
+import com.nexters.palang.domain.auth.presentation.dto.AppleLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
 import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
@@ -17,7 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "Auth", description = "카카오 로그인/인증 API")
+@Tag(name = "Auth", description = "카카오/애플 로그인 및 인증 API")
 public interface AuthApi {
 
     @Operation(summary = "카카오 로그인", description = "모바일 앱이 카카오 SDK로 로그인해 받은 카카오 액세스 토큰을 전달하면, "
@@ -39,6 +40,30 @@ public interface AuthApi {
                                     + "\"status\":403,\"detail\":\"탈퇴한 계정입니다.\"}")))
     })
     ResponseEntity<DataResponse<LoginResponse>> loginWithKakao(@Valid KakaoLoginRequest request);
+
+    @Operation(summary = "애플 로그인", description = "웹(Apple JS SDK) 또는 iOS 앱(네이티브 Sign in with Apple)에서 발급받은 "
+            + "identity token(JWT)을 전달하면, Apple 공개키(JWKS)로 서명을 직접 검증한 뒤 가입/로그인을 처리하고 "
+            + "서비스 자체 JWT를 발급합니다. aud 클레임은 설정된 웹 Service ID 또는 앱 Bundle ID 중 하나와 일치해야 합니다. "
+            + "authorizationCode를 함께 전달하면 회원탈퇴 시 애플 연동 해제(revoke)에 쓸 refresh token을 미리 "
+            + "확보해둡니다(실패해도 로그인은 계속 진행됩니다). givenName/familyName은 애플이 최초 로그인 시에만 "
+            + "내려주는 값으로, 이후 로그인엔 null이어도 됩니다. "
+            + "처음 로그인하는 사용자는 닉네임이 자동 생성되며(isNewUser=true), 약관 동의는 별도로 POST /api/auth/terms를 호출해야 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인/가입 성공"),
+            @ApiResponse(responseCode = "400", description = "애플 identity token 누락 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/apple\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"애플 identity token은 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "애플 인증 실패, 서명/발급자/대상/만료 검증 실패 (AUTH_401_6)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/apple\",\"title\":\"AUTH_401_6\","
+                                    + "\"status\":401,\"detail\":\"애플 인증에 실패했습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "탈퇴한 계정으로 재로그인 시도 (AUTH_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/auth/apple\",\"title\":\"AUTH_403_1\","
+                                    + "\"status\":403,\"detail\":\"탈퇴한 계정입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<LoginResponse>> loginWithApple(@Valid AppleLoginRequest request);
 
     @Operation(summary = "약관 동의", description = "이용약관 + 개인정보 수집·이용 동의를 1회 처리로 기록합니다(FR-AUTH-03). "
             + "이미 동의한 사용자가 다시 호출해도 동의 시각만 갱신되며 에러는 발생하지 않습니다.")

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.auth.presentation;
 import com.nexters.palang.domain.auth.application.AuthMapper;
 import com.nexters.palang.domain.auth.application.AuthResult;
 import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.AppleLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.LoginResponse;
 import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
@@ -28,6 +29,14 @@ public class AuthController implements AuthApi {
     @PostMapping("/api/auth/kakao")
     public ResponseEntity<DataResponse<LoginResponse>> loginWithKakao(@RequestBody @Valid KakaoLoginRequest request) {
         AuthResult result = authService.loginWithKakao(request.kakaoAccessToken());
+        return ResponseEntity.ok(DataResponse.from(AuthMapper.toLoginResponse(result)));
+    }
+
+    @Override
+    @PostMapping("/api/auth/apple")
+    public ResponseEntity<DataResponse<LoginResponse>> loginWithApple(@RequestBody @Valid AppleLoginRequest request) {
+        AuthResult result = authService.loginWithApple(
+                request.identityToken(), request.authorizationCode(), request.givenName(), request.familyName());
         return ResponseEntity.ok(DataResponse.from(AuthMapper.toLoginResponse(result)));
     }
 

--- a/src/main/java/com/nexters/palang/domain/auth/presentation/dto/AppleLoginRequest.java
+++ b/src/main/java/com/nexters/palang/domain/auth/presentation/dto/AppleLoginRequest.java
@@ -1,0 +1,21 @@
+package com.nexters.palang.domain.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginRequest(
+        @NotBlank(message = "애플 identity token은 필수입니다.")
+        @Schema(example = "apple-identity-token")
+        String identityToken,
+
+        @Schema(example = "apple-authorization-code",
+                description = "회원탈퇴 시 애플 연동 해제(revoke)용 refresh token 확보에 사용한다. 없어도 로그인 자체는 진행된다.")
+        String authorizationCode,
+
+        @Schema(example = "길동", description = "애플이 최초 로그인 시에만 내려주는 이름. 이후 로그인엔 null일 수 있다.")
+        String givenName,
+
+        @Schema(example = "홍", description = "애플이 최초 로그인 시에만 내려주는 성. 이후 로그인엔 null일 수 있다.")
+        String familyName
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserRegistrationService.java
@@ -27,12 +27,12 @@ public class UserRegistrationService {
     // FR-AUTH-04: 닉네임 유니크 제약 충돌은 사전 조회 대신 저장 시도 -> 실패 시 접미사를 붙여 재시도하는
     // 낙관적 방식으로 처리한다(사전 조회는 동시성에 취약). 각 시도를 REQUIRES_NEW로 독립된 트랜잭션에서
     // 실행해, 제약 위반 예외가 영속성 컨텍스트를 오염시켜 다음 시도까지 실패시키는 것을 막는다.
-    public User registerViaSns(SnsProvider snsProvider, String snsId, String email) {
+    public User registerViaSns(SnsProvider snsProvider, String snsId, String email, String name) {
         String base = nicknameGenerator.generateBase();
         for (int suffix = 0; suffix <= NicknameGenerator.MAX_SUFFIX_ATTEMPTS; suffix++) {
             String nickname = suffix == 0 ? base : nicknameGenerator.withSuffix(base, suffix);
             try {
-                return createUser(nickname, snsProvider, snsId, email);
+                return createUser(nickname, snsProvider, snsId, email, name);
             } catch (DataIntegrityViolationException e) {
                 if (!isNicknameConflict(e)) {
                     // 닉네임 충돌이 아닌 다른 무결성 위반을 닉네임 생성 실패로 오인해 삼키지 않는다 —
@@ -51,12 +51,13 @@ public class UserRegistrationService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public User createUser(String nickname, SnsProvider snsProvider, String snsId, String email) {
+    public User createUser(String nickname, SnsProvider snsProvider, String snsId, String email, String name) {
         User user = User.builder()
                 .nickname(nickname)
                 .snsProvider(snsProvider)
                 .snsId(snsId)
                 .email(email)
+                .name(name)
                 .build();
         return userRepository.saveAndFlush(user);
     }

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -42,6 +42,11 @@ public class User extends BaseEntity {
     @Column(name = "nickname", length = NICKNAME_MAX_LENGTH, nullable = false)
     private String nickname;
 
+    // 실명. 카카오는 제공하지 않고, 애플은 최초 로그인 시에만 내려줘서 null일 수 있다. 익명 서비스 특성상
+    // 어디에도 노출하지 않고 보관만 한다(FR-AUTH-04 랜덤 닉네임과는 별개).
+    @Column(name = "name", length = 50)
+    private String name;
+
     @Column(name = "nickname_updated_at")
     private LocalDateTime nicknameUpdatedAt;
 
@@ -76,9 +81,15 @@ public class User extends BaseEntity {
     @Column(name = "withdrawn_at")
     private LocalDateTime withdrawnAt;
 
+    // 회원탈퇴 시 애플 연동 해제(revoke)에 쓴다. authorizationCode는 발급 후 수 분 내에만 교환 가능해
+    // 탈퇴 시점이 아니라 로그인 시점에 미리 교환해 저장해둔다.
+    @Column(name = "apple_refresh_token", columnDefinition = "TEXT")
+    private String appleRefreshToken;
+
     @Builder
     private User(
             String nickname,
+            String name,
             String profileImageUrl,
             String backgroundColor,
             SnsProvider snsProvider,
@@ -87,6 +98,7 @@ public class User extends BaseEntity {
             LocalDateTime termsAgreedAt
     ) {
         this.nickname = nickname;
+        this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.backgroundColor = backgroundColor;
         this.snsProvider = snsProvider;
@@ -127,6 +139,10 @@ public class User extends BaseEntity {
     // 이메일 동의를 나중에 하는 경우가 있어, 로그인 시점마다 카카오가 내려준 값으로 갱신한다(멱등).
     public void changeEmail(String email) {
         this.email = email;
+    }
+
+    public void updateAppleRefreshToken(String appleRefreshToken) {
+        this.appleRefreshToken = appleRefreshToken;
     }
 
     public void withdraw() {

--- a/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
@@ -27,6 +27,11 @@ public class WebClientConfig {
         return webClient(builder, baseUrl);
     }
 
+    @Bean
+    public WebClient appleWebClient(WebClient.Builder builder, @Value("${apple.base-url}") String baseUrl) {
+        return webClient(builder, baseUrl);
+    }
+
     private WebClient webClient(WebClient.Builder builder, String baseUrl) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)

--- a/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
+++ b/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
@@ -14,6 +14,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_3", "유효하지 않은 토큰입니다."),
     KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_4", "카카오 인증에 실패했습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_5", "유효하지 않은 리프레시 토큰입니다."),
+    APPLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_6", "애플 인증에 실패했습니다."),
     WITHDRAWN_ACCOUNT(HttpStatus.FORBIDDEN, "AUTH_403_1", "탈퇴한 계정입니다."),
     ;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,15 @@ aladin:
 kakao:
   base-url: https://kapi.kakao.com
 
+apple:
+  base-url: https://appleid.apple.com
+  web-client-id: ${APPLE_WEB_CLIENT_ID:}
+  app-client-id: ${APPLE_APP_CLIENT_ID:}
+
+  team-id: ${APPLE_TEAM_ID:}
+  key-id: ${APPLE_KEY_ID:}
+  private-key: ${APPLE_PRIVATE_KEY:}
+
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
 

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.nexters.palang.domain.auth.domain.RefreshToken;
+import com.nexters.palang.domain.auth.infrastructure.AppleAuthClient;
+import com.nexters.palang.domain.auth.infrastructure.AppleOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
 import com.nexters.palang.domain.user.application.UserRegistrationService;
@@ -48,18 +50,28 @@ class AuthServiceTest {
     private KakaoOAuthClient kakaoOAuthClient;
 
     @Mock
+    private AppleOAuthClient appleOAuthClient;
+
+    @Mock
+    private AppleAuthClient appleAuthClient;
+
+    @Mock
     private JwtTokenProvider jwtTokenProvider;
 
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
-        authService = new AuthService(
-                userRepository, userRegistrationService, refreshTokenRepository, kakaoOAuthClient, jwtTokenProvider);
+        authService = new AuthService(userRepository, userRegistrationService, refreshTokenRepository,
+                kakaoOAuthClient, appleOAuthClient, appleAuthClient, jwtTokenProvider);
     }
 
     private User user(Long id) {
-        User user = User.builder().nickname("닉네임" + id).snsProvider(SnsProvider.KAKAO).snsId("sns-" + id).build();
+        return user(id, SnsProvider.KAKAO);
+    }
+
+    private User user(Long id, SnsProvider snsProvider) {
+        User user = User.builder().nickname("닉네임" + id).snsProvider(snsProvider).snsId("sns-" + id).build();
         ReflectionTestUtils.setField(user, "id", id);
         return user;
     }
@@ -71,7 +83,7 @@ class AuthServiceTest {
                 .willReturn(new KakaoOAuthClient.KakaoUserInfo("sns-100", "user100@example.com"));
         given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-100")).willReturn(Optional.empty());
         User newUser = user(100L);
-        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-100", "user100@example.com"))
+        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-100", "user100@example.com", null))
                 .willReturn(newUser);
         given(jwtTokenProvider.createAccessToken(100L)).willReturn("access-token");
         given(jwtTokenProvider.createRefreshToken(100L)).willReturn("refresh-token");
@@ -103,7 +115,7 @@ class AuthServiceTest {
 
         assertThat(result.isNewUser()).isFalse();
         assertThat(existingUser.getEmail()).isEqualTo("user200@example.com");
-        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any());
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any(), any());
     }
 
     @Test
@@ -120,10 +132,120 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("처음 로그인하는 애플 사용자는 신규 가입되고 isNewUser가 true다")
+    void loginWithAppleSignsUpNewUser() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-100", "apple100@example.com", "com.palang.app"));
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-100")).willReturn(Optional.empty());
+        User newUser = user(100L, SnsProvider.APPLE);
+        given(userRegistrationService.registerViaSns(SnsProvider.APPLE, "apple-sns-100", "apple100@example.com", null))
+                .willReturn(newUser);
+        given(jwtTokenProvider.createAccessToken(100L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(100L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithApple("apple-token", null, null, null);
+
+        assertThat(result.isNewUser()).isTrue();
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("최초 로그인 시 애플이 이름을 내려주면 성+이름 순서로 합쳐 저장한다")
+    void loginWithAppleCombinesGivenAndFamilyNameOnSignUp() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-101", null, "com.palang.app"));
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-101")).willReturn(Optional.empty());
+        User newUser = user(101L, SnsProvider.APPLE);
+        given(userRegistrationService.registerViaSns(SnsProvider.APPLE, "apple-sns-101", null, "홍길동"))
+                .willReturn(newUser);
+        given(jwtTokenProvider.createAccessToken(101L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(101L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        authService.loginWithApple("apple-token", null, "길동", "홍");
+
+        verify(userRegistrationService).registerViaSns(SnsProvider.APPLE, "apple-sns-101", null, "홍길동");
+    }
+
+    @Test
+    @DisplayName("authorizationCode가 있으면 애플에 교환해 refresh token을 저장한다")
+    void loginWithAppleStoresAppleRefreshTokenWhenAuthorizationCodeGiven() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-102", null, "com.palang.app"));
+        User existingUser = user(102L, SnsProvider.APPLE);
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-102"))
+                .willReturn(Optional.of(existingUser));
+        given(appleAuthClient.exchangeForRefreshToken("auth-code", "com.palang.app"))
+                .willReturn(Optional.of("apple-refresh-token"));
+        given(jwtTokenProvider.createAccessToken(102L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(102L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        authService.loginWithApple("apple-token", "auth-code", null, null);
+
+        assertThat(existingUser.getAppleRefreshToken()).isEqualTo("apple-refresh-token");
+    }
+
+    @Test
+    @DisplayName("authorizationCode 교환에 실패해도 로그인은 계속 진행된다")
+    void loginWithAppleSucceedsEvenWhenAuthorizationCodeExchangeFails() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-103", null, "com.palang.app"));
+        User existingUser = user(103L, SnsProvider.APPLE);
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-103"))
+                .willReturn(Optional.of(existingUser));
+        given(appleAuthClient.exchangeForRefreshToken("auth-code", "com.palang.app")).willReturn(Optional.empty());
+        given(jwtTokenProvider.createAccessToken(103L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(103L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithApple("apple-token", "auth-code", null, null);
+
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(existingUser.getAppleRefreshToken()).isNull();
+    }
+
+    @Test
+    @DisplayName("이미 가입된 애플 사용자가 로그인하면 isNewUser가 false이고 이메일이 갱신된다")
+    void loginWithAppleSignsInExistingUser() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-200", "apple200@example.com", "com.palang.app"));
+        User existingUser = user(200L, SnsProvider.APPLE);
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-200"))
+                .willReturn(Optional.of(existingUser));
+        given(jwtTokenProvider.createAccessToken(200L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(200L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithApple("apple-token", null, null, null);
+
+        assertThat(result.isNewUser()).isFalse();
+        assertThat(existingUser.getEmail()).isEqualTo("apple200@example.com");
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any(), any());
+    }
+
+    @Test
+    @DisplayName("탈퇴한 계정으로 애플 로그인을 시도하면 예외가 발생한다")
+    void loginWithAppleFailsWhenAccountWithdrawn() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-300", null, "com.palang.app"));
+        User withdrawnUser = user(300L, SnsProvider.APPLE);
+        withdrawnUser.withdraw();
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-300"))
+                .willReturn(Optional.of(withdrawnUser));
+
+        assertThatThrownBy(() -> authService.loginWithApple("apple-token", null, null, null))
+                .isInstanceOf(AuthException.class);
+    }
+
+    @Test
     @DisplayName("[개발용] userId 없이 devLogin을 호출하면 새 테스트 유저를 만들어 로그인 처리한다")
     void devLoginCreatesNewUserWhenUserIdOmitted() {
         User newUser = user(400L);
-        given(userRegistrationService.registerViaSns(eq(SnsProvider.KAKAO), anyString(), any())).willReturn(newUser);
+        given(userRegistrationService.registerViaSns(eq(SnsProvider.KAKAO), anyString(), any(), any())).willReturn(newUser);
         given(jwtTokenProvider.createAccessToken(400L)).willReturn("access-token");
         given(jwtTokenProvider.createRefreshToken(400L)).willReturn("refresh-token");
         given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
@@ -146,7 +268,7 @@ class AuthServiceTest {
         AuthResult result = authService.devLogin(500L);
 
         assertThat(result.isNewUser()).isFalse();
-        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any());
+        verify(userRegistrationService, never()).registerViaSns(any(), anyString(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/auth/infrastructure/AppleAuthClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/infrastructure/AppleAuthClientTest.java
@@ -1,0 +1,60 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+// 네트워크(토큰 교환) 없이, client_secret JWT를 만드는 로직만 검증한다.
+class AppleAuthClientTest {
+
+    private static final String TEAM_ID = "TEAM1234";
+    private static final String KEY_ID = "KEY1234";
+    private static final String CLIENT_ID = "com.palang.app";
+
+    @Test
+    @DisplayName("client_secret은 Team ID/Key ID/client id로 서명된 유효한 ES256 JWT다")
+    void buildClientSecretProducesSignedJwtWithExpectedClaims() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair keyPair = generator.generateKeyPair();
+        String pem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded())
+                + "\n-----END PRIVATE KEY-----";
+
+        AppleAuthClient appleAuthClient = new AppleAuthClient(null, TEAM_ID, KEY_ID, pem);
+
+        String clientSecret = appleAuthClient.buildClientSecret(CLIENT_ID);
+
+        Claims claims = parseWithPublicKey(clientSecret, keyPair.getPublic());
+        assertThat(claims.getIssuer()).isEqualTo(TEAM_ID);
+        assertThat(claims.getSubject()).isEqualTo(CLIENT_ID);
+        assertThat(claims.getAudience()).containsExactly("https://appleid.apple.com");
+    }
+
+    @Test
+    @DisplayName("private key가 설정되지 않으면 authorizationCode 교환을 건너뛰고 빈 값을 반환한다")
+    void exchangeForRefreshTokenIsNoOpWhenPrivateKeyMissing() {
+        AppleAuthClient appleAuthClient = new AppleAuthClient(null, TEAM_ID, KEY_ID, "");
+
+        Optional<String> result = appleAuthClient.exchangeForRefreshToken("auth-code", CLIENT_ID);
+
+        assertThat(result).isEmpty();
+    }
+
+    private Claims parseWithPublicKey(String jwt, PublicKey publicKey) {
+        return Jwts.parser()
+                .verifyWith(publicKey)
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/auth/infrastructure/AppleOAuthClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/infrastructure/AppleOAuthClientTest.java
@@ -1,0 +1,128 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.domain.auth.infrastructure.dto.ApplePublicKeysResponse;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+// 네트워크(JWKS 조회) 없이, 서명/발급자/대상 검증 로직만 검증한다.
+// 실제 RSA 키쌍으로 identity token을 서명하고, 그 공개키로 JWKS 목록을 직접 구성해 verify()에 넣는다.
+class AppleOAuthClientTest {
+
+    private static final String ISSUER = "https://appleid.apple.com";
+    private static final String WEB_CLIENT_ID = "com.palang.web";
+    private static final String APP_CLIENT_ID = "com.palang.app";
+    private static final String KID = "test-kid";
+
+    private AppleOAuthClient appleOAuthClient;
+    private RSAPrivateKey privateKey;
+    private List<ApplePublicKeysResponse.ApplePublicKey> keys;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+
+        keys = List.of(new ApplePublicKeysResponse.ApplePublicKey(
+                "RSA", KID, "sig", "RS256",
+                encode(publicKey.getModulus()), encode(publicKey.getPublicExponent())));
+
+        appleOAuthClient = new AppleOAuthClient(null, WEB_CLIENT_ID, APP_CLIENT_ID);
+    }
+
+    @Test
+    @DisplayName("웹 Service ID를 대상으로 서명된 유효한 identity token은 검증에 성공하고 sub/email을 추출한다")
+    void verifySucceedsForWebAudience() {
+        String token = token(ISSUER, WEB_CLIENT_ID, "apple-sub-1", "user@example.com", 600);
+
+        AppleOAuthClient.AppleUserInfo userInfo = appleOAuthClient.verify(token, keys);
+
+        assertThat(userInfo.snsId()).isEqualTo("apple-sub-1");
+        assertThat(userInfo.email()).isEqualTo("user@example.com");
+        assertThat(userInfo.audience()).isEqualTo(WEB_CLIENT_ID);
+    }
+
+    @Test
+    @DisplayName("앱 Bundle ID를 대상으로 서명된 유효한 identity token도 검증에 성공한다")
+    void verifySucceedsForAppAudience() {
+        String token = token(ISSUER, APP_CLIENT_ID, "apple-sub-2", null, 600);
+
+        AppleOAuthClient.AppleUserInfo userInfo = appleOAuthClient.verify(token, keys);
+
+        assertThat(userInfo.snsId()).isEqualTo("apple-sub-2");
+        assertThat(userInfo.email()).isNull();
+        assertThat(userInfo.audience()).isEqualTo(APP_CLIENT_ID);
+    }
+
+    @Test
+    @DisplayName("발급자(iss)가 Apple이 아니면 검증에 실패한다")
+    void verifyFailsWhenIssuerMismatched() {
+        String token = token("https://not-apple.example.com", WEB_CLIENT_ID, "apple-sub-3", null, 600);
+
+        assertThatThrownBy(() -> appleOAuthClient.verify(token, keys)).isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("aud가 허용된 client id가 아니면 검증에 실패한다")
+    void verifyFailsWhenAudienceNotAllowed() {
+        String token = token(ISSUER, "unknown-client-id", "apple-sub-4", null, 600);
+
+        assertThatThrownBy(() -> appleOAuthClient.verify(token, keys)).isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 identity token은 검증에 실패한다")
+    void verifyFailsWhenTokenExpired() {
+        String token = token(ISSUER, WEB_CLIENT_ID, "apple-sub-5", null, -600);
+
+        assertThatThrownBy(() -> appleOAuthClient.verify(token, keys)).isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("JWKS 목록에 kid와 일치하는 키가 없으면 검증에 실패한다")
+    void verifyFailsWhenKeyNotFound() {
+        String token = token(ISSUER, WEB_CLIENT_ID, "apple-sub-6", null, 600);
+
+        assertThatThrownBy(() -> appleOAuthClient.verify(token, List.of())).isInstanceOf(RuntimeException.class);
+    }
+
+    private String token(String issuer, String audience, String subject, String email, long expirySeconds) {
+        var builder = Jwts.builder()
+                .header().add("kid", KID).and()
+                .issuer(issuer)
+                .audience().add(audience).and()
+                .subject(subject)
+                .expiration(Date.from(Instant.now().plusSeconds(expirySeconds)));
+        if (email != null) {
+            builder.claim("email", email);
+        }
+        return builder.signWith(privateKey, Jwts.SIG.RS256).compact();
+    }
+
+    private String encode(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            byte[] trimmed = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+            bytes = trimmed;
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/presentation/AuthControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.auth.application.AuthResult;
 import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.auth.presentation.dto.AppleLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.KakaoLoginRequest;
 import com.nexters.palang.domain.auth.presentation.dto.RefreshTokenRequest;
 import com.nexters.palang.global.security.AuthErrorCode;
@@ -76,6 +77,46 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(new KakaoLoginRequest("invalid-token"))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.title").value("AUTH_401_4"));
+    }
+
+    @Test
+    @DisplayName("애플 identity token으로 로그인하면 서비스 자체 JWT를 발급받는다")
+    void loginWithApple() throws Exception {
+        given(authService.loginWithApple("apple-token", "auth-code", "길동", "홍"))
+                .willReturn(new AuthResult("access", "refresh", true, false, false));
+
+        mockMvc.perform(post("/api/auth/apple")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new AppleLoginRequest("apple-token", "auth-code", "길동", "홍"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh"))
+                .andExpect(jsonPath("$.data.isNewUser").value(true));
+    }
+
+    @Test
+    @DisplayName("애플 identity token 없이 로그인을 요청하면 400 에러가 발생한다")
+    void loginWithAppleFailsWhenTokenBlank() throws Exception {
+        mockMvc.perform(post("/api/auth/apple")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new AppleLoginRequest("", null, null, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("애플 인증에 실패하면 401 에러가 발생한다")
+    void loginWithAppleFailsWhenAppleAuthFails() throws Exception {
+        given(authService.loginWithApple("invalid-token", null, null, null))
+                .willThrow(new AuthException(AuthErrorCode.APPLE_AUTH_FAILED));
+
+        mockMvc.perform(post("/api/auth/apple")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new AppleLoginRequest("invalid-token", null, null, null))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_6"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/application/UserRegistrationServiceTest.java
@@ -44,7 +44,7 @@ class UserRegistrationServiceTest {
         given(nicknameGenerator.generateBase()).willReturn("고요한책갈피");
         given(userRepository.saveAndFlush(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
 
-        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-1", "user1@example.com");
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-1", "user1@example.com", null);
 
         assertThat(user.getNickname()).isEqualTo("고요한책갈피");
         assertThat(user.getSnsProvider()).isEqualTo(SnsProvider.KAKAO);
@@ -63,7 +63,7 @@ class UserRegistrationServiceTest {
         given(userRepository.saveAndFlush(argThat(u -> u != null && u.getNickname().equals("고요한책갈피1"))))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-2", null);
+        User user = userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-2", null, null);
 
         assertThat(user.getNickname()).isEqualTo("고요한책갈피1");
     }
@@ -77,7 +77,7 @@ class UserRegistrationServiceTest {
         given(userRepository.saveAndFlush(any(User.class)))
                 .willThrow(new DataIntegrityViolationException("Duplicate entry for key 'users.uq_users_nickname'"));
 
-        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3", null))
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-3", null, null))
                 .isInstanceOf(UserException.class);
     }
 
@@ -89,7 +89,7 @@ class UserRegistrationServiceTest {
                 .willThrow(new DataIntegrityViolationException(
                         "Column 'terms_agreed_at' cannot be null"));
 
-        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-4", null))
+        assertThatThrownBy(() -> userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-4", null, null))
                 .isInstanceOf(DataIntegrityViolationException.class);
         verify(userRepository, times(1)).saveAndFlush(any());
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #71

## 🚀 개요
iOS 앱(네이티브 Sign in with Apple)을 우선 지원하는 Apple OAuth 소셜 로그인을 구현했습니다. 카카오 로그인과 동일하게 `POST /api/auth/apple` 하나로 가입/로그인을 처리하되, Apple identity token은 서버가 직접 JWKS로 서명을 검증해야 한다는 점이 다릅니다. 
또한 회원탈퇴 시 Apple 연동 해제(revoke)에 대비해 authorizationCode를 로그인 시점에 즉시 교환해 refresh token을 미리 확보해두었습니다.

## 📄 작업 내용
- `POST /api/auth/apple` 엔드포인트 추가 (`identityToken`, `authorizationCode`, `givenName`, `familyName` 수신, 응답은 카카오와 동일한 `LoginResponse`)
- Apple identity token을 JWKS(`/auth/keys`)로 직접 서명 검증 — 발급자(iss), 대상(aud: 웹 Service ID/앱 Bundle ID 모두 허용) 확인 (`AppleOAuthClient`)
- authorizationCode를 로그인 시점에 즉시 Apple에 교환해 refresh token 확보 (`AppleAuthClient`, client_secret ES256 JWT 생성 포함) — 실패해도 로그인 자체는 계속 진행 (best-effort)
- 애플이 최초 로그인 시에만 내려주는 실명(givenName/familyName)을 `User.name`에 저장
- `User` 엔티티에 `name`, `apple_refresh_token` 컬럼 추가
- `AUTH_401_6`(`APPLE_AUTH_FAILED`) 에러코드 추가
- `.gitignore`에 `.p8` 키 파일 제외 패턴 추가
- Apple 로그인 관련 단위 테스트 추가 (JWT 서명/발급자/대상 검증 로직, client_secret 생성 로직, 로그인 플로우 전반)

## 📸 스크린샷 / 테스트 결과 (선택)
- 실제 identityToken/authorizationCode를 통한 전체 로그인 플로우는 iOS 앱(프론트)이 있어야 확인 가능해 아직 미검증

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `User`에 실명(`name`)을 닉네임과 별개 필드로 저장하는 설계를 추가하였는데, 카카오 쪽은 일단 null로 저장될 듯 하네요!
- 프론트 쪽 테스트 이후 문제 발생 시 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 로그인을 지원합니다.
  * 웹과 iOS 앱에서 발급된 Apple 인증 정보를 검증할 수 있습니다.
  * 신규 가입 시 사용자 이름을 저장하며, Apple 계정의 갱신 토큰을 안전하게 관리합니다.
  * Apple 인증 실패 시 명확한 오류 응답을 제공합니다.

* **설정**
  * Apple 로그인에 필요한 클라이언트 ID, 팀 ID, 키 정보 설정 항목을 추가했습니다.

* **테스트**
  * Apple 로그인 성공, 신규 가입, 토큰 검증 실패 및 오류 응답 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->