### PR TITLE
Fix/#103 프로필/책표지 이미지 404 수정

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -37,3 +37,8 @@ APPLE_PRIVATE_KEY=
 # ---- 이미지 업로드 저장 경로 (가비아 상용 클라우드에는 오브젝트 스토리지가 없어 서버 디스크에 저장) ----
 # docker-compose의 uploads-data 볼륨과 맞춘 컨테이너 내부 경로. 보통 바꿀 필요 없음.
 IMAGE_UPLOAD_DIR=/app/uploads
+
+# 업로드된 이미지의 공개(절대) URL 접두사. 프론트 도메인과 API 도메인이 달라서(예: dev.pallang.co.kr vs
+# api-dev.pallang.co.kr) 상대 경로를 반환하면 프론트가 자기 자신의 origin으로 잘못 요청해 404가 난다.
+# dev/prod 프로파일에 기본값이 있어 보통 비워둬도 되지만, 도메인이 바뀌면 여기서 덮어쓸 것.
+# STORAGE_PUBLIC_BASE_URL=https://api-dev.pallang.co.kr/images

--- a/src/main/java/com/nexters/palang/global/storage/LocalFileStorageService.java
+++ b/src/main/java/com/nexters/palang/global/storage/LocalFileStorageService.java
@@ -14,13 +14,13 @@ import org.springframework.web.multipart.MultipartFile;
 public class LocalFileStorageService implements FileStorageService {
 
     private final Path uploadDir;
-    private final String baseUrl;
+    private final String publicBaseUrl;
 
     public LocalFileStorageService(
             @Value("${storage.upload-dir}") String uploadDir,
-            @Value("${storage.base-url}") String baseUrl) {
+            @Value("${storage.public-base-url}") String publicBaseUrl) {
         this.uploadDir = Path.of(uploadDir).toAbsolutePath().normalize();
-        this.baseUrl = baseUrl;
+        this.publicBaseUrl = publicBaseUrl;
     }
 
     @Override
@@ -37,6 +37,6 @@ public class LocalFileStorageService implements FileStorageService {
             throw new AppException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        return baseUrl + "/" + subDirectory + "/" + filename;
+        return publicBaseUrl + "/" + subDirectory + "/" + filename;
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -54,6 +54,9 @@ aladin:
   base-url: https://www.aladin.co.kr/ttb/api
   ttb-key: ${ALADIN_TTB_KEY:}
 
+storage:
+  public-base-url: ${STORAGE_PUBLIC_BASE_URL:https://api-dev.pallang.co.kr/images}
+
 # 6. CORS 허용 origin (프론트엔드와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급됨)
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -59,6 +59,9 @@ kakao:
   base-url: https://kapi.kakao.com
   admin-key: ${KAKAO_ADMIN_KEY:}
 
+storage:
+  public-base-url: ${STORAGE_PUBLIC_BASE_URL:https://api.pallang.co.kr/images}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ jwt:
 
 # 이미지 업로드 저장 경로. 가비아 상용 클라우드에는 오브젝트 스토리지 상품이 없어
 # 서버(Docker volume)에 직접 저장하고 /images/** 경로로 서빙한다.
+# base-url: Spring 리소스 핸들러 매핑 경로(WebStorageConfig), public-base-url: 클라이언트에 내려줄 절대 URL(FileStorageService).
+# 이 둘을 분리하지 않으면 base-url이 상대 경로라 클라이언트가 자기 자신의 origin 기준으로 이미지를 요청해 404가 난다.
 storage:
   upload-dir: ${IMAGE_UPLOAD_DIR:./uploads}
   base-url: /images
+  public-base-url: ${STORAGE_PUBLIC_BASE_URL:http://localhost:8080/images}

--- a/src/test/java/com/nexters/palang/global/storage/LocalFileStorageServiceTest.java
+++ b/src/test/java/com/nexters/palang/global/storage/LocalFileStorageServiceTest.java
@@ -18,14 +18,15 @@ class LocalFileStorageServiceTest {
     Path tempDir;
 
     @Test
-    @DisplayName("이미지를 저장하면 하위 디렉터리에 파일이 생기고 base-url 기준 URL을 반환한다")
+    @DisplayName("이미지를 저장하면 하위 디렉터리에 파일이 생기고 public-base-url 기준 절대 URL을 반환한다")
     void storeSavesFileAndReturnsUrl() throws IOException {
-        LocalFileStorageService storageService = new LocalFileStorageService(tempDir.toString(), "/images");
+        LocalFileStorageService storageService =
+                new LocalFileStorageService(tempDir.toString(), "https://api.example.com/images");
         MockMultipartFile file = new MockMultipartFile("coverImage", "cover.jpg", "image/jpeg", "data".getBytes());
 
         String url = storageService.store(file, "book-covers");
 
-        assertThat(url).startsWith("/images/book-covers/").endsWith(".jpg");
+        assertThat(url).startsWith("https://api.example.com/images/book-covers/").endsWith(".jpg");
         String filename = url.substring(url.lastIndexOf('/') + 1);
         assertThat(Files.exists(tempDir.resolve("book-covers").resolve(filename))).isTrue();
     }
@@ -33,7 +34,8 @@ class LocalFileStorageServiceTest {
     @Test
     @DisplayName("이미지 타입이 아니면 예외가 발생하고 파일을 저장하지 않는다")
     void storeFailsWhenContentTypeIsNotImage() {
-        LocalFileStorageService storageService = new LocalFileStorageService(tempDir.toString(), "/images");
+        LocalFileStorageService storageService =
+                new LocalFileStorageService(tempDir.toString(), "https://api.example.com/images");
         MockMultipartFile file = new MockMultipartFile("coverImage", "cover.txt", "text/plain", "data".getBytes());
 
         assertThatThrownBy(() -> storageService.store(file, "book-covers")).isInstanceOf(AppException.class);


### PR DESCRIPTION
## 📌 관련 이슈
- Close #103

## 🚀 개요
프론트(`dev.pallang.co.kr`)와 백엔드(`api-dev.pallang.co.kr`) 도메인이 달라, 업로드된 이미지(프로필/책표지) URL을 상대경로로 응답하면 프론트가 자기 자신의 origin 기준으로 이미지를 요청해 404가 발생하던 문제를 수정합니다.

## 📄 작업 내용
- `storage.public-base-url` 프로퍼티 신설 — 리소스 핸들러 매핑 경로(`storage.base-url`)와 클라이언트에 내려줄 절대 URL을 분리
- `LocalFileStorageService`가 `public-base-url` 기준 절대 URL(`https://api-dev.pallang.co.kr/images/...`)을 반환하도록 수정
- `application.yaml`(local 기본값), `application-dev.yaml`, `application-prod.yaml`, `deploy/.env.example`에 환경별 기본값 반영
- `LocalFileStorageServiceTest`를 절대 URL 기준으로 갱신
- (배포와 무관한 임시 조치) dev DB에 이미 저장된 상대경로 `profile_image_url` 2건을 절대 URL로 수동 정정

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test --tests "*storage*" --tests "*UserService*" --tests "*BookService*"` 통과
- dev 서버에서 정정된 URL로 curl 응답 200 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- prod 도메인을 `api.pallang.co.kr`로 하드코딩된 기본값에 넣었는데, 실제 배포 시 `.env`의 `STORAGE_PUBLIC_BASE_URL`로 덮어쓸 수 있게 열어뒀습니다. 기본값 자체가 맞는지 확인 부탁드립니다.
- `WebStorageConfig`의 `storage.base-url`(`/images`, 리소스 매핑 경로)은 그대로 뒀고 신규 `storage.public-base-url`만 추가했습니다 — 프로퍼티 두 개로 분리한 접근이 적절한지 의견 부탁드립니다.