### PR TITLE
Refactor/#102 내 흔적 목록 API에 지은이(author) 필드 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/opinion/application/MyOpinionProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/MyOpinionProjection.java
@@ -6,6 +6,7 @@ public record MyOpinionProjection(
         Long opinionId,
         Long bookId,
         String bookTitle,
+        String author,
         String bookCoverImageUrl,
         Long passageId,
         String quotedText,

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -96,7 +96,7 @@ public class OpinionQueryRepository {
 
         List<MyOpinionProjection> content = queryFactory
                 .select(Projections.constructor(MyOpinionProjection.class,
-                        opinion.id, book.id, book.title, book.coverImageUrl,
+                        opinion.id, book.id, book.title, book.author, book.coverImageUrl,
                         passage.id, passage.quotedText, passage.pageNumber,
                         opinion.content, opinion.likeCount, opinion.createdAt))
                 .from(opinion)

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -24,8 +24,8 @@ public final class UserMapper {
 
     public static MyOpinionResponse toMyOpinionResponse(MyOpinionProjection projection) {
         return new MyOpinionResponse(
-                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.bookCoverImageUrl(),
-                projection.passageId(), projection.quotedText(), projection.pageNumber(),
+                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.author(),
+                projection.bookCoverImageUrl(), projection.passageId(), projection.quotedText(), projection.pageNumber(),
                 projection.content(), projection.likeCount(), projection.createdAt());
     }
 

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyOpinionResponse.java
@@ -7,6 +7,7 @@ public record MyOpinionResponse(
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
         @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -237,7 +237,7 @@ class OpinionServiceTest {
     void getMyOpinionsReturnsPageFromQueryRepository() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<MyOpinionProjection> expected = new PageImpl<>(
-                List.of(new MyOpinionProjection(1L, 10L, "제목", "cover", 100L, "발췌", 5, "흔적", 0, LocalDateTime.now())),
+                List.of(new MyOpinionProjection(1L, 10L, "제목", "작가", "cover", 100L, "발췌", 5, "흔적", 0, LocalDateTime.now())),
                 pageable, 1);
         given(opinionQueryRepository.findMyOpinions(1L, pageable)).willReturn(expected);
 

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -215,6 +215,8 @@ class OpinionQueryRepositoryTest {
 
         assertThat(results.getContent()).extracting(MyOpinionProjection::opinionId)
                 .containsExactly(newer.getId(), older.getId());
+        assertThat(results.getContent()).extracting(MyOpinionProjection::author)
+                .containsOnly(book.getAuthor());
         assertThat(results.getTotalElements()).isEqualTo(2);
     }
 

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -269,14 +269,15 @@ class UserControllerTest {
     void getMyOpinions() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
         MyOpinionProjection projection = new MyOpinionProjection(
-                1L, 10L, "책 제목", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
+                1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
         given(opinionService.getMyOpinions(eq(1L), any())).willReturn(
                 new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/opinions"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1))
-                .andExpect(jsonPath("$.data.opinions[0].bookTitle").value("책 제목"));
+                .andExpect(jsonPath("$.data.opinions[0].bookTitle").value("책 제목"))
+                .andExpect(jsonPath("$.data.opinions[0].author").value("작가"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #102

## 🚀 개요
내가 남긴 흔적(의견) 목록 API(`GET /api/users/me/opinions`) 응답에 빠져 있던 지은이(author) 필드를 추가합니다.

## 📄 작업 내용
- `MyOpinionProjection`, `OpinionQueryRepository.findMyOpinions`에 `book.author` select 추가
- `MyOpinionResponse`, `UserMapper.toMyOpinionResponse`에 `author` 필드 매핑 추가
- `OpinionServiceTest`, `OpinionQueryRepositoryTest`, `UserControllerTest`에 `author` 검증 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- `OpinionServiceTest`, `UserControllerTest`: 통과
- `OpinionQueryRepositoryTest`(`@DataJpaTest`)는 로컬 환경에서 이번 변경과 무관한 기존 이슈(H2 스키마 미생성)로 실패 — `develop` 기준 원본 코드로도 동일하게 재현되는 걸 확인했습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `MyOpinionProjection`은 위치 기반 생성자라 필드를 중간(`bookTitle` 다음)에 추가하였음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 내 의견 목록에서 도서의 저자 정보를 함께 확인할 수 있습니다.
* **테스트**
  * 내 의견 조회 시 저자 정보가 올바르게 표시되는지 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->