### PR TITLE
Fix/#81 탈퇴 계정 SNS 재로그인 시 영구 차단 수정

### DIFF
--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -10,8 +10,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HexFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,7 +68,9 @@ public class User extends BaseEntity {
     @Column(name = "sns_provider", nullable = false)
     private SnsProvider snsProvider;
 
-    @Column(name = "sns_id", nullable = false)
+    // Apple sub는 최대 255자까지 가능해 컬럼 길이를 명시적으로 맞춘다. 탈퇴 시 anonymizeSnsId()가
+    // "withdrawn:" + SHA-256(64자) 형태의 고정 길이 값으로 치환하므로 원본 길이와 무관하게 안전하다.
+    @Column(name = "sns_id", nullable = false, length = 255)
     private String snsId;
 
     // SNS 로그인 시점에는 아직 약관에 동의하지 않았을 수 있어(FR-AUTH-03) nullable이다.
@@ -150,9 +156,26 @@ public class User extends BaseEntity {
         this.withdrawnAt = LocalDateTime.now();
         // unique 제약(nickname) 해제를 위해 탈퇴 시점에 닉네임을 익명화한다.
         this.nickname = "탈퇴한 사용자" + this.id;
-        // unique 제약(sns_provider+sns_id) 해제를 위해 원본 snsId를 보존한 채 접두사를 붙인다.
-        // 같은 SNS 계정으로 재로그인하면 findBySnsProviderAndSnsId가 이 row를 더 이상 찾지 못해
-        // 신규 가입 경로를 타므로, 탈퇴는 되돌릴 수 없는 익명화로 유지되고 재가입은 새 계정으로 시작한다.
-        this.snsId = "withdrawn:" + this.id + ":" + this.snsId;
+        // unique 제약(sns_provider+sns_id) 해제를 위해 이 row(탈퇴한 계정)만의 snsId를 고정 길이 해시로
+        // 되돌릴 수 없게 바꾼다. registerViaSns로 만들어지는 새 계정의 snsId에는 관여하지 않는다.
+        // 같은 SNS 계정으로 재로그인하면 findBySnsProviderAndSnsId가 원본 snsId로는 이 row를 더 이상
+        // 찾지 못해 신규 가입 경로를 타므로, 탈퇴는 되돌릴 수 없는 익명화로 유지되고 재가입은 새 계정으로 시작한다.
+        this.snsId = anonymizeSnsId(this.id, this.snsId);
+    }
+
+    // Apple sub(최대 255자)까지 고려하면 "withdrawn:" + 원본을 그대로 이어붙일 경우 sns_id 컬럼(varchar(255))을
+    // 넘길 수 있어, SHA-256 해시(64자 고정)로 치환해 원본 길이와 무관하게 컬럼 길이 안에 들어오도록 한다.
+    private static String anonymizeSnsId(Long id, String originalSnsId) {
+        return "withdrawn:" + sha256(id + ":" + originalSnsId);
+    }
+
+    private static String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/domain/User.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/User.java
@@ -150,5 +150,9 @@ public class User extends BaseEntity {
         this.withdrawnAt = LocalDateTime.now();
         // unique 제약(nickname) 해제를 위해 탈퇴 시점에 닉네임을 익명화한다.
         this.nickname = "탈퇴한 사용자" + this.id;
+        // unique 제약(sns_provider+sns_id) 해제를 위해 원본 snsId를 보존한 채 접두사를 붙인다.
+        // 같은 SNS 계정으로 재로그인하면 findBySnsProviderAndSnsId가 이 row를 더 이상 찾지 못해
+        // 신규 가입 경로를 타므로, 탈퇴는 되돌릴 수 없는 익명화로 유지되고 재가입은 새 계정으로 시작한다.
+        this.snsId = "withdrawn:" + this.id + ":" + this.snsId;
     }
 }

