### PR TITLE
Fix/#87 앱 컨테이너 시간대 UTC → KST 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/8080' || exit 1
 
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+# docker-compose의 TZ=Asia/Seoul과 별개로, LocalDateTime.now()가 쓰는 JVM 기본 시간대를
+# 컨테이너 tzdata/TZ 환경변수 설정 여부와 무관하게 명시적으로 고정한다.
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       IMAGE_UPLOAD_DIR: ${IMAGE_UPLOAD_DIR:-/app/uploads}
+      # mysql 서비스와 동일하게 컨테이너 시간대를 KST로 맞춘다. LocalDateTime.now()(BaseEntity의
+      # @CreatedDate/@LastModifiedDate 등)는 JVM 기본 시간대를 따르는데, 이게 없으면 컨테이너 OS
+      # 기본값인 UTC로 떠서 생성/수정 시각이 9시간 느리게 기록된다.
+      TZ: Asia/Seoul
     # deploy/nginx/pallang.conf.template의 upstream이 127.0.0.1:8080을 하드코딩하고 있으므로
     # 호스트 포트를 가변으로 두지 않는다 (바꾸려면 이 파일과 nginx 템플릿을 함께 수정할 것).
     ports:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #87

## 🚀 개요
앱 컨테이너가 UTC로 동작해 댓글 등 생성/수정 시각이 실제 한국시간보다 9시간 느리게 기록되던 문제를 수정합니다.

## 📄 작업 내용
- `docker-compose.yml`: `app` 서비스 environment에 `TZ: Asia/Seoul` 추가 (기존 `mysql` 서비스와 동일하게)
- `Dockerfile`: `ENTRYPOINT`에 `-Duser.timezone=Asia/Seoul` JVM 옵션 추가 — 컨테이너 tzdata/TZ 환경변수 설정 여부와 무관하게 `LocalDateTime.now()`(`BaseEntity`의 `@CreatedDate`/`@LastModifiedDate` 등이 내부적으로 사용)가 항상 KST를 쓰도록 이중으로 고정

**원인 확인**: dev 서버에서 직접 확인한 결과
```
호스트:              Thu Aug  6 17:13:03 KST 2026
pallang-mysql 컨테이너: Thu Aug  6 17:13:03 KST 2026  (정상, TZ 설정됨)
pallang-app 컨테이너:   Thu Aug  6 08:13:03 UTC 2026  (TZ 미설정)
```
`spring.jackson.time-zone`/`hibernate.jdbc.time_zone`은 이미 `Asia/Seoul`로 설정돼 있었지만, 이건 시간대 정보를 가진 타입(`ZonedDateTime`/`OffsetDateTime`)에만 적용되고 `BaseEntity`가 쓰는 `LocalDateTime`에는 적용되지 않아 근본 원인을 못 잡고 있었습니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- `docker compose config`로 `TZ: Asia/Seoul`이 `app` 서비스에 반영되는 것 확인
- 배포 후 dev 서버에서 `docker exec pallang-app date`로 KST 재확인 필요 (배포 담당자 확인 요망)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요? (인프라 설정 변경이라 해당 없음)
- [ ] 테스트 통과 확인 (인프라 설정 변경이라 단위 테스트 대상 아님)
- [ ] 서버 실행 확인 (배포 후 확인 필요)
- [ ] API 동작 확인 (배포 후 확인 필요)

---
## 🔍 리뷰 포인트 (Review Points)
- 이미 UTC로 잘못 저장된 기존 데이터(댓글/발췌 등 createdAt)를 KST로 보정할지 여부는 이번 PR 범위에 포함하지 않았습니다. 필요하면 별도 이슈로 분리해 데이터 백필을 진행하는 게 나을지 확인 부탁드립니다.
- `TZ` 환경변수와 `-Duser.timezone` JVM 옵션을 동시에 설정했는데, 중복이 과한지 혹은 안전장치로 유지하는 게 나을지 의견 부탁드립니다.