### PR TITLE
Feat/#76 흔적/댓글 신고 및 사용자 차단 API

### DIFF
--- a/src/main/java/com/nexters/palang/domain/block/application/BlockService.java
+++ b/src/main/java/com/nexters/palang/domain/block/application/BlockService.java
@@ -1,0 +1,49 @@
+package com.nexters.palang.domain.block.application;
+
+import com.nexters.palang.domain.block.common.BlockErrorCode;
+import com.nexters.palang.domain.block.common.BlockException;
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.block.infrastructure.BlockQueryRepository;
+import com.nexters.palang.domain.block.infrastructure.UserBlockRepository;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlockService {
+
+    private final UserBlockRepository userBlockRepository;
+    private final BlockQueryRepository blockQueryRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void block(Long blockerId, Long blockedUserId) {
+        User blocked = userRepository.findById(blockedUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedUserId)) {
+            throw new BlockException(BlockErrorCode.ALREADY_BLOCKED);
+        }
+        User blocker = userRepository.getReferenceById(blockerId);
+        userBlockRepository.save(UserBlock.of(blocker, blocked));
+    }
+
+    @Transactional
+    public void unblock(Long blockerId, Long blockedUserId) {
+        if (!userBlockRepository.existsByBlockerIdAndBlockedId(blockerId, blockedUserId)) {
+            throw new BlockException(BlockErrorCode.BLOCK_NOT_FOUND);
+        }
+        userBlockRepository.deleteByBlockerIdAndBlockedId(blockerId, blockedUserId);
+    }
+
+    public Page<UserBlock> getBlockedUsers(Long blockerId, Pageable pageable) {
+        return blockQueryRepository.findBlockedUsers(blockerId, pageable);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/common/BlockErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/block/common/BlockErrorCode.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.block.common;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BlockErrorCode implements BaseErrorCode {
+
+    SELF_BLOCK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BLOCK_400_1", "본인을 차단할 수 없습니다."),
+    ALREADY_BLOCKED(HttpStatus.CONFLICT, "BLOCK_409_1", "이미 차단한 사용자입니다."),
+    BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK_404_1", "차단 내역을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/domain/block/common/BlockException.java
+++ b/src/main/java/com/nexters/palang/domain/block/common/BlockException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.block.common;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class BlockException extends AppException {
+
+    public BlockException(BlockErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/domain/UserBlock.java
+++ b/src/main/java/com/nexters/palang/domain/block/domain/UserBlock.java
@@ -1,0 +1,59 @@
+package com.nexters.palang.domain.block.domain;
+
+import com.nexters.palang.domain.block.common.BlockErrorCode;
+import com.nexters.palang.domain.block.common.BlockException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "user_blocks",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_user_blocks_blocker_blocked", columnNames = {"blocker_id", "blocked_id"}),
+        indexes = {
+                @Index(name = "idx_user_blocks_blocker", columnList = "blocker_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlock extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    private User blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    private User blocked;
+
+    private UserBlock(User blocker, User blocked) {
+        this.blocker = blocker;
+        this.blocked = blocked;
+    }
+
+    public static UserBlock of(User blocker, User blocked) {
+        if (blocker.getId().equals(blocked.getId())) {
+            throw new BlockException(BlockErrorCode.SELF_BLOCK_NOT_ALLOWED);
+        }
+        return new UserBlock(blocker, blocked);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/infrastructure/BlockQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/block/infrastructure/BlockQueryRepository.java
@@ -1,0 +1,39 @@
+package com.nexters.palang.domain.block.infrastructure;
+
+import com.nexters.palang.domain.block.domain.QUserBlock;
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<UserBlock> findBlockedUsers(Long blockerId, Pageable pageable) {
+        QUserBlock userBlock = QUserBlock.userBlock;
+
+        List<UserBlock> content = queryFactory
+                .selectFrom(userBlock)
+                .join(userBlock.blocked).fetchJoin()
+                .where(userBlock.blocker.id.eq(blockerId))
+                .orderBy(userBlock.createdAt.desc(), userBlock.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(userBlock.count())
+                .from(userBlock)
+                .where(userBlock.blocker.id.eq(blockerId))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepository.java
+++ b/src/main/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepository.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.block.infrastructure;
+
+import com.nexters.palang.domain.block.domain.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
+
+    boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    void deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+}

--- a/src/main/java/com/nexters/palang/domain/block/presentation/BlockApi.java
+++ b/src/main/java/com/nexters/palang/domain/block/presentation/BlockApi.java
@@ -1,0 +1,78 @@
+package com.nexters.palang.domain.block.presentation;
+
+import com.nexters.palang.domain.block.presentation.dto.BlockedUserListResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Block", description = "사용자 차단 API")
+public interface BlockApi {
+
+    @Operation(summary = "사용자 차단", description = "해당 사용자를 차단합니다. 차단하면 이후 흔적 목록에서 차단한 사용자의 흔적이 보이지 않습니다. "
+            + "본인은 차단할 수 없습니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "차단 성공"),
+            @ApiResponse(responseCode = "400", description = "본인 차단 시도 (BLOCK_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"BLOCK_400_1\","
+                                    + "\"status\":400,\"detail\":\"본인을 차단할 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음 (USER_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"USER_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 사용자를 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 차단한 사용자 (BLOCK_409_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"BLOCK_409_1\","
+                                    + "\"status\":409,\"detail\":\"이미 차단한 사용자입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> block(
+            @Parameter(description = "차단할 사용자 ID", required = true) Long userId
+    );
+
+    @Operation(summary = "사용자 차단 해제", description = "차단했던 사용자를 차단 해제합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "차단 해제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "차단 내역을 찾을 수 없음 (BLOCK_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/1/block\",\"title\":\"BLOCK_404_1\","
+                                    + "\"status\":404,\"detail\":\"차단 내역을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> unblock(
+            @Parameter(description = "차단 해제할 사용자 ID", required = true) Long userId
+    );
+
+    @Operation(summary = "차단 목록 조회", description = "내가 차단한 사용자 목록을 최신순으로 조회합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/blocks\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/blocks\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<BlockedUserListResponse>> getBlockedUsers(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+}

--- a/src/main/java/com/nexters/palang/domain/block/presentation/BlockController.java
+++ b/src/main/java/com/nexters/palang/domain/block/presentation/BlockController.java
@@ -1,0 +1,58 @@
+package com.nexters.palang.domain.block.presentation;
+
+import com.nexters.palang.domain.block.application.BlockService;
+import com.nexters.palang.domain.block.presentation.dto.BlockedUserListResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BlockController implements BlockApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final BlockService blockService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @PostMapping("/api/users/{userId}/block")
+    public ResponseEntity<DataResponse<Void>> block(@PathVariable Long userId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        blockService.block(currentUserId, userId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @DeleteMapping("/api/users/{userId}/block")
+    public ResponseEntity<DataResponse<Void>> unblock(@PathVariable Long userId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        blockService.unblock(currentUserId, userId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @GetMapping("/api/users/me/blocks")
+    public ResponseEntity<DataResponse<BlockedUserListResponse>> getBlockedUsers(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(
+                BlockedUserListResponse.from(blockService.getBlockedUsers(currentUserId, pageable(page, size)))));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/presentation/dto/BlockedUserListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/block/presentation/dto/BlockedUserListResponse.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.block.presentation.dto;
+
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record BlockedUserListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BlockedUserResponse> users,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+    public static BlockedUserListResponse from(Page<UserBlock> page) {
+        List<BlockedUserResponse> users = page.getContent().stream()
+                .map(BlockedUserResponse::from)
+                .toList();
+        return new BlockedUserListResponse(users, PageInfo.from(page));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/block/presentation/dto/BlockedUserResponse.java
+++ b/src/main/java/com/nexters/palang/domain/block/presentation/dto/BlockedUserResponse.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.block.presentation.dto;
+
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record BlockedUserResponse(
+        @Schema(example = "7", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "책읽는고양이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "https://pallang-assets.s3.ap-northeast-2.amazonaws.com/profile/7.png", nullable = true) String profileImageUrl,
+        @Schema(example = "2026-08-05T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime blockedAt
+) {
+    public static BlockedUserResponse from(UserBlock userBlock) {
+        User blocked = userBlock.getBlocked();
+        return new BlockedUserResponse(
+                blocked.getId(), blocked.getNickname(), blocked.getProfileImageUrl(), userBlock.getCreatedAt());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
+++ b/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
@@ -36,14 +36,14 @@ public class CommentService {
     private final OpinionRepository opinionRepository;
     private final UserRepository userRepository;
 
-    public Page<RootCommentGroup> getRootComments(Long opinionId, Pageable pageable) {
+    public Page<RootCommentGroup> getRootComments(Long opinionId, Pageable pageable, Long currentUserId) {
         validateOpinionExists(opinionId);
 
-        Page<Comment> roots = commentQueryRepository.findRootComments(opinionId, pageable);
+        Page<Comment> roots = commentQueryRepository.findRootComments(opinionId, pageable, currentUserId);
         List<Long> rootIds = roots.getContent().stream().map(Comment::getId).toList();
-        Map<Long, Long> replyCounts = commentQueryRepository.countRepliesByParentIds(rootIds);
+        Map<Long, Long> replyCounts = commentQueryRepository.countRepliesByParentIds(rootIds, currentUserId);
         Map<Long, List<Comment>> replyPreviews =
-                commentQueryRepository.findReplyPreviewsByParentIds(rootIds, REPLY_PREVIEW_SIZE);
+                commentQueryRepository.findReplyPreviewsByParentIds(rootIds, REPLY_PREVIEW_SIZE, currentUserId);
 
         return roots.map(root -> new RootCommentGroup(
                 root,
@@ -51,10 +51,10 @@ public class CommentService {
                 replyCounts.getOrDefault(root.getId(), 0L)));
     }
 
-    public Page<Comment> getReplies(Long parentCommentId, Pageable pageable) {
+    public Page<Comment> getReplies(Long parentCommentId, Pageable pageable, Long currentUserId) {
         Comment parent = getExistingComment(parentCommentId);
         getExistingOpinion(parent.getOpinion().getId());
-        return commentQueryRepository.findReplies(parentCommentId, pageable);
+        return commentQueryRepository.findReplies(parentCommentId, pageable, currentUserId);
     }
 
     @Transactional

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepository.java
@@ -1,8 +1,11 @@
 package com.nexters.palang.domain.comment.infrastructure;
 
+import com.nexters.palang.domain.block.domain.QUserBlock;
 import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.comment.domain.QComment;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,13 +22,14 @@ public class CommentQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Page<Comment> findRootComments(Long opinionId, Pageable pageable) {
+    public Page<Comment> findRootComments(Long opinionId, Pageable pageable, Long currentUserId) {
         QComment comment = QComment.comment;
+        BooleanExpression notBlocked = notBlockedByCurrentUser(comment, currentUserId);
 
         List<Comment> content = queryFactory
                 .selectFrom(comment)
                 .join(comment.user).fetchJoin()
-                .where(comment.opinion.id.eq(opinionId), comment.parentComment.isNull())
+                .where(comment.opinion.id.eq(opinionId), comment.parentComment.isNull(), notBlocked)
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -34,13 +38,13 @@ public class CommentQueryRepository {
         Long total = queryFactory
                 .select(comment.count())
                 .from(comment)
-                .where(comment.opinion.id.eq(opinionId), comment.parentComment.isNull())
+                .where(comment.opinion.id.eq(opinionId), comment.parentComment.isNull(), notBlocked)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    public Map<Long, Long> countRepliesByParentIds(List<Long> parentIds) {
+    public Map<Long, Long> countRepliesByParentIds(List<Long> parentIds, Long currentUserId) {
         if (parentIds.isEmpty()) {
             return Map.of();
         }
@@ -49,7 +53,7 @@ public class CommentQueryRepository {
         List<Tuple> counts = queryFactory
                 .select(comment.parentComment.id, comment.count())
                 .from(comment)
-                .where(comment.parentComment.id.in(parentIds))
+                .where(comment.parentComment.id.in(parentIds), notBlockedByCurrentUser(comment, currentUserId))
                 .groupBy(comment.parentComment.id)
                 .fetch();
 
@@ -61,18 +65,19 @@ public class CommentQueryRepository {
     }
 
     // 답글이 아무리 많아도 부모마다 최대 previewSize개만 DB에서 LIMIT으로 가져온다 (전체 답글을 로드하지 않는다).
-    public Map<Long, List<Comment>> findReplyPreviewsByParentIds(List<Long> parentIds, int previewSize) {
+    public Map<Long, List<Comment>> findReplyPreviewsByParentIds(List<Long> parentIds, int previewSize, Long currentUserId) {
         if (parentIds.isEmpty()) {
             return Map.of();
         }
         QComment comment = QComment.comment;
+        BooleanExpression notBlocked = notBlockedByCurrentUser(comment, currentUserId);
 
         Map<Long, List<Comment>> previewsByParentId = new LinkedHashMap<>();
         for (Long parentId : parentIds) {
             List<Comment> preview = queryFactory
                     .selectFrom(comment)
                     .join(comment.user).fetchJoin()
-                    .where(comment.parentComment.id.eq(parentId))
+                    .where(comment.parentComment.id.eq(parentId), notBlocked)
                     .orderBy(comment.createdAt.asc(), comment.id.asc())
                     .limit(previewSize)
                     .fetch();
@@ -81,13 +86,14 @@ public class CommentQueryRepository {
         return previewsByParentId;
     }
 
-    public Page<Comment> findReplies(Long parentCommentId, Pageable pageable) {
+    public Page<Comment> findReplies(Long parentCommentId, Pageable pageable, Long currentUserId) {
         QComment comment = QComment.comment;
+        BooleanExpression notBlocked = notBlockedByCurrentUser(comment, currentUserId);
 
         List<Comment> content = queryFactory
                 .selectFrom(comment)
                 .join(comment.user).fetchJoin()
-                .where(comment.parentComment.id.eq(parentCommentId))
+                .where(comment.parentComment.id.eq(parentCommentId), notBlocked)
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -96,9 +102,21 @@ public class CommentQueryRepository {
         Long total = queryFactory
                 .select(comment.count())
                 .from(comment)
-                .where(comment.parentComment.id.eq(parentCommentId))
+                .where(comment.parentComment.id.eq(parentCommentId), notBlocked)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // 차단(신고·차단 기능): 로그인 사용자가 차단한 작성자의 댓글/답글은 목록에서 제외한다.
+    private BooleanExpression notBlockedByCurrentUser(QComment comment, Long currentUserId) {
+        if (currentUserId == null) {
+            return null;
+        }
+        QUserBlock userBlock = QUserBlock.userBlock;
+        return comment.user.id.notIn(JPAExpressions
+                .select(userBlock.blocked.id)
+                .from(userBlock)
+                .where(userBlock.blocker.id.eq(currentUserId)));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
@@ -24,7 +24,8 @@ public interface CommentApi {
     @Operation(summary = "댓글 목록 조회",
             description = "흔적에 달린 원댓글과 답글을 조회합니다. 원댓글은 page/size로 페이지네이션되며, "
                     + "각 원댓글에는 답글이 최대 5개까지 미리보기로 포함됩니다. 5개를 초과하면 hasMoreReplies=true이며, "
-                    + "나머지는 GET /api/comments/{commentId}/replies로 조회합니다.")
+                    + "나머지는 GET /api/comments/{commentId}/replies로 조회합니다. "
+                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 댓글/답글은 목록에서 제외됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
@@ -43,7 +44,8 @@ public interface CommentApi {
     );
 
     @Operation(summary = "답글 더보기",
-            description = "특정 원댓글에 달린 답글을 page/size로 페이지네이션 조회합니다.")
+            description = "특정 원댓글에 달린 답글을 page/size로 페이지네이션 조회합니다. "
+                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 답글은 목록에서 제외됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/CommentController.java
@@ -41,8 +41,9 @@ public class CommentController implements CommentApi {
             @PathVariable Long opinionId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        return ResponseEntity.ok(DataResponse.from(
-                CommentMapper.toRootListResponse(commentService.getRootComments(opinionId, pageable(page, size)))));
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        return ResponseEntity.ok(DataResponse.from(CommentMapper.toRootListResponse(
+                commentService.getRootComments(opinionId, pageable(page, size), currentUserId))));
     }
 
     @Override
@@ -51,8 +52,9 @@ public class CommentController implements CommentApi {
             @PathVariable Long commentId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
         return ResponseEntity.ok(DataResponse.from(
-                CommentMapper.toListResponse(commentService.getReplies(commentId, pageable(page, size)))));
+                CommentMapper.toListResponse(commentService.getReplies(commentId, pageable(page, size), currentUserId))));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
+import com.nexters.palang.domain.block.domain.QUserBlock;
 import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.comment.domain.QComment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
@@ -13,6 +14,7 @@ import com.nexters.palang.domain.user.domain.QUser;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -37,6 +39,7 @@ public class OpinionQueryRepository {
         QUser user = QUser.user;
         QOpinionLike opinionLike = QOpinionLike.opinionLike;
         QComment comment = QComment.comment;
+        QUserBlock userBlock = QUserBlock.userBlock;
 
         Expression<Boolean> likedExpression = currentUserId != null
                 ? JPAExpressions.selectOne()
@@ -50,13 +53,21 @@ public class OpinionQueryRepository {
                 .from(comment)
                 .where(comment.opinion.id.eq(opinion.id), comment.deletedAt.isNull());
 
+        // 차단(신고·차단 기능): 로그인 사용자가 차단한 작성자의 흔적은 피드에서 제외한다.
+        BooleanExpression notBlockedByCurrentUser = currentUserId != null
+                ? opinion.user.id.notIn(JPAExpressions
+                        .select(userBlock.blocked.id)
+                        .from(userBlock)
+                        .where(userBlock.blocker.id.eq(currentUserId)))
+                : null;
+
         List<OpinionSummaryProjection> content = queryFactory
                 .select(Projections.constructor(OpinionSummaryProjection.class,
                         opinion.id, user.id, user.nickname, opinion.content, opinion.likeCount, opinion.createdAt,
                         likedExpression, commentCountExpression))
                 .from(opinion)
                 .join(opinion.user, user)
-                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())
+                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull(), notBlockedByCurrentUser)
                 .orderBy(orderSpecifiers(sortType, opinion))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -65,7 +76,7 @@ public class OpinionQueryRepository {
         Long total = queryFactory
                 .select(opinion.count())
                 .from(opinion)
-                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull())
+                .where(opinion.passage.id.eq(passageId), opinion.deletedAt.isNull(), notBlockedByCurrentUser)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);

--- a/src/main/java/com/nexters/palang/domain/report/application/ReportService.java
+++ b/src/main/java/com/nexters/palang/domain/report/application/ReportService.java
@@ -1,0 +1,79 @@
+package com.nexters.palang.domain.report.application;
+
+import com.nexters.palang.domain.comment.common.CommentErrorCode;
+import com.nexters.palang.domain.comment.common.CommentException;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.report.common.ReportErrorCode;
+import com.nexters.palang.domain.report.common.ReportException;
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportTargetType;
+import com.nexters.palang.domain.report.infrastructure.ReportRepository;
+import com.nexters.palang.domain.report.presentation.dto.CreateReportRequest;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final OpinionRepository opinionRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Report reportOpinion(Long opinionId, Long reporterId, CreateReportRequest request) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        validateNotSelf(opinion.getUser().getId(), reporterId);
+        return saveReport(reporterId, ReportTargetType.OPINION, opinionId, request);
+    }
+
+    @Transactional
+    public Report reportComment(Long commentId, Long reporterId, CreateReportRequest request) {
+        Comment comment = getExistingComment(commentId);
+        validateNotSelf(comment.getUser().getId(), reporterId);
+        return saveReport(reporterId, ReportTargetType.COMMENT, commentId, request);
+    }
+
+    private Report saveReport(Long reporterId, ReportTargetType targetType, Long targetId, CreateReportRequest request) {
+        if (reportRepository.existsByReporterIdAndTargetTypeAndTargetId(reporterId, targetType, targetId)) {
+            throw new ReportException(ReportErrorCode.DUPLICATE_REPORT);
+        }
+        User reporter = userRepository.getReferenceById(reporterId);
+        Report report = Report.of(reporter, targetType, targetId, request.reason(), request.detail());
+        return reportRepository.save(report);
+    }
+
+    private void validateNotSelf(Long targetOwnerId, Long reporterId) {
+        if (targetOwnerId.equals(reporterId)) {
+            throw new ReportException(ReportErrorCode.SELF_REPORT_NOT_ALLOWED);
+        }
+    }
+
+    private Opinion getExistingOpinion(Long opinionId) {
+        Opinion opinion = opinionRepository.findById(opinionId)
+                .orElseThrow(() -> new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
+        if (opinion.isDeleted()) {
+            throw new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND);
+        }
+        return opinion;
+    }
+
+    private Comment getExistingComment(Long commentId) {
+        Comment comment = commentRepository.findByIdWithUser(commentId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+        if (comment.isDeleted()) {
+            throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
+        }
+        return comment;
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/report/common/ReportErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/report/common/ReportErrorCode.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.report.common;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReportErrorCode implements BaseErrorCode {
+
+    DETAIL_REQUIRED_FOR_ETC(HttpStatus.BAD_REQUEST, "REPORT_400_1", "기타 사유를 선택한 경우 상세 내용을 입력해야 합니다."),
+    SELF_REPORT_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT_400_2", "본인이 작성한 콘텐츠는 신고할 수 없습니다."),
+    DUPLICATE_REPORT(HttpStatus.CONFLICT, "REPORT_409_1", "이미 신고한 대상입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/domain/report/common/ReportException.java
+++ b/src/main/java/com/nexters/palang/domain/report/common/ReportException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.report.common;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class ReportException extends AppException {
+
+    public ReportException(ReportErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/report/domain/Report.java
+++ b/src/main/java/com/nexters/palang/domain/report/domain/Report.java
@@ -1,0 +1,78 @@
+package com.nexters.palang.domain.report.domain;
+
+import com.nexters.palang.domain.report.common.ReportErrorCode;
+import com.nexters.palang.domain.report.common.ReportException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "reports",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reports_reporter_target",
+                columnNames = {"reporter_id", "target_type", "target_id"}),
+        indexes = {
+                @Index(name = "idx_reports_target", columnList = "target_type, target_id")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseEntity {
+
+    public static final int DETAIL_MAX_LENGTH = 500;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private ReportTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private ReportReason reason;
+
+    @Column(name = "detail", length = DETAIL_MAX_LENGTH)
+    private String detail;
+
+    private Report(User reporter, ReportTargetType targetType, Long targetId, ReportReason reason, String detail) {
+        this.reporter = reporter;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.reason = reason;
+        this.detail = detail;
+    }
+
+    // 기타 사유는 상세 내용 없이는 신고 검토에 쓸모가 없으므로 생성 시점에 막는다.
+    public static Report of(User reporter, ReportTargetType targetType, Long targetId, ReportReason reason, String detail) {
+        if (reason == ReportReason.ETC && (detail == null || detail.isBlank())) {
+            throw new ReportException(ReportErrorCode.DETAIL_REQUIRED_FOR_ETC);
+        }
+        return new Report(reporter, targetType, targetId, reason, detail);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/report/domain/ReportReason.java
+++ b/src/main/java/com/nexters/palang/domain/report/domain/ReportReason.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.domain.report.domain;
+
+public enum ReportReason {
+    SPAM,
+    HATE,
+    ABUSE,
+    COPYRIGHT,
+    ETC
+}

--- a/src/main/java/com/nexters/palang/domain/report/domain/ReportTargetType.java
+++ b/src/main/java/com/nexters/palang/domain/report/domain/ReportTargetType.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.report.domain;
+
+public enum ReportTargetType {
+    OPINION,
+    COMMENT
+}

--- a/src/main/java/com/nexters/palang/domain/report/infrastructure/ReportRepository.java
+++ b/src/main/java/com/nexters/palang/domain/report/infrastructure/ReportRepository.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.report.infrastructure;
+
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportTargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByReporterIdAndTargetTypeAndTargetId(Long reporterId, ReportTargetType targetType, Long targetId);
+}

--- a/src/main/java/com/nexters/palang/domain/report/presentation/ReportApi.java
+++ b/src/main/java/com/nexters/palang/domain/report/presentation/ReportApi.java
@@ -1,0 +1,86 @@
+package com.nexters.palang.domain.report.presentation;
+
+import com.nexters.palang.domain.report.presentation.dto.CreateReportRequest;
+import com.nexters.palang.domain.report.presentation.dto.ReportResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Report", description = "신고 API")
+public interface ReportApi {
+
+    @Operation(summary = "흔적 신고", description = "흔적을 사유(스팸/혐오/욕설/저작권/기타)와 함께 신고합니다. "
+            + "기타 사유는 상세 내용이 필수입니다. 본인이 작성한 흔적, 이미 신고한 흔적은 신고할 수 없습니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신고 접수 성공"),
+            @ApiResponse(responseCode = "400", description = "사유 누락(COMMON_400_1) 또는 기타 사유에 상세 내용 누락(REPORT_400_1) "
+                    + "또는 본인 흔적 신고 시도(REPORT_400_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "REPORT_400_1", value = "{\"type\":\"/api/opinions/1/reports\","
+                                    + "\"title\":\"REPORT_400_1\",\"status\":400,"
+                                    + "\"detail\":\"기타 사유를 선택한 경우 상세 내용을 입력해야 합니다.\"}"),
+                            @ExampleObject(name = "REPORT_400_2", value = "{\"type\":\"/api/opinions/1/reports\","
+                                    + "\"title\":\"REPORT_400_2\",\"status\":400,"
+                                    + "\"detail\":\"본인이 작성한 콘텐츠는 신고할 수 없습니다.\"}")
+                    })),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1/reports\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1/reports\",\"title\":\"OPINION_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 흔적을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 신고한 대상 (REPORT_409_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1/reports\",\"title\":\"REPORT_409_1\","
+                                    + "\"status\":409,\"detail\":\"이미 신고한 대상입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<ReportResponse>> reportOpinion(
+            @Parameter(description = "흔적 ID", required = true) Long opinionId,
+            @Valid CreateReportRequest request
+    );
+
+    @Operation(summary = "댓글 신고", description = "댓글/답글을 사유(스팸/혐오/욕설/저작권/기타)와 함께 신고합니다. "
+            + "기타 사유는 상세 내용이 필수입니다. 본인이 작성한 댓글, 이미 신고한 댓글은 신고할 수 없습니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신고 접수 성공"),
+            @ApiResponse(responseCode = "400", description = "사유 누락(COMMON_400_1) 또는 기타 사유에 상세 내용 누락(REPORT_400_1) "
+                    + "또는 본인 댓글 신고 시도(REPORT_400_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "REPORT_400_1", value = "{\"type\":\"/api/comments/1/reports\","
+                                    + "\"title\":\"REPORT_400_1\",\"status\":400,"
+                                    + "\"detail\":\"기타 사유를 선택한 경우 상세 내용을 입력해야 합니다.\"}"),
+                            @ExampleObject(name = "REPORT_400_2", value = "{\"type\":\"/api/comments/1/reports\","
+                                    + "\"title\":\"REPORT_400_2\",\"status\":400,"
+                                    + "\"detail\":\"본인이 작성한 콘텐츠는 신고할 수 없습니다.\"}")
+                    })),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/comments/1/reports\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음 (COMMENT_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/comments/1/reports\",\"title\":\"COMMENT_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 댓글을 찾을 수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "409", description = "이미 신고한 대상 (REPORT_409_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/comments/1/reports\",\"title\":\"REPORT_409_1\","
+                                    + "\"status\":409,\"detail\":\"이미 신고한 대상입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<ReportResponse>> reportComment(
+            @Parameter(description = "댓글 ID", required = true) Long commentId,
+            @Valid CreateReportRequest request
+    );
+}

--- a/src/main/java/com/nexters/palang/domain/report/presentation/ReportController.java
+++ b/src/main/java/com/nexters/palang/domain/report/presentation/ReportController.java
@@ -1,0 +1,43 @@
+package com.nexters.palang.domain.report.presentation;
+
+import com.nexters.palang.domain.report.application.ReportService;
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.presentation.dto.CreateReportRequest;
+import com.nexters.palang.domain.report.presentation.dto.ReportResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController implements ReportApi {
+
+    private final ReportService reportService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @PostMapping("/api/opinions/{opinionId}/reports")
+    public ResponseEntity<DataResponse<ReportResponse>> reportOpinion(
+            @PathVariable Long opinionId,
+            @RequestBody @Valid CreateReportRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Report report = reportService.reportOpinion(opinionId, currentUserId, request);
+        return ResponseEntity.ok(DataResponse.from(ReportResponse.from(report)));
+    }
+
+    @Override
+    @PostMapping("/api/comments/{commentId}/reports")
+    public ResponseEntity<DataResponse<ReportResponse>> reportComment(
+            @PathVariable Long commentId,
+            @RequestBody @Valid CreateReportRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Report report = reportService.reportComment(commentId, currentUserId, request);
+        return ResponseEntity.ok(DataResponse.from(ReportResponse.from(report)));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/report/presentation/dto/CreateReportRequest.java
+++ b/src/main/java/com/nexters/palang/domain/report/presentation/dto/CreateReportRequest.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.report.presentation.dto;
+
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateReportRequest(
+        @NotNull(message = "신고 사유는 필수입니다.")
+        @Schema(example = "SPAM", requiredMode = Schema.RequiredMode.REQUIRED)
+        ReportReason reason,
+        @Size(max = Report.DETAIL_MAX_LENGTH, message = "상세 내용은 500자를 초과할 수 없습니다.")
+        @Schema(description = "기타 사유 선택 시 필수", example = "같은 광고 링크를 반복해서 남겼어요.", nullable = true)
+        String detail
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/report/presentation/dto/ReportResponse.java
+++ b/src/main/java/com/nexters/palang/domain/report/presentation/dto/ReportResponse.java
@@ -1,0 +1,26 @@
+package com.nexters.palang.domain.report.presentation.dto;
+
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportReason;
+import com.nexters.palang.domain.report.domain.ReportTargetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record ReportResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long reportId,
+        @Schema(example = "OPINION", requiredMode = Schema.RequiredMode.REQUIRED) ReportTargetType targetType,
+        @Schema(example = "10", requiredMode = Schema.RequiredMode.REQUIRED) Long targetId,
+        @Schema(example = "SPAM", requiredMode = Schema.RequiredMode.REQUIRED) ReportReason reason,
+        @Schema(example = "같은 광고 링크를 반복해서 남겼어요.", nullable = true) String detail,
+        @Schema(example = "2026-08-05T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+    public static ReportResponse from(Report report) {
+        return new ReportResponse(
+                report.getId(),
+                report.getTargetType(),
+                report.getTargetId(),
+                report.getReason(),
+                report.getDetail(),
+                report.getCreatedAt());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/block/application/BlockServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/block/application/BlockServiceTest.java
@@ -1,0 +1,98 @@
+package com.nexters.palang.domain.block.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.block.common.BlockException;
+import com.nexters.palang.domain.block.infrastructure.BlockQueryRepository;
+import com.nexters.palang.domain.block.infrastructure.UserBlockRepository;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BlockServiceTest {
+
+    @Mock
+    private UserBlockRepository userBlockRepository;
+
+    @Mock
+    private BlockQueryRepository blockQueryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private BlockService blockService;
+
+    private User blocker;
+    private User target;
+
+    @BeforeEach
+    void setUp() {
+        blockService = new BlockService(userBlockRepository, blockQueryRepository, userRepository);
+        blocker = user(1L);
+        target = user(2L);
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 차단하면 예외가 발생한다")
+    void blockFailsWhenTargetNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> blockService.block(blocker.getId(), 999L)).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("이미 차단한 사용자를 다시 차단하면 예외가 발생한다")
+    void blockFailsWhenAlreadyBlocked() {
+        given(userRepository.findById(target.getId())).willReturn(Optional.of(target));
+        given(userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), target.getId())).willReturn(true);
+
+        assertThatThrownBy(() -> blockService.block(blocker.getId(), target.getId())).isInstanceOf(BlockException.class);
+    }
+
+    @Test
+    @DisplayName("본인을 차단하려 하면 예외가 발생한다")
+    void blockFailsWhenSelfBlock() {
+        given(userRepository.findById(blocker.getId())).willReturn(Optional.of(blocker));
+        given(userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), blocker.getId())).willReturn(false);
+        given(userRepository.getReferenceById(blocker.getId())).willReturn(blocker);
+
+        assertThatThrownBy(() -> blockService.block(blocker.getId(), blocker.getId())).isInstanceOf(BlockException.class);
+    }
+
+    @Test
+    @DisplayName("차단 해제할 내역이 없으면 예외가 발생한다")
+    void unblockFailsWhenNotFound() {
+        given(userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), target.getId())).willReturn(false);
+
+        assertThatThrownBy(() -> blockService.unblock(blocker.getId(), target.getId())).isInstanceOf(BlockException.class);
+        verify(userBlockRepository, never()).deleteByBlockerIdAndBlockedId(blocker.getId(), target.getId());
+    }
+
+    @Test
+    @DisplayName("차단 내역이 있으면 차단을 해제한다")
+    void unblockDeletesExistingBlock() {
+        given(userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), target.getId())).willReturn(true);
+
+        blockService.unblock(blocker.getId(), target.getId());
+
+        verify(userBlockRepository).deleteByBlockerIdAndBlockedId(blocker.getId(), target.getId());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/block/domain/UserBlockTest.java
+++ b/src/test/java/com/nexters/palang/domain/block/domain/UserBlockTest.java
@@ -1,0 +1,39 @@
+package com.nexters.palang.domain.block.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.domain.block.common.BlockException;
+import com.nexters.palang.domain.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class UserBlockTest {
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("서로 다른 사용자를 차단하면 정상적으로 생성된다")
+    void createsUserBlockForDifferentUsers() {
+        User blocker = user(1L);
+        User blocked = user(2L);
+
+        UserBlock userBlock = UserBlock.of(blocker, blocked);
+
+        assertThat(userBlock.getBlocker()).isEqualTo(blocker);
+        assertThat(userBlock.getBlocked()).isEqualTo(blocked);
+    }
+
+    @Test
+    @DisplayName("본인을 차단하려 하면 예외가 발생한다")
+    void throwsWhenBlockingSelf() {
+        User self = user(1L);
+
+        assertThatThrownBy(() -> UserBlock.of(self, self)).isInstanceOf(BlockException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/block/infrastructure/BlockQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/block/infrastructure/BlockQueryRepositoryTest.java
@@ -1,0 +1,73 @@
+package com.nexters.palang.domain.block.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class BlockQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private BlockQueryRepository blockQueryRepository;
+
+    private User blocker;
+
+    @BeforeEach
+    void setUp() {
+        blockQueryRepository = new BlockQueryRepository(new JPAQueryFactory(entityManager.getEntityManager()));
+        blocker = user("blocker");
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId)
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Test
+    @DisplayName("차단한 사용자 목록을 최신순으로 조회하고 다른 사람의 차단 목록은 제외한다")
+    void findBlockedUsersOrdersByCreatedAtDescendingAndExcludesOtherBlockers() {
+        User other = user("other-b");
+        User first = user("first-b");
+        User second = user("second-b");
+        User notMine = user("not-mine");
+        entityManager.persistAndFlush(UserBlock.of(blocker, first));
+        entityManager.persistAndFlush(UserBlock.of(blocker, second));
+        entityManager.persistAndFlush(UserBlock.of(other, notMine));
+
+        Page<UserBlock> result = blockQueryRepository.findBlockedUsers(blocker.getId(), PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).extracting(block -> block.getBlocked().getId())
+                .containsExactly(second.getId(), first.getId());
+    }
+
+    @Test
+    @DisplayName("차단한 사용자가 없으면 빈 목록을 반환한다")
+    void findBlockedUsersReturnsEmptyWhenNoBlocks() {
+        Page<UserBlock> result = blockQueryRepository.findBlockedUsers(blocker.getId(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.nexters.palang.domain.block.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class UserBlockRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private UserBlockRepository userBlockRepository;
+
+    private User blocker;
+    private User blocked;
+
+    @BeforeEach
+    void setUp() {
+        blocker = user("blocker");
+        blocked = user("blocked");
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId)
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId(snsId)
+                .termsAgreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Test
+    @DisplayName("차단 관계를 저장하면 존재 여부를 조회할 수 있다")
+    void existsByBlockerIdAndBlockedIdReturnsTrueAfterSave() {
+        entityManager.persistAndFlush(UserBlock.of(blocker, blocked));
+
+        boolean exists = userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), blocked.getId());
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("차단 관계가 없으면 존재하지 않는다고 조회된다")
+    void existsByBlockerIdAndBlockedIdReturnsFalseWhenNotBlocked() {
+        boolean exists = userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), blocked.getId());
+
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("차단을 삭제하면 더 이상 존재하지 않는다")
+    void deleteByBlockerIdAndBlockedIdRemovesBlock() {
+        entityManager.persistAndFlush(UserBlock.of(blocker, blocked));
+
+        userBlockRepository.deleteByBlockerIdAndBlockedId(blocker.getId(), blocked.getId());
+        entityManager.flush();
+
+        assertThat(userBlockRepository.existsByBlockerIdAndBlockedId(blocker.getId(), blocked.getId())).isFalse();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/block/presentation/BlockControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/block/presentation/BlockControllerTest.java
@@ -1,0 +1,133 @@
+package com.nexters.palang.domain.block.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nexters.palang.domain.block.application.BlockService;
+import com.nexters.palang.domain.block.common.BlockErrorCode;
+import com.nexters.palang.domain.block.common.BlockException;
+import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BlockController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class BlockControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BlockService blockService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 20);
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private UserBlock userBlock(User blocker, User blocked) {
+        return UserBlock.of(blocker, blocked);
+    }
+
+    @Test
+    @DisplayName("사용자를 차단하면 서비스에 차단을 위임한다")
+    void block() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(post("/api/users/2/block")).andExpect(status().isOk());
+
+        verify(blockService).block(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("인증 없이 차단을 시도하면 401 에러가 발생한다")
+    void blockFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/users/2/block"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("본인을 차단하려 하면 400 에러가 발생한다")
+    void blockFailsWhenSelfBlock() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        doThrow(new BlockException(BlockErrorCode.SELF_BLOCK_NOT_ALLOWED)).when(blockService).block(1L, 1L);
+
+        mockMvc.perform(post("/api/users/1/block"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("BLOCK_400_1"));
+    }
+
+    @Test
+    @DisplayName("이미 차단한 사용자를 다시 차단하면 409 에러가 발생한다")
+    void blockFailsWhenAlreadyBlocked() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        doThrow(new BlockException(BlockErrorCode.ALREADY_BLOCKED)).when(blockService).block(1L, 2L);
+
+        mockMvc.perform(post("/api/users/2/block"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("BLOCK_409_1"));
+    }
+
+    @Test
+    @DisplayName("차단을 해제하면 서비스에 해제를 위임한다")
+    void unblock() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/users/2/block")).andExpect(status().isOk());
+
+        verify(blockService).unblock(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("차단 내역이 없으면 차단 해제 시 404 에러가 발생한다")
+    void unblockFailsWhenNotFound() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        doThrow(new BlockException(BlockErrorCode.BLOCK_NOT_FOUND)).when(blockService).unblock(1L, 2L);
+
+        mockMvc.perform(delete("/api/users/2/block"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("BLOCK_404_1"));
+    }
+
+    @Test
+    @DisplayName("차단 목록을 조회하면 차단한 사용자 목록을 반환한다")
+    void getBlockedUsers() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        UserBlock block = userBlock(user(1L), user(2L));
+        given(blockService.getBlockedUsers(eq(1L), any())).willReturn(new PageImpl<>(List.of(block), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/blocks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.users[0].userId").value(2));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
@@ -90,7 +90,7 @@ class CommentServiceTest {
     void getRootCommentsFailsWhenOpinionNotFound() {
         given(opinionRepository.findById(999L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> commentService.getRootComments(999L, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> commentService.getRootComments(999L, PageRequest.of(0, 20), null))
                 .isInstanceOf(OpinionException.class);
     }
 
@@ -100,7 +100,7 @@ class CommentServiceTest {
         opinion.delete();
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
 
-        assertThatThrownBy(() -> commentService.getRootComments(1L, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> commentService.getRootComments(1L, PageRequest.of(0, 20), null))
                 .isInstanceOf(OpinionException.class);
     }
 
@@ -111,19 +111,19 @@ class CommentServiceTest {
         Comment root1 = rootComment(1L, opinion, writer);
         Comment root2 = rootComment(2L, opinion, writer);
         Pageable pageable = PageRequest.of(0, 20);
-        given(commentQueryRepository.findRootComments(1L, pageable))
+        given(commentQueryRepository.findRootComments(1L, pageable, null))
                 .willReturn(new PageImpl<>(List.of(root1, root2), pageable, 2));
 
         List<Comment> root1Preview = List.of(
                 replyComment(11L, root1, writer), replyComment(12L, root1, writer),
                 replyComment(13L, root1, writer), replyComment(14L, root1, writer),
                 replyComment(15L, root1, writer));
-        given(commentQueryRepository.countRepliesByParentIds(List.of(1L, 2L)))
+        given(commentQueryRepository.countRepliesByParentIds(List.of(1L, 2L), null))
                 .willReturn(Map.of(1L, 6L));
-        given(commentQueryRepository.findReplyPreviewsByParentIds(List.of(1L, 2L), 5))
+        given(commentQueryRepository.findReplyPreviewsByParentIds(List.of(1L, 2L), 5, null))
                 .willReturn(Map.of(1L, root1Preview));
 
-        Page<RootCommentGroup> results = commentService.getRootComments(1L, pageable);
+        Page<RootCommentGroup> results = commentService.getRootComments(1L, pageable, null);
 
         RootCommentGroup group1 = results.getContent().get(0);
         assertThat(group1.replyPreview()).hasSize(5);
@@ -137,11 +137,26 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("로그인 사용자가 조회하면 차단 필터링을 위해 currentUserId를 조회 리포지토리에 그대로 전달한다")
+    void getRootCommentsPassesCurrentUserIdForBlockFiltering() {
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        Pageable pageable = PageRequest.of(0, 20);
+        given(commentQueryRepository.findRootComments(1L, pageable, 30L))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+        given(commentQueryRepository.countRepliesByParentIds(List.of(), 30L)).willReturn(Map.of());
+        given(commentQueryRepository.findReplyPreviewsByParentIds(List.of(), 5, 30L)).willReturn(Map.of());
+
+        commentService.getRootComments(1L, pageable, 30L);
+
+        org.mockito.Mockito.verify(commentQueryRepository).findRootComments(1L, pageable, 30L);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 원댓글의 답글을 조회하면 예외가 발생한다")
     void getRepliesFailsWhenParentCommentNotFound() {
         given(commentRepository.findByIdWithUser(999L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> commentService.getReplies(999L, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> commentService.getReplies(999L, PageRequest.of(0, 20), null))
                 .isInstanceOf(CommentException.class);
     }
 
@@ -153,9 +168,9 @@ class CommentServiceTest {
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
         Pageable pageable = PageRequest.of(0, 5);
         Page<Comment> expected = new PageImpl<>(List.of(replyComment(11L, root, writer)), pageable, 1);
-        given(commentQueryRepository.findReplies(1L, pageable)).willReturn(expected);
+        given(commentQueryRepository.findReplies(1L, pageable, null)).willReturn(expected);
 
-        Page<Comment> results = commentService.getReplies(1L, pageable);
+        Page<Comment> results = commentService.getReplies(1L, pageable, null);
 
         assertThat(results).isEqualTo(expected);
     }
@@ -168,7 +183,7 @@ class CommentServiceTest {
         opinion.delete();
         given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
 
-        assertThatThrownBy(() -> commentService.getReplies(1L, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> commentService.getReplies(1L, PageRequest.of(0, 20), null))
                 .isInstanceOf(OpinionException.class);
     }
 

--- a/src/test/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/infrastructure/CommentQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.comment.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nexters.palang.domain.block.domain.UserBlock;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -85,7 +86,7 @@ class CommentQueryRepositoryTest {
         Comment root2 = root("둘째 댓글");
         reply(root1, "답글");
 
-        Page<Comment> results = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20));
+        Page<Comment> results = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20), null);
 
         assertThat(results.getContent()).extracting(Comment::getId).containsExactly(root1.getId(), root2.getId());
         assertThat(results.getTotalElements()).isEqualTo(2);
@@ -104,9 +105,26 @@ class CommentQueryRepositoryTest {
         entityManager.persistAndFlush(Comment.root(otherOpinion, writer, "다른 흔적의 댓글"));
         Comment myRoot = root("내 흔적의 댓글");
 
-        Page<Comment> results = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20));
+        Page<Comment> results = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20), null);
 
         assertThat(results.getContent()).extracting(Comment::getId).containsExactly(myRoot.getId());
+    }
+
+    @Test
+    @DisplayName("차단한 작성자의 원댓글은 목록에서 제외되고, 차단하지 않은 사용자에게는 그대로 보인다")
+    void findRootCommentsExcludesCommentsFromBlockedWriter() {
+        User me = user("me");
+        User blockedWriter = user("blocked-w");
+        Comment myRoot = root("내 댓글");
+        Comment blockedRoot = entityManager.persistAndFlush(Comment.root(opinion, blockedWriter, "차단한 사람의 댓글"));
+        entityManager.persistAndFlush(UserBlock.of(me, blockedWriter));
+
+        Page<Comment> resultForMe = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20), me.getId());
+        Page<Comment> resultForAnonymous = commentQueryRepository.findRootComments(opinion.getId(), PageRequest.of(0, 20), null);
+
+        assertThat(resultForMe.getContent()).extracting(Comment::getId).containsExactly(myRoot.getId());
+        assertThat(resultForAnonymous.getContent()).extracting(Comment::getId)
+                .containsExactlyInAnyOrder(myRoot.getId(), blockedRoot.getId());
     }
 
     @Test
@@ -118,7 +136,7 @@ class CommentQueryRepositoryTest {
         reply(root1, "첫 댓글의 답글2");
         reply(root2, "둘째 댓글의 답글");
 
-        Map<Long, Long> counts = commentQueryRepository.countRepliesByParentIds(List.of(root1.getId(), root2.getId()));
+        Map<Long, Long> counts = commentQueryRepository.countRepliesByParentIds(List.of(root1.getId(), root2.getId()), null);
 
         assertThat(counts).containsEntry(root1.getId(), 2L).containsEntry(root2.getId(), 1L);
     }
@@ -126,9 +144,26 @@ class CommentQueryRepositoryTest {
     @Test
     @DisplayName("부모 ID 목록이 비어 있으면 빈 개수 맵을 반환한다")
     void countRepliesByParentIdsReturnsEmptyForEmptyInput() {
-        Map<Long, Long> counts = commentQueryRepository.countRepliesByParentIds(List.of());
+        Map<Long, Long> counts = commentQueryRepository.countRepliesByParentIds(List.of(), null);
 
         assertThat(counts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("차단한 작성자의 답글은 개수 집계에서 제외된다")
+    void countRepliesByParentIdsExcludesRepliesFromBlockedWriter() {
+        User me = user("me");
+        User blockedWriter = user("blocked-w");
+        Comment root1 = root("첫 댓글");
+        reply(root1, "내 답글");
+        entityManager.persistAndFlush(Comment.reply(root1, blockedWriter, "차단한 사람의 답글"));
+        entityManager.persistAndFlush(UserBlock.of(me, blockedWriter));
+
+        Map<Long, Long> countsForMe = commentQueryRepository.countRepliesByParentIds(List.of(root1.getId()), me.getId());
+        Map<Long, Long> countsForAnonymous = commentQueryRepository.countRepliesByParentIds(List.of(root1.getId()), null);
+
+        assertThat(countsForMe).containsEntry(root1.getId(), 1L);
+        assertThat(countsForAnonymous).containsEntry(root1.getId(), 2L);
     }
 
     @Test
@@ -144,7 +179,7 @@ class CommentQueryRepositoryTest {
         Comment root2Reply = reply(root2, "둘째 댓글의 답글");
 
         Map<Long, List<Comment>> previews = commentQueryRepository.findReplyPreviewsByParentIds(
-                List.of(root1.getId(), root2.getId()), 2);
+                List.of(root1.getId(), root2.getId()), 2, null);
 
         assertThat(previews.get(root1.getId())).extracting(Comment::getId)
                 .containsExactly(root1Reply1.getId(), root1Reply2.getId());
@@ -154,7 +189,7 @@ class CommentQueryRepositoryTest {
     @Test
     @DisplayName("부모 ID 목록이 비어 있으면 빈 미리보기 맵을 반환한다")
     void findReplyPreviewsByParentIdsReturnsEmptyForEmptyInput() {
-        Map<Long, List<Comment>> previews = commentQueryRepository.findReplyPreviewsByParentIds(List.of(), 5);
+        Map<Long, List<Comment>> previews = commentQueryRepository.findReplyPreviewsByParentIds(List.of(), 5, null);
 
         assertThat(previews).isEmpty();
     }
@@ -167,10 +202,25 @@ class CommentQueryRepositoryTest {
             reply(rootComment, "답글 " + i);
         }
 
-        Page<Comment> firstPage = commentQueryRepository.findReplies(rootComment.getId(), PageRequest.of(0, 5));
+        Page<Comment> firstPage = commentQueryRepository.findReplies(rootComment.getId(), PageRequest.of(0, 5), null);
 
         assertThat(firstPage.getContent()).hasSize(5);
         assertThat(firstPage.getTotalElements()).isEqualTo(6);
         assertThat(firstPage.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("차단한 작성자의 답글은 답글 더보기 목록에서 제외된다")
+    void findRepliesExcludesRepliesFromBlockedWriter() {
+        User me = user("me");
+        User blockedWriter = user("blocked-w");
+        Comment rootComment = root("원댓글");
+        Comment myReply = reply(rootComment, "내 답글");
+        entityManager.persistAndFlush(Comment.reply(rootComment, blockedWriter, "차단한 사람의 답글"));
+        entityManager.persistAndFlush(UserBlock.of(me, blockedWriter));
+
+        Page<Comment> resultForMe = commentQueryRepository.findReplies(rootComment.getId(), PageRequest.of(0, 20), me.getId());
+
+        assertThat(resultForMe.getContent()).extracting(Comment::getId).containsExactly(myReply.getId());
     }
 }

--- a/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
@@ -89,7 +89,7 @@ class CommentControllerTest {
         Comment root = rootComment(1L, writer);
         Comment reply = replyComment(2L, root, writer);
         RootCommentGroup group = new RootCommentGroup(root, List.of(reply), 1);
-        given(commentService.getRootComments(eq(1L), any())).willReturn(
+        given(commentService.getRootComments(eq(1L), any(), any())).willReturn(
                 new PageImpl<>(List.of(group), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/opinions/1/comments"))
@@ -103,7 +103,7 @@ class CommentControllerTest {
     @Test
     @DisplayName("존재하지 않는 흔적의 댓글 목록을 조회하면 404 에러가 발생한다")
     void getCommentsFailsWhenOpinionNotFound() throws Exception {
-        given(commentService.getRootComments(eq(999L), any()))
+        given(commentService.getRootComments(eq(999L), any(), any()))
                 .willThrow(new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
 
         mockMvc.perform(get("/api/opinions/999/comments"))
@@ -112,12 +112,25 @@ class CommentControllerTest {
     }
 
     @Test
+    @DisplayName("로그인 상태로 댓글 목록을 조회하면 차단 필터링을 위해 currentUserId를 서비스에 전달한다")
+    void getCommentsPassesCurrentUserIdWhenAuthenticated() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(java.util.Optional.of(1L));
+        given(commentService.getRootComments(eq(1L), any(), eq(1L))).willReturn(
+                new PageImpl<>(List.of(), DEFAULT_PAGEABLE, 0));
+
+        mockMvc.perform(get("/api/opinions/1/comments"))
+                .andExpect(status().isOk());
+
+        verify(commentService).getRootComments(eq(1L), any(), eq(1L));
+    }
+
+    @Test
     @DisplayName("답글 더보기를 요청하면 답글 목록을 반환한다")
     void getReplies() throws Exception {
         User writer = user(1L);
         Comment root = rootComment(1L, writer);
         Comment reply = replyComment(2L, root, writer);
-        given(commentService.getReplies(eq(1L), any())).willReturn(
+        given(commentService.getReplies(eq(1L), any(), any())).willReturn(
                 new PageImpl<>(List.of(reply), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/comments/1/replies"))
@@ -128,7 +141,7 @@ class CommentControllerTest {
     @Test
     @DisplayName("존재하지 않는 원댓글의 답글을 조회하면 404 에러가 발생한다")
     void getRepliesFailsWhenParentNotFound() throws Exception {
-        given(commentService.getReplies(eq(999L), any()))
+        given(commentService.getReplies(eq(999L), any(), any()))
                 .willThrow(new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
 
         mockMvc.perform(get("/api/comments/999/replies"))

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.opinion.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nexters.palang.domain.block.domain.UserBlock;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
@@ -177,6 +178,28 @@ class OpinionQueryRepositoryTest {
                 passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
 
         assertThat(result.getContent().get(0).commentCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("차단한 작성자의 흔적은 피드에서 제외되고, 차단하지 않은 사용자에게는 그대로 보인다")
+    void findOpinionsExcludesOpinionsFromBlockedWriter() {
+        User blockedWriter = user("blocked-w");
+        Passage passage = passage(blockedWriter);
+        Opinion opinionByBlockedWriter = opinion(passage, blockedWriter, "차단한 사람의 흔적", 0);
+        entityManager.persistAndFlush(UserBlock.of(me, blockedWriter));
+
+        Page<OpinionSummaryProjection> resultForMe = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), me.getId());
+        Page<OpinionSummaryProjection> resultForOther = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), other.getId());
+        Page<OpinionSummaryProjection> resultForAnonymous = opinionQueryRepository.findOpinions(
+                passage.getId(), OpinionSortType.LATEST, PageRequest.of(0, 10), null);
+
+        assertThat(resultForMe.getContent()).isEmpty();
+        assertThat(resultForOther.getContent()).extracting(OpinionSummaryProjection::opinionId)
+                .containsExactly(opinionByBlockedWriter.getId());
+        assertThat(resultForAnonymous.getContent()).extracting(OpinionSummaryProjection::opinionId)
+                .containsExactly(opinionByBlockedWriter.getId());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/report/application/ReportServiceTest.java
@@ -1,0 +1,190 @@
+package com.nexters.palang.domain.report.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.report.common.ReportException;
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportReason;
+import com.nexters.palang.domain.report.domain.ReportTargetType;
+import com.nexters.palang.domain.report.infrastructure.ReportRepository;
+import com.nexters.palang.domain.report.presentation.dto.CreateReportRequest;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private ReportService reportService;
+
+    private User writer;
+    private User reporter;
+
+    @BeforeEach
+    void setUp() {
+        reportService = new ReportService(reportRepository, opinionRepository, commentRepository, userRepository);
+        writer = user(10L);
+        reporter = user(20L);
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Opinion opinion(Long id, User author) {
+        Opinion built = Opinion.builder().user(author).content("흔적 내용").build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Comment comment(Long id, User author) {
+        Comment built = Comment.root(opinion(100L, author), author, "댓글 내용");
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 흔적을 신고하면 예외가 발생한다")
+    void reportOpinionFailsWhenOpinionNotFound() {
+        given(opinionRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reportService.reportOpinion(999L, reporter.getId(),
+                new CreateReportRequest(ReportReason.SPAM, null)))
+                .isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("삭제된 흔적을 신고하면 예외가 발생한다")
+    void reportOpinionFailsWhenOpinionDeleted() {
+        Opinion opinion = opinion(1L, writer);
+        opinion.delete();
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        assertThatThrownBy(() -> reportService.reportOpinion(1L, reporter.getId(),
+                new CreateReportRequest(ReportReason.SPAM, null)))
+                .isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 신고하면 예외가 발생한다")
+    void reportOpinionFailsWhenSelfReport() {
+        Opinion opinion = opinion(1L, writer);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+
+        assertThatThrownBy(() -> reportService.reportOpinion(1L, writer.getId(),
+                new CreateReportRequest(ReportReason.SPAM, null)))
+                .isInstanceOf(ReportException.class);
+    }
+
+    @Test
+    @DisplayName("이미 신고한 흔적을 다시 신고하면 예외가 발생한다")
+    void reportOpinionFailsWhenDuplicate() {
+        Opinion opinion = opinion(1L, writer);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+                reporter.getId(), ReportTargetType.OPINION, 1L)).willReturn(true);
+
+        assertThatThrownBy(() -> reportService.reportOpinion(1L, reporter.getId(),
+                new CreateReportRequest(ReportReason.SPAM, null)))
+                .isInstanceOf(ReportException.class);
+    }
+
+    @Test
+    @DisplayName("흔적을 신고하면 신고 레코드가 저장된다")
+    void reportOpinionSucceeds() {
+        Opinion opinion = opinion(1L, writer);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+                reporter.getId(), ReportTargetType.OPINION, 1L)).willReturn(false);
+        given(userRepository.getReferenceById(reporter.getId())).willReturn(reporter);
+        given(reportRepository.save(any(Report.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        Report report = reportService.reportOpinion(1L, reporter.getId(), new CreateReportRequest(ReportReason.HATE, null));
+
+        assertThat(report.getTargetType()).isEqualTo(ReportTargetType.OPINION);
+        assertThat(report.getTargetId()).isEqualTo(1L);
+        assertThat(report.getReason()).isEqualTo(ReportReason.HATE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글을 신고하면 예외가 발생한다")
+    void reportCommentFailsWhenCommentNotFound() {
+        given(commentRepository.findByIdWithUser(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reportService.reportComment(999L, reporter.getId(),
+                new CreateReportRequest(ReportReason.ABUSE, null)))
+                .isInstanceOf(com.nexters.palang.domain.comment.common.CommentException.class);
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 댓글을 신고하면 예외가 발생한다")
+    void reportCommentFailsWhenSelfReport() {
+        Comment comment = comment(1L, writer);
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> reportService.reportComment(1L, writer.getId(),
+                new CreateReportRequest(ReportReason.ABUSE, null)))
+                .isInstanceOf(ReportException.class);
+    }
+
+    @Test
+    @DisplayName("댓글을 신고하면 신고 레코드가 저장된다")
+    void reportCommentSucceeds() {
+        Comment comment = comment(1L, writer);
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(comment));
+        given(reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+                reporter.getId(), ReportTargetType.COMMENT, 1L)).willReturn(false);
+        given(userRepository.getReferenceById(reporter.getId())).willReturn(reporter);
+        given(reportRepository.save(any(Report.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        Report report = reportService.reportComment(1L, reporter.getId(),
+                new CreateReportRequest(ReportReason.COPYRIGHT, null));
+
+        assertThat(report.getTargetType()).isEqualTo(ReportTargetType.COMMENT);
+        assertThat(report.getTargetId()).isEqualTo(1L);
+        assertThat(report.getReason()).isEqualTo(ReportReason.COPYRIGHT);
+    }
+
+    @Test
+    @DisplayName("기타 사유로 신고하면서 상세 내용을 빠뜨리면 예외가 발생한다")
+    void reportFailsWhenEtcReasonWithoutDetail() {
+        Opinion opinion = opinion(1L, writer);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(reportRepository.existsByReporterIdAndTargetTypeAndTargetId(
+                reporter.getId(), ReportTargetType.OPINION, 1L)).willReturn(false);
+        given(userRepository.getReferenceById(reporter.getId())).willReturn(reporter);
+
+        assertThatThrownBy(() -> reportService.reportOpinion(1L, reporter.getId(),
+                new CreateReportRequest(ReportReason.ETC, null)))
+                .isInstanceOf(ReportException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/report/domain/ReportTest.java
+++ b/src/test/java/com/nexters/palang/domain/report/domain/ReportTest.java
@@ -1,0 +1,46 @@
+package com.nexters.palang.domain.report.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.domain.report.common.ReportException;
+import com.nexters.palang.domain.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ReportTest {
+
+    @Test
+    @DisplayName("기타 사유가 아니면 상세 내용 없이도 신고를 생성할 수 있다")
+    void createsReportWithoutDetailWhenReasonIsNotEtc() {
+        User reporter = User.builder().build();
+
+        Report report = Report.of(reporter, ReportTargetType.OPINION, 1L, ReportReason.SPAM, null);
+
+        assertThat(report.getReason()).isEqualTo(ReportReason.SPAM);
+        assertThat(report.getDetail()).isNull();
+    }
+
+    @Test
+    @DisplayName("기타 사유인데 상세 내용이 없으면 예외가 발생한다")
+    void throwsWhenReasonIsEtcAndDetailIsMissing() {
+        User reporter = User.builder().build();
+
+        assertThatThrownBy(() -> Report.of(reporter, ReportTargetType.OPINION, 1L, ReportReason.ETC, null))
+                .isInstanceOf(ReportException.class);
+        assertThatThrownBy(() -> Report.of(reporter, ReportTargetType.OPINION, 1L, ReportReason.ETC, "   "))
+                .isInstanceOf(ReportException.class);
+    }
+
+    @Test
+    @DisplayName("기타 사유이고 상세 내용이 있으면 신고를 생성할 수 있다")
+    void createsReportWhenReasonIsEtcAndDetailIsProvided() {
+        User reporter = User.builder().build();
+
+        Report report = Report.of(reporter, ReportTargetType.COMMENT, 2L, ReportReason.ETC, "이유 설명");
+
+        assertThat(report.getTargetType()).isEqualTo(ReportTargetType.COMMENT);
+        assertThat(report.getTargetId()).isEqualTo(2L);
+        assertThat(report.getDetail()).isEqualTo("이유 설명");
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/report/presentation/ReportControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/report/presentation/ReportControllerTest.java
@@ -1,0 +1,132 @@
+package com.nexters.palang.domain.report.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.report.application.ReportService;
+import com.nexters.palang.domain.report.common.ReportErrorCode;
+import com.nexters.palang.domain.report.common.ReportException;
+import com.nexters.palang.domain.report.domain.Report;
+import com.nexters.palang.domain.report.domain.ReportReason;
+import com.nexters.palang.domain.report.domain.ReportTargetType;
+import com.nexters.palang.domain.report.presentation.dto.CreateReportRequest;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ReportController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private Report report(Long id, ReportTargetType targetType, Long targetId) {
+        Report built = Report.of(null, targetType, targetId, ReportReason.SPAM, null);
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("흔적을 신고하면 신고 결과를 반환한다")
+    void reportOpinion() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(reportService.reportOpinion(eq(1L), eq(1L), any(CreateReportRequest.class)))
+                .willReturn(report(1L, ReportTargetType.OPINION, 1L));
+
+        mockMvc.perform(post("/api/opinions/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateReportRequest(ReportReason.SPAM, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reportId").value(1))
+                .andExpect(jsonPath("$.data.targetType").value("OPINION"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 흔적을 신고하면 401 에러가 발생한다")
+    void reportOpinionFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/opinions/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateReportRequest(ReportReason.SPAM, null))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("본인이 작성한 흔적을 신고하면 400 에러가 발생한다")
+    void reportOpinionFailsWhenSelfReport() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(reportService.reportOpinion(eq(1L), eq(1L), any(CreateReportRequest.class)))
+                .willThrow(new ReportException(ReportErrorCode.SELF_REPORT_NOT_ALLOWED));
+
+        mockMvc.perform(post("/api/opinions/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateReportRequest(ReportReason.SPAM, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("REPORT_400_2"));
+    }
+
+    @Test
+    @DisplayName("사유 없이 흔적을 신고하면 400 에러가 발생한다")
+    void reportOpinionFailsWhenReasonMissing() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(post("/api/opinions/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("이미 신고한 흔적을 다시 신고하면 409 에러가 발생한다")
+    void reportOpinionFailsWhenDuplicate() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(reportService.reportOpinion(eq(1L), eq(1L), any(CreateReportRequest.class)))
+                .willThrow(new ReportException(ReportErrorCode.DUPLICATE_REPORT));
+
+        mockMvc.perform(post("/api/opinions/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateReportRequest(ReportReason.SPAM, null))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("REPORT_409_1"));
+    }
+
+    @Test
+    @DisplayName("댓글을 신고하면 신고 결과를 반환한다")
+    void reportComment() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(reportService.reportComment(eq(1L), eq(1L), any(CreateReportRequest.class)))
+                .willReturn(report(2L, ReportTargetType.COMMENT, 1L));
+
+        mockMvc.perform(post("/api/comments/1/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateReportRequest(ReportReason.ABUSE, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reportId").value(2))
+                .andExpect(jsonPath("$.data.targetType").value("COMMENT"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #76

## 🚀 개요
> 흔적/댓글은 사용자 생성 콘텐츠(UGC)라 신고·차단 기능이 필수입니다. 신고(Report) 접수와 사용자 차단(Block) 백엔드 API를 신규 도메인으로 구현했습니다.

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- `Report` 엔티티(`domain/report`) 신설: reporter, targetType(OPINION/COMMENT), targetId, reason(SPAM/HATE/ABUSE/COPYRIGHT/ETC), detail. 기타 사유는 상세 내용 필수(생성 시점 검증), `unique(reporter, targetType, targetId)`로 중복 신고 방지
- `UserBlock` 엔티티(`domain/block`) 신설: blocker/blocked, 본인 차단 방지, `unique(blocker, blocked)`
- 흔적 피드(`GET /api/passages/{passageId}/opinions`)와 댓글 목록(`GET /api/opinions/{opinionId}/comments`, `GET /api/comments/{commentId}/replies`)에 차단 필터링 반영 — 차단한 사용자의 흔적/댓글/답글을 제외하는 QueryDSL 서브쿼리 추가 (차단 버튼의 실질 효과). 댓글 조회는 기존에 인증이 없던 구조라 soft-auth(`currentUserProvider.findCurrentUserId()`)를 threading하도록 함께 변경
- `ReportErrorCode`/`BlockErrorCode` + 커스텀 예외 정의
- Swagger 문서화 (`swagger-docs` 스킬 컨벤션에 맞춰 `requiredMode` 명시)

| Method | Path | 설명 |
|---|---|---|
| POST | `/api/opinions/{opinionId}/reports` | 흔적 신고 |
| POST | `/api/comments/{commentId}/reports` | 댓글 신고 |
| POST | `/api/users/{userId}/block` | 사용자 차단 |
| DELETE | `/api/users/{userId}/block` | 차단 해제 |
| GET | `/api/users/me/blocks` | 차단 목록 조회 |

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
- `./gradlew test` 전체 368개 테스트 통과 (신규 도메인 단위/통합 테스트 + 기존 댓글 조회 테스트 시그니처 변경분 포함)
- 로컬 부팅 후 `/v3/api-docs`로 4개 엔드포인트와 요청/응답 스키마의 `required` 필드가 의도대로 생성되는지 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요.
- 신고는 `targetType` + `targetId` 방식으로 흔적/댓글을 공통 처리했습니다. 각 콘텐츠별로 별도 엔티티(OpinionReport/CommentReport)를 두는 대신 이 방식을 택했는데, 이 판단이 맞는지 확인 부탁드립니다.
- 차단 필터링을 흔적 피드에 이어 댓글/답글 조회에도 반영하면서, 기존에 인증이 없던 댓글 조회 API에 soft-auth를 추가했습니다. `CommentService`/`CommentQueryRepository`의 메서드 시그니처가 바뀌어 기존 테스트도 함께 수정했는데, 동작 자체가 바뀐 건 없는지(로그인 안 한 사용자는 여전히 전체 댓글이 보이는지) 확인 부탁드립니다.
- 신고 접수 후 관리자 검토/자동 블라인드 처리 등 운영 플로우는 포함하지 않았습니다(레코드 적재까지만). 별도 이슈로 분리하는 것을 제안드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 사용자를 차단하거나 차단 해제하고, 차단 목록을 페이지 단위로 조회할 수 있습니다.
  * 의견과 댓글을 신고할 수 있으며, 신고 사유와 상세 내용을 입력할 수 있습니다.
* **개선**
  * 차단한 사용자의 의견과 댓글이 피드 및 댓글 목록에서 자동으로 제외됩니다.
  * 중복 차단·신고, 자기 차단·신고 등 부적절한 요청에 대한 오류 안내가 강화되었습니다.
* **테스트**
  * 차단, 신고, 목록 필터링 및 주요 오류 상황에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->