### PR TITLE
Chore/#82 issue-template 스킬 assignee 자동 지정

### DIFF
--- a/.claude/skills/issue-template/SKILL.md
+++ b/.claude/skills/issue-template/SKILL.md
@@ -49,6 +49,7 @@ description: Use whenever creating or editing a GitHub issue (gh issue create, g
 - `💡 참고 사항`에는 관련 문서(예: `backend_plan.md` 섹션 번호), 선행/후속 이슈 번호, 미확정 사항을 적는다.
 - 기존에 이 형식을 따르지 않는 이슈 본문(예: `## 배경` / `## 작업 내용` / `## 참고` 형태)을 발견하면, 원래 내용을 보존하면서 유형에 맞는 섹션 구조로 재배치한다 (내용을 새로 지어내지 않는다).
 - 라벨이 없거나 제목 접두사와 라벨이 어긋나면, 저장소 라벨 목록(`gh label list`)에서 맞는 라벨을 찾아 붙인다.
+- `gh issue create` 실행 시 사용자가 다른 담당자를 명시하지 않는 한 항상 `--assignee @me` 옵션을 포함해 작성자 본인에게 할당한다. (`gh issue create`는 기본적으로 담당자를 지정하지 않으므로 빠뜨리면 미할당으로 생성된다.) 이미 생성된 이슈에 할당자를 추가/변경할 때는 `gh issue edit <번호> --add-assignee @me`를 사용한다.
 
 ## 참고
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #82

## 🚀 개요
> Claude Code의 `issue-template` 스킬로 이슈를 생성할 때 담당자가 지정되지 않고 항상 미할당으로 생성되던 문제를 수정합니다.

## 📄 작업 내용
- `.claude/skills/issue-template/SKILL.md`의 작성 규칙에 `gh issue create` 실행 시 `--assignee @me`를 기본 포함하도록 규칙 추가
- 이미 생성된 이슈에 할당자를 추가할 때는 `gh issue edit <번호> --add-assignee @me`를 사용하도록 안내 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 스킬 가이드 문서(markdown)만 수정한 변경으로, 코드/빌드에 영향 없어 별도 테스트 없음.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `.github/ISSUE_TEMPLATE/*.md`의 front matter에 `assignees` 필드를 추가하는 방식도 검토했으나, 이는 GitHub 웹 UI 이슈 생성 화면에만 적용되고 `gh issue create` CLI에는 반영되지 않아 스킬 가이드 수정으로 대체했습니다. 이 판단이 맞는지 확인 부탁드립니다.