### PR TITLE
Feat/#99 내 서재 보기 - 사용자가 흔적을 남긴 도서 목록 API 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -81,11 +81,11 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
-    // 내 서재도 홈 캐러셀과 동일하게 offset을 지정하지 않으면 가운데를 기준으로 조회하며,
-    // 가운데에는 사용자가 가장 최근에 흔적을 남긴 도서가 오도록 정렬한다.
+    // 내 서재는 홈 캐러셀과 달리 "전체 목록의 중간"이 아니라 "내가 가장 최근에 남긴 흔적"이 가운데에 와야 한다.
+    // findMyLibraryBooks가 이미 최근 흔적 순으로 정렬해 반환하므로, offset을 지정하지 않으면 0(=가장 최근 도서부터)을 사용한다.
     public BookCarouselPage getMyLibraryBooks(Long userId, Long offset, int size) {
         long total = bookQueryRepository.countMyLibraryBooks(userId);
-        long resolvedOffset = offset != null ? Math.max(0, offset) : centerOffset(total, size);
+        long resolvedOffset = offset != null ? Math.max(0, offset) : 0;
         List<BookActivityProjection> books = bookQueryRepository.findMyLibraryBooks(userId, resolvedOffset, size);
         return new BookCarouselPage(books, resolvedOffset, size, total);
     }

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -81,6 +81,15 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
+    // 내 서재도 홈 캐러셀과 동일하게 offset을 지정하지 않으면 가운데를 기준으로 조회하며,
+    // 가운데에는 사용자가 가장 최근에 흔적을 남긴 도서가 오도록 정렬한다.
+    public BookCarouselPage getMyLibraryBooks(Long userId, Long offset, int size) {
+        long total = bookQueryRepository.countMyLibraryBooks(userId);
+        long resolvedOffset = offset != null ? Math.max(0, offset) : centerOffset(total, size);
+        List<BookActivityProjection> books = bookQueryRepository.findMyLibraryBooks(userId, resolvedOffset, size);
+        return new BookCarouselPage(books, resolvedOffset, size, total);
+    }
+
     public Page<Book> getRecentBooks(Long userId, Pageable pageable) {
         Page<Long> bookIds = bookQueryRepository.findRecentlyActiveBookIds(userId, pageable);
         Map<Long, Book> booksById = bookRepository.findAllById(bookIds.getContent()).stream()

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -81,7 +81,7 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
-    // 내 서재는 홈 캐러셀과 달리 "전체 목록의 중간"이 아니라 "내가 가장 최근에 남긴 흔적"이 가운데에 와야 한다.
+    // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열한다.
     // findMyLibraryBooks가 이미 최근 흔적 순으로 정렬해 반환하므로, offset을 지정하지 않으면 0(=가장 최근 도서부터)을 사용한다.
     public BookCarouselPage getMyLibraryBooks(Long userId, Long offset, int size) {
         long total = bookQueryRepository.countMyLibraryBooks(userId);

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -95,7 +95,7 @@ public class BookQueryRepository {
     }
 
     // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남긴 도서만 대상으로 하되, 대목/흔적 수는 홈 캐러셀과 동일하게
-    // 도서 전체 기준으로 보여준다. 가운데 정렬 기준은 사용자가 해당 도서에 남긴 가장 최근 흔적 시각이다.
+    // 도서 전체 기준으로 보여준다. 정렬 기준은 사용자가 해당 도서에 남긴 가장 최근 흔적 시각이다(최신순).
     public List<BookActivityProjection> findMyLibraryBooks(Long userId, long offset, int limit) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -94,6 +94,47 @@ public class BookQueryRepository {
         return countBooksWithPassages();
     }
 
+    // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남긴 도서만 대상으로 하되, 대목/흔적 수는 홈 캐러셀과 동일하게
+    // 도서 전체 기준으로 보여준다. 가운데 정렬 기준은 사용자가 해당 도서에 남긴 가장 최근 흔적 시각이다.
+    public List<BookActivityProjection> findMyLibraryBooks(Long userId, long offset, int limit) {
+        QBook book = QBook.book;
+        QPassage passage = QPassage.passage;
+        QOpinion opinionMine = new QOpinion("opinionMine");
+        QOpinion opinionAll = new QOpinion("opinionAll");
+
+        return queryFactory
+                .select(Projections.constructor(BookActivityProjection.class,
+                        book.id, book.title, book.author, book.coverImageUrl,
+                        passage.countDistinct(), opinionAll.countDistinct()))
+                .from(book)
+                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(opinionMine).on(opinionMine.passage.eq(passage)
+                        .and(opinionMine.user.id.eq(userId))
+                        .and(opinionMine.deletedAt.isNull()))
+                .leftJoin(opinionAll).on(opinionAll.passage.eq(passage).and(opinionAll.deletedAt.isNull()))
+                .groupBy(book.id, book.title, book.author, book.coverImageUrl)
+                .orderBy(opinionMine.createdAt.max().desc(), book.id.asc())
+                .offset(offset)
+                .limit(limit)
+                .fetch();
+    }
+
+    public long countMyLibraryBooks(Long userId) {
+        QBook book = QBook.book;
+        QPassage passage = QPassage.passage;
+        QOpinion opinionMine = QOpinion.opinion;
+
+        Long count = queryFactory
+                .select(book.countDistinct())
+                .from(book)
+                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(opinionMine).on(opinionMine.passage.eq(passage)
+                        .and(opinionMine.user.id.eq(userId))
+                        .and(opinionMine.deletedAt.isNull()))
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
     public Page<BookActivityProjection> findPopularBooks(Pageable pageable) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -93,6 +93,23 @@ public interface BookApi {
             @Parameter(description = "조회 개수 (기본값 20, 최대 100)") int size
     );
 
+    @Operation(summary = "내 서재 도서 목록",
+            description = "현재 로그인한 사용자가 흔적을 남긴 도서만 대상으로, 대목/흔적 수와 함께 조회합니다. "
+                    + "offset을 생략하면 전체 목록 중 사용자가 가장 최근에 흔적을 남긴 도서가 정가운데에 오도록 "
+                    + "조회하며, 좌우 스크롤 시에는 응답으로 받은 pageInfo를 참고해 offset - size(이전) 또는 "
+                    + "offset + size(다음)로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "offset/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
+            @Parameter(description = "조회 시작 위치 (0부터 시작). 생략하면 전체 목록 중 가운데를 기준으로 조회") Long offset,
+            @Parameter(description = "조회 개수 (기본값 20, 최대 100)") int size
+    );
+
     @Operation(summary = "내가 최근에 남긴 도서 목록",
             description = "현재 로그인한 사용자가 최근에 대목을 남긴 도서 목록입니다. "
                     + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -95,9 +95,9 @@ public interface BookApi {
 
     @Operation(summary = "내 서재 도서 목록",
             description = "현재 로그인한 사용자가 흔적을 남긴 도서만 대상으로, 대목/흔적 수와 함께 조회합니다. "
-                    + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬되며, offset을 생략하면 그 가장 최근 도서가 "
-                    + "가운데에 오도록 0부터 조회합니다. 좌측(과거)으로 더 스크롤할 때는 응답으로 받은 pageInfo를 "
-                    + "참고해 offset + size(다음)로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+                    + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬되며, offset을 생략하면 0부터(=가장 최근 "
+                    + "도서부터) 조회합니다. 더 과거 도서를 이어서 보려면 응답으로 받은 pageInfo를 참고해 "
+                    + "offset + size로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "offset/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -95,9 +95,9 @@ public interface BookApi {
 
     @Operation(summary = "내 서재 도서 목록",
             description = "현재 로그인한 사용자가 흔적을 남긴 도서만 대상으로, 대목/흔적 수와 함께 조회합니다. "
-                    + "offset을 생략하면 전체 목록 중 사용자가 가장 최근에 흔적을 남긴 도서가 정가운데에 오도록 "
-                    + "조회하며, 좌우 스크롤 시에는 응답으로 받은 pageInfo를 참고해 offset - size(이전) 또는 "
-                    + "offset + size(다음)로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+                    + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬되며, offset을 생략하면 그 가장 최근 도서가 "
+                    + "가운데에 오도록 0부터 조회합니다. 좌측(과거)으로 더 스크롤할 때는 응답으로 받은 pageInfo를 "
+                    + "참고해 offset + size(다음)로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "offset/size 형식 오류 (COMMON_400_1)",
@@ -106,7 +106,7 @@ public interface BookApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
-            @Parameter(description = "조회 시작 위치 (0부터 시작). 생략하면 전체 목록 중 가운데를 기준으로 조회") Long offset,
+            @Parameter(description = "조회 시작 위치 (0부터 시작). 생략하면 가장 최근에 흔적을 남긴 도서부터 조회") Long offset,
             @Parameter(description = "조회 개수 (기본값 20, 최대 100)") int size
     );
 

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -78,6 +78,17 @@ public class BookController implements BookApi {
     }
 
     @Override
+    @GetMapping("/api/home/my-library")
+    public ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
+            @RequestParam(required = false) Long offset,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        int clampedSize = Math.clamp(size, 1, MAX_SIZE);
+        return ResponseEntity.ok(DataResponse.from(
+                BookMapper.toCarouselListResponse(bookService.getMyLibraryBooks(currentUserId, offset, clampedSize))));
+    }
+
+    @Override
     @GetMapping("/api/books/recent")
     public ResponseEntity<DataResponse<BookListResponse>> getRecentBooks(
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -78,7 +78,7 @@ public class BookController implements BookApi {
     }
 
     @Override
-    @GetMapping("/api/home/my-library")
+    @GetMapping("/api/books/my-library")
     public ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
             @RequestParam(required = false) Long offset,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -193,4 +193,29 @@ class BookServiceTest {
 
         assertThat(result.offset()).isEqualTo(0L);
     }
+
+    @Test
+    @DisplayName("내 서재는 offset을 지정하지 않으면 사용자의 흔적 도서 개수를 기준으로 가운데 offset을 계산한다")
+    void getMyLibraryBooksResolvesCenterOffsetWhenOffsetIsNull() {
+        given(bookQueryRepository.countMyLibraryBooks(10L)).willReturn(100L);
+        given(bookQueryRepository.findMyLibraryBooks(10L, 40L, 20))
+                .willReturn(List.of(new BookActivityProjection(1L, "책1", "작가", "cover", 5, 10)));
+
+        BookCarouselPage result = bookService.getMyLibraryBooks(10L, null, 20);
+
+        assertThat(result.offset()).isEqualTo(40L);
+        assertThat(result.totalElements()).isEqualTo(100L);
+        assertThat(result.books()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("내 서재는 offset을 직접 지정하면 그 값을 그대로 사용해 조회한다")
+    void getMyLibraryBooksUsesGivenOffset() {
+        given(bookQueryRepository.countMyLibraryBooks(10L)).willReturn(100L);
+        given(bookQueryRepository.findMyLibraryBooks(10L, 60L, 20)).willReturn(List.of());
+
+        BookCarouselPage result = bookService.getMyLibraryBooks(10L, 60L, 20);
+
+        assertThat(result.offset()).isEqualTo(60L);
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -195,15 +195,15 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("내 서재는 offset을 지정하지 않으면 사용자의 흔적 도서 개수를 기준으로 가운데 offset을 계산한다")
-    void getMyLibraryBooksResolvesCenterOffsetWhenOffsetIsNull() {
+    @DisplayName("내 서재는 offset을 지정하지 않으면 가장 최근에 흔적을 남긴 도서부터(offset 0) 조회한다")
+    void getMyLibraryBooksDefaultsToZeroOffsetWhenOffsetIsNull() {
         given(bookQueryRepository.countMyLibraryBooks(10L)).willReturn(100L);
-        given(bookQueryRepository.findMyLibraryBooks(10L, 40L, 20))
+        given(bookQueryRepository.findMyLibraryBooks(10L, 0L, 20))
                 .willReturn(List.of(new BookActivityProjection(1L, "책1", "작가", "cover", 5, 10)));
 
         BookCarouselPage result = bookService.getMyLibraryBooks(10L, null, 20);
 
-        assertThat(result.offset()).isEqualTo(40L);
+        assertThat(result.offset()).isEqualTo(0L);
         assertThat(result.totalElements()).isEqualTo(100L);
         assertThat(result.books()).hasSize(1);
     }

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -260,6 +260,42 @@ class BookQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("내 서재는 내가 흔적을 남긴 도서만 포함하고 대목/흔적 수는 도서 전체 기준으로 집계한다")
+    void findMyLibraryBooksOnlyIncludesBooksWithMyOpinion() {
+        User me = user("me-lib");
+        User other = user("other-lib");
+        Book myBook = book("내가 흔적을 남긴 책");
+        Book othersBook = book("다른 사람만 흔적을 남긴 책");
+        Passage myPassage = passage(myBook, me, 1);
+        opinion(myPassage, me);
+        opinion(myPassage, other);
+        opinion(passage(othersBook, other, 1), other);
+
+        List<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(me.getId(), 0, 20);
+
+        assertThat(results).extracting(BookActivityProjection::bookId).containsExactly(myBook.getId());
+        assertThat(results.get(0).passageCount()).isEqualTo(1);
+        assertThat(results.get(0).opinionCount()).isEqualTo(2);
+        assertThat(bookQueryRepository.countMyLibraryBooks(me.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("내 서재는 내가 가장 최근에 흔적을 남긴 도서부터 반환한다")
+    void findMyLibraryBooksOrdersByMyMostRecentOpinion() throws InterruptedException {
+        User me = user("me-lib-order");
+        Book olderBook = book("먼저 흔적을 남긴 책");
+        Book newerBook = book("나중에 흔적을 남긴 책");
+        opinion(passage(olderBook, me, 1), me);
+        Thread.sleep(10);
+        opinion(passage(newerBook, me, 1), me);
+
+        List<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(me.getId(), 0, 20);
+
+        assertThat(results).extracting(BookActivityProjection::bookId)
+                .containsExactly(newerBook.getId(), olderBook.getId());
+    }
+
+    @Test
     @DisplayName("직접 대목을 만들지 않고 기존 대목에 흔적만 남긴 도서도 포함한다")
     void findRecentlyActiveBookIdsIncludesBooksWhereUserOnlyLeftOpinion() {
         User creator = user("creator");

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -180,6 +180,30 @@ class BookControllerTest {
     }
 
     @Test
+    @DisplayName("내 서재 도서 목록을 요청하면 현재 사용자 기준으로 조회한다")
+    void getMyLibraryBooks() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(bookService.getMyLibraryBooks(eq(1L), isNull(), anyInt())).willReturn(
+                new BookCarouselPage(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)), 0, 20, 1));
+
+        mockMvc.perform(get("/api/home/my-library"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].bookId").value(1))
+                .andExpect(jsonPath("$.data.books[0].passageCount").value(3))
+                .andExpect(jsonPath("$.data.books[0].opinionCount").value(7));
+    }
+
+    @Test
+    @DisplayName("인증 없이 내 서재 도서 목록을 요청하면 401 에러가 발생한다")
+    void getMyLibraryBooksFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(get("/api/home/my-library"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
     @DisplayName("내가 최근에 남긴 도서 목록을 요청하면 현재 사용자 기준으로 조회한다")
     void getRecentBooks() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -186,7 +186,7 @@ class BookControllerTest {
         given(bookService.getMyLibraryBooks(eq(1L), isNull(), anyInt())).willReturn(
                 new BookCarouselPage(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)), 0, 20, 1));
 
-        mockMvc.perform(get("/api/home/my-library"))
+        mockMvc.perform(get("/api/books/my-library"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books[0].bookId").value(1))
                 .andExpect(jsonPath("$.data.books[0].passageCount").value(3))
@@ -198,7 +198,7 @@ class BookControllerTest {
     void getMyLibraryBooksFailsWhenUnauthenticated() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
 
-        mockMvc.perform(get("/api/home/my-library"))
+        mockMvc.perform(get("/api/books/my-library"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #99

## 🚀 개요
- 홈 화면의 흔적 있는 도서 캐러셀에 이어, 로그인한 사용자가 직접 흔적(대목/의견)을 남긴 도서만 모아 보는 "내 서재" 목록 API를 추가한다.

## 📄 작업 내용
- `BookQueryRepository`: `findMyLibraryBooks`/`countMyLibraryBooks` 추가 — 사용자가 흔적을 남긴 도서만 필터링하고, 그 사용자의 가장 최근 흔적 시각 기준 내림차순 정렬 (대목/흔적 수는 도서 전체 기준으로 집계)
- `BookService`: `getMyLibraryBooks(userId, offset, size)` 추가 — offset 미지정 시 0부터(=가장 최근 도서부터) 조회
- `BookController`/`BookApi`: `GET /api/books/my-library` 신규 엔드포인트, `CurrentUserProvider`로 인증 필요, Swagger 문서화
- 관련 테스트 추가: `BookQueryRepositoryTest`, `BookServiceTest`, `BookControllerTest`

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/books/my-library` | 내가 흔적을 남긴 도서 목록 (offset/size, 최근순) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test --tests "com.nexters.palang.domain.book.*"` 통과

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `passageCount`/`opinionCount`는 도서 전체(모든 사용자) 기준으로 내려주는데, "내 서재" 맥락에서 이게 맞는 정보인지 확인 부탁드립니다. (내가 남긴 흔적 수가 아님)
- offset/size 방식을 그대로 유지했는데, 캐러셀처럼 좌우 자유 스크롤이 필요 없다면 page/size로 바꾸는 게 더 단순할 수 있습니다.
