### PR TITLE
Feat/#97 도서 내부 검색 - 흔적 있는 도서만 노출 + 정렬 옵션 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookSearchSort.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookSearchSort.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.book.application;
+
+public enum BookSearchSort {
+    NAME,
+    RECENT,
+    OPINION
+}

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -41,8 +41,8 @@ public class BookService {
         return aladinBookApiClient.search(keyword, pageable);
     }
 
-    public Page<BookSearchProjection> searchInternalBooks(String keyword, Pageable pageable) {
-        return bookQueryRepository.searchByTitle(keyword, pageable);
+    public Page<BookSearchProjection> searchInternalBooks(String keyword, BookSearchSort sort, Pageable pageable) {
+        return bookQueryRepository.searchByTitle(keyword, sort, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -2,9 +2,11 @@ package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
+import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.domain.QPassage;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
@@ -23,7 +25,8 @@ public class BookQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     // 띄어쓰기 차이를 무시하고 검색할 수 있도록 제목/키워드 모두에서 공백을 제거한 뒤 비교한다.
-    public Page<BookSearchProjection> searchByTitle(String keyword, Pageable pageable) {
+    // 흔적(Opinion)이 하나도 없는 도서는 결과에서 제외하므로 leftJoin이 아닌 innerJoin을 사용한다.
+    public Page<BookSearchProjection> searchByTitle(String keyword, BookSearchSort sort, Pageable pageable) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinion = QOpinion.opinion;
@@ -37,12 +40,12 @@ public class BookQueryRepository {
                         book.isbn, book.coverImageUrl, book.source,
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
-                .leftJoin(passage).on(passage.book.eq(book))
-                .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
+                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.pageCount,
                         book.isbn, book.coverImageUrl, book.source)
-                .orderBy(book.id.asc())
+                .orderBy(searchOrderSpecifiers(sort, book, opinion))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -50,10 +53,20 @@ public class BookQueryRepository {
         Long total = queryFactory
                 .select(book.countDistinct())
                 .from(book)
+                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private OrderSpecifier<?>[] searchOrderSpecifiers(BookSearchSort sort, QBook book, QOpinion opinion) {
+        return switch (sort) {
+            case NAME -> new OrderSpecifier[]{book.title.asc(), book.id.asc()};
+            case RECENT -> new OrderSpecifier[]{opinion.createdAt.max().desc(), book.id.asc()};
+            case OPINION -> new OrderSpecifier[]{opinion.countDistinct().desc(), book.id.asc()};
+        };
     }
 
     // 홈 캐러셀은 전체 목록 중 임의의 가운데 offset에서 좌우로 조회해야 해서, page*size로 offset이

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.book.presentation;
 
+import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookListResponse;
@@ -41,15 +42,18 @@ public interface BookApi {
     );
 
     @Operation(summary = "도서 내부 검색",
-            description = "서비스 DB에 이미 등록된 도서를 제목으로 검색하며, 도서별 대목/흔적 수를 함께 반환합니다. "
+            description = "서비스 DB에 등록된 도서 중 흔적(Opinion)이 하나 이상 있는 도서만 제목으로 검색하며, "
+                    + "도서별 대목/흔적 수를 함께 반환합니다. "
                     + "제목과 검색어의 띄어쓰기 차이는 무시하고 매칭합니다. keyword에 빈 문자열을 넘기면 전체 목록을 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),
-            @ApiResponse(responseCode = "400", description = "keyword 누락 또는 page/size 형식 오류 (COMMON_400_1)",
+            @ApiResponse(responseCode = "400", description = "keyword 누락, sort 값 오류 또는 page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookSearchListResponse>> searchInternalBooks(
             @Parameter(description = "검색 키워드 (빈 문자열이면 전체 목록)", required = true) String keyword,
+            @Parameter(description = "정렬 기준 (NAME: 이름순, RECENT: 최신 흔적순, OPINION: 흔적 많은 순, 기본값 RECENT)")
+            BookSearchSort sort,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.book.presentation;
 
 import com.nexters.palang.domain.book.application.BookMapper;
+import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.BookService;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
@@ -50,10 +51,11 @@ public class BookController implements BookApi {
     @GetMapping("/api/books/internal-search")
     public ResponseEntity<DataResponse<BookSearchListResponse>> searchInternalBooks(
             @RequestParam String keyword,
+            @RequestParam(defaultValue = "RECENT") BookSearchSort sort,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        return ResponseEntity.ok(DataResponse.from(
-                BookMapper.toSearchListResponse(bookService.searchInternalBooks(keyword, pageable(page, size)))));
+        return ResponseEntity.ok(DataResponse.from(BookMapper.toSearchListResponse(
+                bookService.searchInternalBooks(keyword, sort, pageable(page, size)))));
     }
 
     @Override

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -82,9 +82,9 @@ class BookServiceTest {
                 List.of(new BookSearchProjection(
                         1L, "프랑켄슈타인", "작가", "출판사", 300, "isbn", "cover", BookSource.MANUAL, 5, 10)),
                 pageable, 1);
-        given(bookQueryRepository.searchByTitle("프랑", pageable)).willReturn(expected);
+        given(bookQueryRepository.searchByTitle("프랑", BookSearchSort.RECENT, pageable)).willReturn(expected);
 
-        Page<BookSearchProjection> results = bookService.searchInternalBooks("프랑", pageable);
+        Page<BookSearchProjection> results = bookService.searchInternalBooks("프랑", BookSearchSort.RECENT, pageable);
 
         assertThat(results).isEqualTo(expected);
     }

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
+import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.domain.Passage;
@@ -78,34 +79,95 @@ class BookQueryRepositoryTest {
     @Test
     @DisplayName("검색어와 제목의 띄어쓰기가 달라도 도서를 찾는다")
     void searchByTitleIgnoresWhitespaceDifferences() {
+        User writer = user("wsr1");
         Book book = book("두 번째 산책");
+        opinion(passage(book, writer, 1), writer);
 
-        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle("두번째산책", PageRequest.of(0, 20));
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "두번째산책", BookSearchSort.RECENT, PageRequest.of(0, 20));
 
         assertThat(results.getContent()).extracting(BookSearchProjection::bookId).containsExactly(book.getId());
     }
 
     @Test
-    @DisplayName("대목/흔적이 없는 도서도 검색 결과에 포함되고 수는 0으로 집계된다")
-    void searchByTitleIncludesBooksWithoutPassages() {
-        Book book = book("아직 흔적 없는 책");
+    @DisplayName("흔적(Opinion)이 없는 도서는 검색 결과에서 제외된다")
+    void searchByTitleExcludesBooksWithoutOpinions() {
+        User writer = user("wsr2");
+        Book bookWithoutPassage = book("대목도 없는 책");
+        Book bookWithoutOpinion = book("대목만 있는 책");
+        passage(bookWithoutOpinion, writer, 1);
 
-        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle("아직", PageRequest.of(0, 20));
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle("책", BookSearchSort.RECENT,
+                PageRequest.of(0, 20));
 
-        assertThat(results.getContent()).extracting(BookSearchProjection::bookId).containsExactly(book.getId());
-        assertThat(results.getContent().get(0).passageCount()).isEqualTo(0);
-        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(0);
+        assertThat(results.getContent()).isEmpty();
+        assertThat(bookWithoutPassage.getId()).isNotNull();
     }
 
     @Test
-    @DisplayName("검색어가 빈 문자열이면 전체 도서 목록을 반환한다")
+    @DisplayName("검색어가 빈 문자열이면 흔적이 있는 전체 도서 목록을 반환한다")
     void searchByTitleReturnsAllBooksWhenKeywordIsBlank() {
-        book("책1");
-        book("책2");
+        User writer = user("wsr3");
+        Book book1 = book("책1");
+        Book book2 = book("책2");
+        opinion(passage(book1, writer, 1), writer);
+        opinion(passage(book2, writer, 1), writer);
 
-        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle("", PageRequest.of(0, 20));
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "", BookSearchSort.RECENT, PageRequest.of(0, 20));
 
         assertThat(results.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("이름순 정렬은 제목 오름차순으로 도서를 반환한다")
+    void searchByTitleSortsByNameAscending() {
+        User writer = user("wsr4");
+        Book bookB = book("나책");
+        Book bookA = book("가책");
+        opinion(passage(bookB, writer, 1), writer);
+        opinion(passage(bookA, writer, 1), writer);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "책", BookSearchSort.NAME, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .containsExactly(bookA.getId(), bookB.getId());
+    }
+
+    @Test
+    @DisplayName("최신순 정렬은 가장 최근에 흔적이 남은 도서부터 반환한다")
+    void searchByTitleSortsByRecentOpinion() throws InterruptedException {
+        User writer = user("wsr5");
+        Book olderBook = book("먼저 남긴 책");
+        Book newerBook = book("나중에 남긴 책");
+        opinion(passage(olderBook, writer, 1), writer);
+        Thread.sleep(10);
+        opinion(passage(newerBook, writer, 1), writer);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "책", BookSearchSort.RECENT, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .containsExactly(newerBook.getId(), olderBook.getId());
+    }
+
+    @Test
+    @DisplayName("의견순 정렬은 흔적이 많은 도서부터 반환한다")
+    void searchByTitleSortsByOpinionCountDescending() {
+        User writer = user("wsr6");
+        Book popularBook = book("의견 많은 책");
+        Book lessPopularBook = book("의견 적은 책");
+        Passage popularPassage = passage(popularBook, writer, 1);
+        opinion(popularPassage, writer);
+        opinion(popularPassage, writer);
+        opinion(passage(lessPopularBook, writer, 1), writer);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "책", BookSearchSort.OPINION, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .containsExactly(popularBook.getId(), lessPopularBook.getId());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookCarouselPage;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
+import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.BookService;
 import com.nexters.palang.domain.book.application.ExternalBookResult;
 import com.nexters.palang.domain.book.domain.Book;
@@ -100,7 +101,7 @@ class BookControllerTest {
     @Test
     @DisplayName("키워드로 도서 내부 검색을 요청하면 등록된 도서 목록을 반환한다")
     void searchInternalBooks() throws Exception {
-        given(bookService.searchInternalBooks(eq("제목"), any(Pageable.class))).willReturn(
+        given(bookService.searchInternalBooks(eq("제목"), any(BookSearchSort.class), any(Pageable.class))).willReturn(
                 new PageImpl<>(List.of(new BookSearchProjection(
                         1L, "제목", "작가", "출판사", 300, "isbn", "cover", BookSource.MANUAL, 12, 34)),
                         DEFAULT_PAGEABLE, 1));


### PR DESCRIPTION
## 📌 관련 이슈
- Close #97

## 🚀 개요
- 내부 도서 검색(`GET /api/books/internal-search`)에서 흔적(Opinion)이 하나도 없는 도서까지 노출되던 문제를 수정하고, 이름순/최신순/의견순 정렬 옵션을 추가했습니다.

## 📄 작업 내용
- `BookSearchSort` enum 추가 (`NAME`, `RECENT`, `OPINION`)
- `BookQueryRepository.searchByTitle`: `leftJoin` → `innerJoin`으로 변경해 흔적(Opinion)이 있는 도서만 조회하도록 수정
- `searchByTitle`에 정렬 파라미터를 받아 이름순(제목 오름차순)/최신순(가장 최근 흔적)/의견순(흔적 많은 순)으로 정렬하는 로직 추가
- `BookService.searchInternalBooks`, `BookController#searchInternalBooks`, `BookApi#searchInternalBooks`에 `sort` 쿼리 파라미터 반영 (기본값 `RECENT`, Swagger 문서 포함)
- `BookQueryRepositoryTest`의 "흔적 없는 도서도 포함" 케이스를 "제외된다"로 수정하고, 정렬 옵션별 테스트 3개 추가
- `BookServiceTest`, `BookControllerTest`의 관련 stub에 `sort` 파라미터 반영

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과 확인 (BUILD SUCCESSFUL)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `sort` 기본값을 `RECENT`로 뒀는데, 프론트 요구사항상 다른 기본 정렬(예: NAME)이 더 적합한지 확인 부탁드립니다.
- "최신순"을 "가장 최근에 흔적(Opinion)이 달린 시점" 기준으로 구현했는데, 의도한 정의가 맞는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 도서 검색 시 제목순, 최신 의견순, 의견 수순으로 정렬할 수 있습니다.
  * 정렬 기준을 선택하지 않으면 최신 의견순으로 검색됩니다.
  * 의견이나 관련 기록이 있는 도서만 검색 결과에 표시됩니다.

* **버그 수정**
  * 검색 결과의 정렬 기준과 표시 대상이 일관되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->