### PR TITLE
Chore/#95 로컬 개발용 CORS 허용 origin에 localhost:3001~3010 추가

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -56,7 +56,7 @@ aladin:
 
 # 6. CORS 허용 origin (프론트엔드와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급됨)
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ apple:
   private-key: ${APPLE_PRIVATE_KEY:}
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
 
 jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-please-change-this-01234567890123456789}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #95

## 🚀 개요
- 로컬 개발 시 프론트엔드가 3000번 포트 외 다른 포트에서 뜨는 경우가 있어, CORS 허용 origin을 localhost:3001~3010까지 임시로 확장했습니다.

## 📄 작업 내용
- `application.yaml`의 `cors.allowed-origins` 기본값에 `http://localhost:3001`~`http://localhost:3010` 추가
- `application-dev.yaml`의 `cors.allowed-origins` 기본값에 동일하게 `http://localhost:3001`~`http://localhost:3010` 추가
- `application-prod.yaml`은 개발용 임시 조치 대상이 아니므로 변경하지 않음

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 확인 (BUILD SUCCESSFUL)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 임시 조치라 포트 범위(3001~3010)가 과한지, 혹은 필요한 만큼만 좁히는 게 나을지 의견 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로컬 개발 환경에서 `localhost:3001`부터 `localhost:3010`까지의 주소에서도 원활하게 접속할 수 있도록 CORS 허용 범위를 확장했습니다.
  * 기존 `localhost:3000` 접속 권한은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->