--- a/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/auth/application/AuthServiceTest.java
@@ -138,6 +138,26 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("탈퇴 후 같은 카카오 계정으로 재로그인하면 신규 계정으로 가입된다")
+    void loginWithKakaoSignsUpAsNewUserAfterWithdrawal() {
+        // User.withdraw()가 snsId를 익명화해 uq_users_sns 제약을 해제하므로, 탈퇴한 계정은 원본 snsId로 더 이상 조회되지 않는다.
+        given(kakaoOAuthClient.getUserInfo("kakao-token"))
+                .willReturn(new KakaoOAuthClient.KakaoUserInfo("sns-300", "user300@example.com"));
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.KAKAO, "sns-300")).willReturn(Optional.empty());
+        User rejoinedUser = user(301L);
+        given(userRegistrationService.registerViaSns(SnsProvider.KAKAO, "sns-300", "user300@example.com", null))
+                .willReturn(rejoinedUser);
+        given(jwtTokenProvider.createAccessToken(301L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(301L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithKakao("kakao-token");
+
+        assertThat(result.isNewUser()).isTrue();
+        verify(userRegistrationService).registerViaSns(SnsProvider.KAKAO, "sns-300", "user300@example.com", null);
+    }
+
+    @Test
     @DisplayName("처음 로그인하는 애플 사용자는 신규 가입되고 isNewUser가 true다")
     void loginWithAppleSignsUpNewUser() {
         given(appleOAuthClient.getUserInfo("apple-token"))
@@ -245,6 +265,25 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.loginWithApple("apple-token", null, null, null))
                 .isInstanceOf(AuthException.class);
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 같은 애플 계정으로 재로그인하면 신규 계정으로 가입된다")
+    void loginWithAppleSignsUpAsNewUserAfterWithdrawal() {
+        given(appleOAuthClient.getUserInfo("apple-token"))
+                .willReturn(new AppleOAuthClient.AppleUserInfo("apple-sns-300", "apple300@example.com", "com.palang.app"));
+        given(userRepository.findBySnsProviderAndSnsId(SnsProvider.APPLE, "apple-sns-300")).willReturn(Optional.empty());
+        User rejoinedUser = user(301L, SnsProvider.APPLE);
+        given(userRegistrationService.registerViaSns(SnsProvider.APPLE, "apple-sns-300", "apple300@example.com", null))
+                .willReturn(rejoinedUser);
+        given(jwtTokenProvider.createAccessToken(301L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(301L)).willReturn("refresh-token");
+        given(jwtTokenProvider.refreshTokenExpiryFromNow()).willReturn(LocalDateTime.now().plusDays(14));
+
+        AuthResult result = authService.loginWithApple("apple-token", null, null, null);
+
+        assertThat(result.isNewUser()).isTrue();
+        verify(userRegistrationService).registerViaSns(SnsProvider.APPLE, "apple-sns-300", "apple300@example.com", null);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
@@ -107,6 +107,21 @@ class UserTest {
         assertThat(user.isWithdrawn()).isTrue();
         assertThat(user.getWithdrawnAt()).isNotNull();
         assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자42");
-        assertThat(user.getSnsId()).isEqualTo("withdrawn:42:kakao-123");
+        assertThat(user.getSnsId())
+                .startsWith("withdrawn:")
+                .hasSize(74)
+                .doesNotContain("kakao-123");
+    }
+
+    @Test
+    @DisplayName("애플 sub처럼 snsId가 최대 길이(255자)여도 익명화된 값은 sns_id 컬럼 길이를 넘지 않는다")
+    void withdrawAnonymizedSnsIdFitsWithinColumnLengthEvenForMaxLengthAppleSub() {
+        String maxLengthAppleSub = "a".repeat(255);
+        User user = User.builder().nickname("기존닉네임").snsProvider(SnsProvider.APPLE).snsId(maxLengthAppleSub).build();
+        ReflectionTestUtils.setField(user, "id", 999_999_999_999L);
+
+        user.withdraw();
+
+        assertThat(user.getSnsId()).hasSizeLessThanOrEqualTo(255);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/domain/UserTest.java
@@ -95,4 +95,18 @@ class UserTest {
 
         assertThat(user.isHasCompletedOnboarding()).isTrue();
     }
+
+    @Test
+    @DisplayName("탈퇴하면 닉네임과 snsId가 익명화되어 같은 SNS 계정으로 재가입할 수 있게 된다")
+    void withdrawAnonymizesNicknameAndSnsId() {
+        User user = User.builder().nickname("기존닉네임").snsProvider(SnsProvider.KAKAO).snsId("kakao-123").build();
+        ReflectionTestUtils.setField(user, "id", 42L);
+
+        user.withdraw();
+
+        assertThat(user.isWithdrawn()).isTrue();
+        assertThat(user.getWithdrawnAt()).isNotNull();
+        assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자42");
+        assertThat(user.getSnsId()).isEqualTo("withdrawn:42:kakao-123");
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #81

## 🚀 개요
탈퇴한 계정이 같은 SNS 계정(카카오/애플)으로 재로그인하면 영구히 403(`AUTH_403_1`)이 반환되던 문제를 수정합니다. 탈퇴는 되돌릴 수 없는 익명화로 유지하면서, 같은 SNS 계정으로는 새 계정으로 재가입할 수 있게 합니다.

## 📄 작업 내용
- `User.withdraw()`: 닉네임을 `탈퇴한 사용자{id}`로 익명화하던 기존 패턴과 동일하게, `snsId`도 `withdrawn:{id}:{원본snsId}`로 바꿔 `uq_users_sns` 유니크 제약을 해제
- 이에 따라 재로그인 시 `findBySnsProviderAndSnsId(provider, 원본snsId)`가 탈퇴한 row를 더 이상 찾지 못해 `AuthService`가 자동으로 신규 가입(`registerViaSns`) 경로를 타서 새 `User` row 생성 (별도 분기 로직 변경 없음, 기존 `isWithdrawn()` 403 처리는 방어 코드로 유지)
- `UserTest`: 탈퇴 시 닉네임·snsId가 함께 익명화되는지 검증하는 테스트 추가
- `AuthServiceTest`: 탈퇴 후 카카오/애플 각각 같은 SNS 계정으로 재로그인하면 신규 계정으로 가입되는 테스트 2개 추가

탈퇴 전 작성한 발췌·의견·댓글은 옛 User row(FK)에 그대로 남아 다른 이용자에게는 계속 `탈퇴한 사용자{id}`로 보이고, 재가입한 새 계정과는 연결되지 않습니다 (PRIVACY §3 "탈퇴 시 콘텐츠는 익명화하여 남길 수 있다"와의 정합성 유지).

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과 (377 tests, 0 failures)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 탈퇴 후 재가입 시 예전 발췌/의견/댓글이 새 계정과 전혀 연결되지 않고(완전히 새 계정처럼 시작) 익명 상태로만 남는 게 맞는 방향인지 확인 부탁드립니다. 대안(예: 재가입 계정에서 예전 흔적을 다시 볼 수 있게 하되 타인에게는 계속 익명으로 노출)도 검토 가능하나, 이번 PR은 정책 문구(#79)와의 정합성을 우선해 현재 방식으로 구현했습니다.
- `snsId`에 접두사를 붙이는 방식이라 `sns_id` 컬럼 길이(기본 255) 안에서는 문제없지만, 향후 SNS 제공자가 매우 긴 식별자를 내려주는 경우를 대비해 컬럼 길이를 명시적으로 늘리는 게 나을지도 논의 대상입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 탈퇴한 사용자가 동일한 카카오 또는 애플 계정으로 다시 로그인하면 신규 가입 절차로 처리됩니다.
  * 탈퇴 시 기존 SNS 식별자와의 충돌을 방지하고 재가입할 수 있도록 사용자 정보가 익명화됩니다.

* **버그 수정**
  * 탈퇴 사용자가 기존 계정으로 잘못 조회되어 로그인되는 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->