### PR TITLE
Fix/#89 OCR 텍스트 블록 읽기 순서 오류 수정

### DIFF
--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/ocr/clova/ClovaOcrClient.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/ocr/clova/ClovaOcrClient.java
@@ -6,7 +6,6 @@ import com.nexters.palang.domain.passage.common.error.PassageErrorCode;
 import com.nexters.palang.domain.passage.infrastructure.ocr.OcrClient;
 import com.nexters.palang.domain.passage.infrastructure.ocr.OcrTextBlock;
 import com.nexters.palang.domain.passage.common.error.PassageException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.core.io.ByteArrayResource;
@@ -44,18 +43,22 @@ public class ClovaOcrClient implements OcrClient {
 
         ClovaOcrResponse response = requestOcr(bodyBuilder);
 
-        List<OcrTextBlock> blocks = response.images().get(0).fields().stream()
-                .map(this::toTextBlock)
-                // Clova는 필드를 읽기 순서로 보장하지 않으므로, 좌상단 좌표 기준으로 재정렬
-                .sorted(Comparator.comparingDouble((OcrTextBlock block) -> block.boundingBox().topY())
-                        .thenComparingDouble(block -> block.boundingBox().leftX()))
-                .toList();
+        List<OcrTextBlock> blocks = toOrderedTextBlocks(response.images().get(0).fields());
 
         if (blocks.isEmpty()) {
             throw new PassageException(PassageErrorCode.OCR_TEXT_NOT_FOUND);
         }
 
         return blocks;
+    }
+
+    // Clova는 같은 줄의 단어들을 순서대로 반환하고 각 줄의 마지막 단어에 lineBreak=true를 표시한다.
+    // 단어별 바운딩 박스 좌표(특히 topY)는 사진 기울기·글자 높이 차이로 흔들려 좌표 재정렬 시 줄이 뒤섞이므로,
+    // 좌표로 다시 정렬하지 않고 Clova가 준 원본 순서를 그대로 신뢰한다.
+    List<OcrTextBlock> toOrderedTextBlocks(List<ClovaOcrResponse.Field> fields) {
+        return fields.stream()
+                .map(this::toTextBlock)
+                .toList();
     }
 
     // 클로바 OCR API에 HTTP POST 요청 보내기

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/ocr/clova/ClovaOcrClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/ocr/clova/ClovaOcrClientTest.java
@@ -1,0 +1,49 @@
+package com.nexters.palang.domain.passage.infrastructure.ocr.clova;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.passage.infrastructure.ocr.OcrTextBlock;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClovaOcrClientTest {
+
+    private final ClovaOcrClient client = new ClovaOcrClient(null, null);
+
+    @Test
+    @DisplayName("좌표(topY)가 줄 사이에서 겹쳐도 Clova가 준 원본 순서를 그대로 유지한다")
+    void keepsOriginalFieldOrderEvenWhenTopYOverlapsAcrossLines() {
+        // 사진이 살짝 기울어져 두 번째 줄 앞부분 단어의 topY가 첫 번째 줄 뒷부분 단어보다 작은 상황을 재현
+        ClovaOcrResponse.Field line1Word1 = field("보아,", 10, 100, false);
+        ClovaOcrResponse.Field line1Word2 = field("개인적인", 12, 150, false);
+        ClovaOcrResponse.Field line1Word3 = field("원한에", 9, 200, true);
+        ClovaOcrResponse.Field line2Word1 = field("의한", 11, 100, false);
+        ClovaOcrResponse.Field line2Word2 = field("범행이", 13, 150, false);
+        ClovaOcrResponse.Field line2Word3 = field("아닐까", 8, 200, true);
+        List<ClovaOcrResponse.Field> originalOrder = List.of(
+                line1Word1, line1Word2, line1Word3, line2Word1, line2Word2, line2Word3
+        );
+
+        List<OcrTextBlock> blocks = client.toOrderedTextBlocks(originalOrder);
+
+        assertThat(blocks).extracting(OcrTextBlock::text)
+                .containsExactly("보아,", "개인적인", "원한에", "의한", "범행이", "아닐까");
+    }
+
+    @Test
+    @DisplayName("각 필드의 lineBreak 값을 그대로 전달한다")
+    void preservesLineBreakFlag() {
+        ClovaOcrResponse.Field word = field("보아,", 10, 100, true);
+
+        List<OcrTextBlock> blocks = client.toOrderedTextBlocks(List.of(word));
+
+        assertThat(blocks.get(0).lineBreak()).isTrue();
+    }
+
+    private ClovaOcrResponse.Field field(String text, double topY, double leftX, boolean lineBreak) {
+        ClovaOcrResponse.Vertex topLeft = new ClovaOcrResponse.Vertex(leftX, topY);
+        ClovaOcrResponse.BoundingPoly boundingPoly = new ClovaOcrResponse.BoundingPoly(List.of(topLeft));
+        return new ClovaOcrResponse.Field("NORMAL", boundingPoly, text, 0.99, lineBreak);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #89

## 🚀 개요
> Clova OCR 텍스트 블록을 좌표(topY/leftX) 기준으로 자체 재정렬하면서, 촬영 기울기나 글자 높이 차이로 인접한 두 줄의 단어가 서로 뒤섞이던 문제를 수정합니다. Clova가 이미 제공하는 `lineBreak`(줄 경계)과 원본 필드 순서를 신뢰하는 방식으로 변경했습니다.

## 📄 작업 내용
- `ClovaOcrClient.recognize()`에서 `topY`/`leftX` 기준 `Comparator` 정렬 제거
- Clova가 반환한 `fields` 원본 순서를 그대로 사용하는 `toOrderedTextBlocks()` 메서드로 분리
- 좌표가 줄 사이에서 겹치는 상황을 재현해, 원본 순서가 보존되는지 검증하는 `ClovaOcrClientTest` 추가 (lineBreak pass-through 검증 포함)

## 📸 스크린샷 / 테스트 결과 (선택)
> `./gradlew test` 전체 통과 확인 (기존 테스트 + 신규 `ClovaOcrClientTest` 2건)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- Naver Cloud 공식 문서(https://api.ncloud-docs.com/docs/en/ai-application-service-ocr-ocr)에는 "fields 배열이 페이지 전체 기준 읽기 순서를 보장한다"는 명시적 문구는 없고, `lineBreak`이 줄의 마지막 단어를 표시한다는 것만 확인했습니다. 실기기로 촬영한 실제 이미지로 회귀 검증(서버 실행 + API 호출)은 아직 못 했는데, 리뷰 시 실제 이미지로 한 번 확인해주실 수 있을까요?
- 다단(컬럼) 레이아웃처럼 복잡한 지면 구조에서는 원본 순서만으로 충분하지 않을 수 있습니다 — 현재 스코프(책 발췌, 단일 컬럼 본문)에서는 문제없다고 판단했는데, 이 가정에 동의하시는지 확인 부탁드립니다.