### PR TITLE
Feat/#75 카카오 회원탈퇴 시 연동 해제(unlink) 처리

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -23,6 +23,9 @@ ALADIN_TTB_KEY=
 CLOVA_OCR_INVOKE_URL=
 CLOVA_OCR_SECRET_KEY=
 
+# ---- 카카오 로그인/회원탈퇴 (Admin Key: 카카오 개발자 콘솔 > 앱 설정 > 앱 키) ----
+KAKAO_ADMIN_KEY=
+
 # ---- Apple 로그인 ----
 APPLE_WEB_CLIENT_ID=
 APPLE_APP_CLIENT_ID=

--- a/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
+++ b/src/main/java/com/nexters/palang/domain/auth/application/AuthService.java
@@ -6,6 +6,7 @@ import com.nexters.palang.domain.auth.infrastructure.AppleOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
 import com.nexters.palang.domain.user.application.UserRegistrationService;
+import com.nexters.palang.domain.user.application.UserService;
 import com.nexters.palang.domain.user.common.error.UserErrorCode;
 import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.SnsProvider;
@@ -22,15 +23,18 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final UserService userService;
     private final UserRegistrationService userRegistrationService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final KakaoOAuthClient kakaoOAuthClient;
@@ -127,6 +131,27 @@ public class AuthService {
     public void logout(Long userId, String refreshToken) {
         refreshTokenRepository.findByUserIdAndTokenHash(userId, hash(refreshToken))
                 .ifPresent(RefreshToken::revoke);
+    }
+
+    // 카카오 연동 해제와 세션 무효화는 회원탈퇴의 도메인 규칙(소프트 삭제)이 아니라 auth 인프라(외부 API,
+    // 토큰 저장소)에 걸친 부수효과라 여기서 오케스트레이션하고, 실제 탈퇴 상태 변경은 UserService에 위임한다.
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = getActiveUser(userId);
+        if (user.getSnsProvider() == SnsProvider.KAKAO) {
+            unlinkKakao(user.getSnsId());
+        }
+        refreshTokenRepository.revokeAllByUserId(userId);
+        userService.withdraw(userId);
+    }
+
+    // 카카오 unlink가 실패해도(네트워크 오류, Admin Key 미설정 등) 탈퇴 자체를 막지는 않는다.
+    private void unlinkKakao(String snsId) {
+        try {
+            kakaoOAuthClient.unlink(snsId);
+        } catch (AuthException e) {
+            log.warn("카카오 연동 해제에 실패했습니다. snsId={}", snsId, e);
+        }
     }
 
     private AuthResult issueTokens(User user, boolean isNewUser) {

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
@@ -3,22 +3,37 @@ package com.nexters.palang.domain.auth.infrastructure;
 import com.nexters.palang.domain.auth.infrastructure.dto.KakaoUserInfoResponse;
 import com.nexters.palang.global.security.AuthErrorCode;
 import com.nexters.palang.global.security.AuthException;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Component
-@RequiredArgsConstructor
 public class KakaoOAuthClient {
 
+    private static final String USER_INFO_URI = "/v2/user/me";
+    private static final String UNLINK_URI = "/v1/user/unlink";
+
     private final WebClient kakaoWebClient;
+    private final String adminKey;
+
+    public KakaoOAuthClient(WebClient kakaoWebClient, @Value("${kakao.admin-key}") String adminKey) {
+        this.kakaoWebClient = kakaoWebClient;
+        this.adminKey = adminKey;
+    }
 
     // 모바일 앱이 카카오 SDK로 로그인 후 전달한 액세스 토큰을 카카오 서버에 직접 검증한다.
     public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         KakaoUserInfoResponse response;
         try {
             response = kakaoWebClient.get()
-                    .uri("/v2/user/me")
+                    .uri(USER_INFO_URI)
                     .headers(headers -> headers.setBearerAuth(kakaoAccessToken))
                     .retrieve()
                     .bodyToMono(KakaoUserInfoResponse.class)
@@ -32,6 +47,33 @@ public class KakaoOAuthClient {
         }
         String email = response.kakaoAccount() == null ? null : response.kakaoAccount().email();
         return new KakaoUserInfo(String.valueOf(response.id()), email);
+    }
+
+    // 회원탈퇴 시 카카오 연동을 서버 대 서버(Admin Key)로 해제한다. 사용자의 access token을
+    // 다시 받을 필요가 없어 탈퇴 API 계약이 단순해진다. Admin Key가 설정되지 않은 환경(로컬 등)에서는
+    // no-op으로 건너뛴다.
+    public void unlink(String snsId) {
+        if (adminKey == null || adminKey.isBlank()) {
+            log.debug("카카오 Admin Key가 설정되지 않아 연동 해제를 건너뜁니다.");
+            return;
+        }
+
+        try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("target_id_type", "user_id");
+            form.add("target_id", snsId);
+
+            kakaoWebClient.post()
+                    .uri(UNLINK_URI)
+                    .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + adminKey)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(form))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+        } catch (RuntimeException e) {
+            throw new AuthException(AuthErrorCode.KAKAO_UNLINK_FAILED);
+        }
     }
 
     // 이메일은 카카오계정(이메일) 동의항목을 거부했거나 미인증 상태면 null일 수 있다.

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClient.java
@@ -26,6 +26,11 @@ public class KakaoOAuthClient {
     public KakaoOAuthClient(WebClient kakaoWebClient, @Value("${kakao.admin-key}") String adminKey) {
         this.kakaoWebClient = kakaoWebClient;
         this.adminKey = adminKey;
+        // 배포 환경에서 설정을 빠뜨리면 회원탈퇴가 카카오 연동은 풀지 않은 채 조용히 성공해버릴 수 있어,
+        // 매 요청 로그(debug)와 별개로 기동 시점에 한 번 눈에 띄게 남긴다.
+        if (adminKey == null || adminKey.isBlank()) {
+            log.warn("kakao.admin-key가 설정되지 않았습니다. 회원탈퇴 시 카카오 연동 해제(unlink)가 동작하지 않습니다.");
+        }
     }
 
     // 모바일 앱이 카카오 SDK로 로그인 후 전달한 액세스 토큰을 카카오 서버에 직접 검증한다.

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
@@ -3,10 +3,18 @@ package com.nexters.palang.domain.auth.infrastructure;
 import com.nexters.palang.domain.auth.domain.RefreshToken;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUserIdAndTokenHashAndRevokedFalse(Long userId, String tokenHash);
 
     Optional<RefreshToken> findByUserIdAndTokenHash(Long userId, String tokenHash);
+
+    // 회원탈퇴 시 해당 유저의 모든 세션을 무효화하기 위해 개별 조회 없이 일괄 revoke한다.
+    @Modifying
+    @Query("update RefreshToken r set r.revoked = true where r.userId = :userId and r.revoked = false")
+    void revokeAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -109,7 +109,8 @@ public interface UserApi {
     );
 
     @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
-            + "공개된 발췌·의견·댓글은 남습니다). 카카오 계정은 서버가 연동을 함께 해제하며, 발급된 모든 리프레시 토큰도 즉시 무효화됩니다. "
+            + "공개된 발췌·의견·댓글은 남습니다). 카카오 연동 해제를 함께 시도하나 실패해도 탈퇴 자체는 계속 진행되며(best-effort), "
+            + "발급된 모든 리프레시 토큰은 즉시 무효화됩니다. "
             + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -109,7 +109,8 @@ public interface UserApi {
     );
 
     @Operation(summary = "회원 탈퇴", description = "소프트 삭제 처리하고 닉네임을 익명화합니다(다른 이용자의 대화 맥락 유지를 위해 "
-            + "공개된 발췌·의견·댓글은 남습니다). Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+            + "공개된 발췌·의견·댓글은 남습니다). 카카오 계정은 서버가 연동을 함께 해제하며, 발급된 모든 리프레시 토큰도 즉시 무효화됩니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.user.presentation;
 
+import com.nexters.palang.domain.auth.application.AuthService;
 import com.nexters.palang.domain.opinion.application.OpinionService;
 import com.nexters.palang.domain.user.application.UserMapper;
 import com.nexters.palang.domain.user.application.UserService;
@@ -36,6 +37,7 @@ public class UserController implements UserApi {
     private static final int MAX_SIZE = 100;
 
     private final UserService userService;
+    private final AuthService authService;
     private final OpinionService opinionService;
     private final CurrentUserProvider currentUserProvider;
 
@@ -77,7 +79,7 @@ public class UserController implements UserApi {
     @DeleteMapping("/api/users/me")
     public ResponseEntity<DataResponse<Void>> withdraw() {
         Long currentUserId = currentUserProvider.getCurrentUserId();
-        userService.withdraw(currentUserId);
+        authService.withdraw(currentUserId);
         return ResponseEntity.ok(DataResponse.from(null));
     }
 

--- a/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
+++ b/src/main/java/com/nexters/palang/global/security/AuthErrorCode.java
@@ -16,6 +16,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_5", "유효하지 않은 리프레시 토큰입니다."),
     APPLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_6", "애플 인증에 실패했습니다."),
     WITHDRAWN_ACCOUNT(HttpStatus.FORBIDDEN, "AUTH_403_1", "탈퇴한 계정입니다."),
+    KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "AUTH_502_1", "카카오 연동 해제에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -57,6 +57,7 @@ aladin:
 
 kakao:
   base-url: https://kapi.kakao.com
+  admin-key: ${KAKAO_ADMIN_KEY:}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ aladin:
 
 kakao:
   base-url: https://kapi.kakao.com
+  admin-key: ${KAKAO_ADMIN_KEY:}
 
 apple:
   base-url: https://appleid.apple.com

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -16,10 +17,12 @@ import com.nexters.palang.domain.auth.infrastructure.AppleOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.KakaoOAuthClient;
 import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
 import com.nexters.palang.domain.user.application.UserRegistrationService;
+import com.nexters.palang.domain.user.application.UserService;
 import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.AuthErrorCode;
 import com.nexters.palang.global.security.AuthException;
 import com.nexters.palang.global.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -39,6 +42,9 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserService userService;
 
     @Mock
     private UserRegistrationService userRegistrationService;
@@ -62,7 +68,7 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        authService = new AuthService(userRepository, userRegistrationService, refreshTokenRepository,
+        authService = new AuthService(userRepository, userService, userRegistrationService, refreshTokenRepository,
                 kakaoOAuthClient, appleOAuthClient, appleAuthClient, jwtTokenProvider);
     }
 
@@ -374,6 +380,53 @@ class AuthServiceTest {
         given(refreshTokenRepository.findByUserIdAndTokenHash(1L, sha256("refresh"))).willReturn(Optional.empty());
 
         authService.logout(1L, "refresh");
+    }
+
+    @Test
+    @DisplayName("카카오 사용자가 탈퇴하면 카카오 연동 해제와 리프레시 토큰 일괄 폐기, 소프트 삭제가 모두 이뤄진다")
+    void withdrawUnlinksKakaoAndRevokesTokens() {
+        User user = user(1L, SnsProvider.KAKAO);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        authService.withdraw(1L);
+
+        verify(kakaoOAuthClient).unlink("sns-1");
+        verify(refreshTokenRepository).revokeAllByUserId(1L);
+        verify(userService).withdraw(1L);
+    }
+
+    @Test
+    @DisplayName("애플 사용자가 탈퇴하면 카카오 연동 해제는 호출되지 않는다")
+    void withdrawDoesNotUnlinkKakaoForAppleUser() {
+        User user = user(1L, SnsProvider.APPLE);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        authService.withdraw(1L);
+
+        verify(kakaoOAuthClient, never()).unlink(anyString());
+        verify(refreshTokenRepository).revokeAllByUserId(1L);
+        verify(userService).withdraw(1L);
+    }
+
+    @Test
+    @DisplayName("카카오 연동 해제가 실패해도 탈퇴 자체는 계속 진행된다")
+    void withdrawContinuesEvenWhenKakaoUnlinkFails() {
+        User user = user(1L, SnsProvider.KAKAO);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        doThrow(new AuthException(AuthErrorCode.KAKAO_UNLINK_FAILED)).when(kakaoOAuthClient).unlink("sns-1");
+
+        authService.withdraw(1L);
+
+        verify(refreshTokenRepository).revokeAllByUserId(1L);
+        verify(userService).withdraw(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 탈퇴하려 하면 예외가 발생한다")
+    void withdrawFailsWhenUserNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.withdraw(999L)).isInstanceOf(UserException.class);
     }
 
     private String sha256(String value) {

--- a/src/test/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/infrastructure/KakaoOAuthClientTest.java
@@ -1,0 +1,26 @@
+package com.nexters.palang.domain.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+// 네트워크(연동 해제 호출) 없이, Admin Key 미설정 시 no-op으로 건너뛰는 분기만 검증한다.
+class KakaoOAuthClientTest {
+
+    @Test
+    @DisplayName("Admin Key가 설정되지 않으면 연동 해제 호출 없이 조용히 건너뛴다")
+    void unlinkIsNoOpWhenAdminKeyMissing() {
+        KakaoOAuthClient kakaoOAuthClient = new KakaoOAuthClient(null, "");
+
+        assertThatCode(() -> kakaoOAuthClient.unlink("sns-1")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Admin Key가 null이어도 연동 해제 호출 없이 조용히 건너뛴다")
+    void unlinkIsNoOpWhenAdminKeyNull() {
+        KakaoOAuthClient kakaoOAuthClient = new KakaoOAuthClient(null, null);
+
+        assertThatCode(() -> kakaoOAuthClient.unlink("sns-1")).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.auth.application.AuthService;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionService;
@@ -53,6 +54,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private AuthService authService;
 
     @MockitoBean
     private OpinionService opinionService;
@@ -224,14 +228,14 @@ class UserControllerTest {
         mockMvc.perform(delete("/api/users/me"))
                 .andExpect(status().isOk());
 
-        verify(userService).withdraw(1L);
+        verify(authService).withdraw(1L);
     }
 
     @Test
     @DisplayName("존재하지 않는 사용자가 탈퇴를 요청하면 404 에러가 발생한다")
     void withdrawFailsWhenNotFound() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        doThrow(new UserException(UserErrorCode.USER_NOT_FOUND)).when(userService).withdraw(1L);
+        doThrow(new UserException(UserErrorCode.USER_NOT_FOUND)).when(authService).withdraw(1L);
 
         mockMvc.perform(delete("/api/users/me"))
                 .andExpect(status().isNotFound())


### PR DESCRIPTION
## 📌 관련 이슈
- Close #75

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
회원탈퇴(`DELETE /api/users/me`) 시 카카오 연동이 그대로 남아있던 문제를 해결한다. Admin Key로 카카오 unlink를 서버 대 서버로 호출하고, 탈퇴한 유저의 모든 리프레시 토큰을 일괄 폐기하도록 탈퇴 흐름을 보강했다.

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- `KakaoOAuthClient.unlink(snsId)` 추가: Admin Key로 `POST /v1/user/unlink` 호출 (Admin Key 미설정 시 no-op으로 건너뜀, 애플 클라이언트와 동일한 graceful degradation 패턴)
- `AuthErrorCode.KAKAO_UNLINK_FAILED`(502) 추가
- `AuthService.withdraw(userId)` 신설: 카카오 유저면 unlink 시도(실패해도 탈퇴는 계속 진행) → 리프레시 토큰 일괄 revoke → `UserService.withdraw`로 소프트 삭제 위임
- `RefreshTokenRepository.revokeAllByUserId` bulk update 쿼리 추가 (기존에는 개별 토큰만 revoke 가능했음)
- `UserController.withdraw()`가 `AuthService.withdraw`를 호출하도록 변경 (`UserService.withdraw` 자체는 순수 소프트 삭제 로직 그대로 유지)
- `KAKAO_ADMIN_KEY` 환경변수 추가 (`application.yaml`, `application-prod.yaml`, `deploy/.env.example`)
- Swagger 문서(`UserApi`) 갱신

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
`./gradlew test` 전체 통과 (`BUILD SUCCESSFUL`)
- `KakaoOAuthClientTest` 신규 추가 (Admin Key 미설정 시 no-op 검증)
- `AuthServiceTest`에 withdraw 케이스 4개 추가 (카카오 unlink 호출, 애플은 unlink 미호출, unlink 실패해도 탈퇴 진행, 존재하지 않는 유저 예외)
- `UserControllerTest` withdraw 관련 테스트를 `AuthService` mocking으로 수정

로컬(local 프로파일, H2)에서 서버를 직접 띄워 실제 API로 확인:
- `dev-login` → `GET /api/users/me` (200, `snsProvider: KAKAO`) → `DELETE /api/users/me` (200, Admin Key 미설정이라도 에러 없이 처리)
- 탈퇴 후 `GET /api/users/me` → 404 `USER_404_1` (소프트 삭제 확인)
- 탈퇴 전 발급된 리프레시 토큰으로 `POST /api/auth/refresh` → 401 `AUTH_401_5` (일괄 revoke 확인)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 카카오 unlink 실패를 탈퇴 실패로 이어지지 않게(best-effort) 처리했는데, 이 정책이 맞을지 확인 부탁드립니다. (엄격하게 막아야 한다면 `AuthService.unlinkKakao`에서 예외를 다시 던지도록 바꿀 수 있습니다.)
- 회원탈퇴 오케스트레이션(카카오 unlink + 토큰 revoke)을 `UserService`가 아니라 `AuthService`에 둔 이유는, 로그인 흐름과 마찬가지로 auth 인프라(외부 API, 토큰 저장소)에 걸친 부수효과라 판단해서입니다. `UserService.withdraw`는 순수 소프트 삭제만 담당하도록 남겨뒀습니다.
- `KAKAO_ADMIN_KEY`는 GitHub Environment secret(`APP_ENV_FILE`)에 추가 완료했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴 시 카카오 계정 연동이 해제됩니다.
  * 발급된 모든 리프레시 토큰이 즉시 무효화됩니다.
  * 카카오 연동 해제에 실패해도 회원 탈퇴는 계속 진행됩니다.
* **개선 사항**
  * 카카오 연동 해제 실패 시 관련 오류가 안내됩니다.
  * 회원 탈퇴 API 설명이 실제 처리 방식에 맞게 보완되었습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
