### PR TITLE
Feat/#107 내 서재 API - opinionCountScope 추가 및 페이지네이션 표준화

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -81,13 +81,9 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
-    // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열한다.
-    // findMyLibraryBooks가 이미 최근 흔적 순으로 정렬해 반환하므로, offset을 지정하지 않으면 0(=가장 최근 도서부터)을 사용한다.
-    public BookCarouselPage getMyLibraryBooks(Long userId, Long offset, int size) {
-        long total = bookQueryRepository.countMyLibraryBooks(userId);
-        long resolvedOffset = offset != null ? Math.max(0, offset) : 0;
-        List<BookActivityProjection> books = bookQueryRepository.findMyLibraryBooks(userId, resolvedOffset, size);
-        return new BookCarouselPage(books, resolvedOffset, size, total);
+    // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열하며, 표준 page/size 페이지네이션을 사용한다.
+    public Page<BookActivityProjection> getMyLibraryBooks(Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
+        return bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
     }
 
     public Page<Book> getRecentBooks(Long userId, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/application/OpinionCountScope.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/OpinionCountScope.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.book.application;
+
+public enum OpinionCountScope {
+    ALL,
+    MINE
+}

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -112,17 +112,21 @@ public class BookQueryRepository {
                 ? opinionMine.countDistinct()
                 : opinionAll.countDistinct();
 
+        // opinionMine/opinionAll은 도서 전체 집계용 passage 조인과 별개로 passage.book을 통해 book에 직접
+        // 연결한다. 특정 passage 행을 공유해서 조인하면 opinionMine의 innerJoin이 passage를 "내가 흔적을 남긴
+        // 대목"으로 제한해버려서, passageCount/opinionAll(ALL)이 도서 전체가 아니라 그 대목만 집계하게 된다.
         JPAQuery<BookActivityProjection> query = queryFactory
                 .select(Projections.constructor(BookActivityProjection.class,
                         book.id, book.title, book.author, book.coverImageUrl,
                         passage.countDistinct(), opinionCount))
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinionMine).on(opinionMine.passage.eq(passage)
+                .innerJoin(opinionMine).on(opinionMine.passage.book.eq(book)
                         .and(opinionMine.user.id.eq(userId))
                         .and(opinionMine.deletedAt.isNull()));
         if (opinionCountScope == OpinionCountScope.ALL) {
-            query = query.leftJoin(opinionAll).on(opinionAll.passage.eq(passage).and(opinionAll.deletedAt.isNull()));
+            query = query.leftJoin(opinionAll)
+                    .on(opinionAll.passage.book.eq(book).and(opinionAll.deletedAt.isNull()));
         }
 
         List<BookActivityProjection> content = query

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -3,13 +3,16 @@ package com.nexters.palang.domain.book.infrastructure;
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookSearchSort;
+import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -94,32 +97,45 @@ public class BookQueryRepository {
         return countBooksWithPassages();
     }
 
-    // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남긴 도서만 대상으로 하되, 대목/흔적 수는 홈 캐러셀과 동일하게
-    // 도서 전체 기준으로 보여준다. 정렬 기준은 사용자가 해당 도서에 남긴 가장 최근 흔적 시각이다(최신순).
-    public List<BookActivityProjection> findMyLibraryBooks(Long userId, long offset, int limit) {
+    // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남긴 도서만 대상으로 한다. 대목 수는 홈 캐러셀과 동일하게
+    // 도서 전체 기준으로 보여주지만, 흔적 수는 opinionCountScope에 따라 도서 전체(ALL, 홈 노출용) 또는
+    // 로그인 사용자 본인이 남긴 것(MINE, 마이페이지 노출용)만 집계한다. 정렬 기준은 스코프와 무관하게 사용자가
+    // 해당 도서에 남긴 가장 최근 흔적 시각이다(최신순).
+    public Page<BookActivityProjection> findMyLibraryBooks(
+            Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinionMine = new QOpinion("opinionMine");
         QOpinion opinionAll = new QOpinion("opinionAll");
 
-        return queryFactory
+        NumberExpression<Long> opinionCount = opinionCountScope == OpinionCountScope.MINE
+                ? opinionMine.countDistinct()
+                : opinionAll.countDistinct();
+
+        JPAQuery<BookActivityProjection> query = queryFactory
                 .select(Projections.constructor(BookActivityProjection.class,
                         book.id, book.title, book.author, book.coverImageUrl,
-                        passage.countDistinct(), opinionAll.countDistinct()))
+                        passage.countDistinct(), opinionCount))
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
                 .innerJoin(opinionMine).on(opinionMine.passage.eq(passage)
                         .and(opinionMine.user.id.eq(userId))
-                        .and(opinionMine.deletedAt.isNull()))
-                .leftJoin(opinionAll).on(opinionAll.passage.eq(passage).and(opinionAll.deletedAt.isNull()))
+                        .and(opinionMine.deletedAt.isNull()));
+        if (opinionCountScope == OpinionCountScope.ALL) {
+            query = query.leftJoin(opinionAll).on(opinionAll.passage.eq(passage).and(opinionAll.deletedAt.isNull()));
+        }
+
+        List<BookActivityProjection> content = query
                 .groupBy(book.id, book.title, book.author, book.coverImageUrl)
                 .orderBy(opinionMine.createdAt.max().desc(), book.id.asc())
-                .offset(offset)
-                .limit(limit)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        return new PageImpl<>(content, pageable, countMyLibraryBooks(userId));
     }
 
-    public long countMyLibraryBooks(Long userId) {
+    private long countMyLibraryBooks(Long userId) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinionMine = QOpinion.opinion;

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -29,6 +29,8 @@ public class BookQueryRepository {
 
     // 띄어쓰기 차이를 무시하고 검색할 수 있도록 제목/키워드 모두에서 공백을 제거한 뒤 비교한다.
     // 흔적(Opinion)이 하나도 없는 도서는 결과에서 제외하므로 leftJoin이 아닌 innerJoin을 사용한다.
+    // opinion은 passage.book으로 book에 직접 연결한다 (특정 passage 행에 걸면 그 passage로만 결과가
+    // 제한되어, 흔적 없는 다른 대목이 passageCount/opinionCount 집계에서 빠지게 된다).
     public Page<BookSearchProjection> searchByTitle(String keyword, BookSearchSort sort, Pageable pageable) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
@@ -44,7 +46,7 @@ public class BookQueryRepository {
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
+                .innerJoin(opinion).on(opinion.passage.book.eq(book).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.pageCount,
                         book.isbn, book.coverImageUrl, book.source)
@@ -57,7 +59,7 @@ public class BookQueryRepository {
                 .select(book.countDistinct())
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
+                .innerJoin(opinion).on(opinion.passage.book.eq(book).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .fetchOne();
 

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -45,7 +45,7 @@ public class BookQueryRepository {
                         book.isbn, book.coverImageUrl, book.source,
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .innerJoin(opinion).on(opinion.passage.book.eq(book).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.pageCount,
@@ -58,7 +58,7 @@ public class BookQueryRepository {
         Long total = queryFactory
                 .select(book.countDistinct())
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .innerJoin(opinion).on(opinion.passage.book.eq(book).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .fetchOne();
@@ -86,7 +86,7 @@ public class BookQueryRepository {
                         book.id, book.title, book.author, book.coverImageUrl,
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .groupBy(book.id, book.title, book.author, book.coverImageUrl)
                 .orderBy(passage.createdAt.max().desc(), book.id.asc())
@@ -122,7 +122,7 @@ public class BookQueryRepository {
                         book.id, book.title, book.author, book.coverImageUrl,
                         passage.countDistinct(), opinionCount))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .innerJoin(opinionMine).on(opinionMine.passage.book.eq(book)
                         .and(opinionMine.user.id.eq(userId))
                         .and(opinionMine.deletedAt.isNull()));
@@ -167,7 +167,7 @@ public class BookQueryRepository {
                         book.id, book.title, book.author, book.coverImageUrl,
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .groupBy(book.id, book.title, book.author, book.coverImageUrl)
                 .orderBy(opinion.countDistinct().desc(), book.id.asc())
@@ -212,7 +212,7 @@ public class BookQueryRepository {
         Long count = queryFactory
                 .select(book.countDistinct())
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
+                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
                 .fetchOne();
         return count != null ? count : 0L;
     }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.book.presentation;
 
 import com.nexters.palang.domain.book.application.BookSearchSort;
+import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookListResponse;
@@ -95,19 +96,22 @@ public interface BookApi {
 
     @Operation(summary = "내 서재 도서 목록",
             description = "현재 로그인한 사용자가 흔적을 남긴 도서만 대상으로, 대목/흔적 수와 함께 조회합니다. "
-                    + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬되며, offset을 생략하면 0부터(=가장 최근 "
-                    + "도서부터) 조회합니다. 더 과거 도서를 이어서 보려면 응답으로 받은 pageInfo를 참고해 "
-                    + "offset + size로 다시 요청하면 됩니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+                    + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬됩니다. opinionCountScope로 흔적 수 집계 "
+                    + "기준을 선택할 수 있습니다: ALL(기본값, 도서 전체 흔적 수 - 홈 화면 노출용) 또는 "
+                    + "MINE(로그인 사용자 본인이 남긴 흔적 수 - 마이페이지 노출용). "
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "offset/size 형식 오류 (COMMON_400_1)",
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
-            @Parameter(description = "조회 시작 위치 (0부터 시작). 생략하면 가장 최근에 흔적을 남긴 도서부터 조회") Long offset,
-            @Parameter(description = "조회 개수 (기본값 20, 최대 100)") int size
+    ResponseEntity<DataResponse<BookActivityListResponse>> getMyLibraryBooks(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size,
+            @Parameter(description = "흔적 수 집계 기준 (ALL: 도서 전체, MINE: 로그인 사용자 본인, 기본값 ALL)")
+            OpinionCountScope opinionCountScope
     );
 
     @Operation(summary = "내가 최근에 남긴 도서 목록",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.book.presentation;
 import com.nexters.palang.domain.book.application.BookMapper;
 import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.BookService;
+import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.presentation.dto.BookActivityListResponse;
 import com.nexters.palang.domain.book.presentation.dto.BookCarouselListResponse;
@@ -79,13 +80,13 @@ public class BookController implements BookApi {
 
     @Override
     @GetMapping("/api/books/my-library")
-    public ResponseEntity<DataResponse<BookCarouselListResponse>> getMyLibraryBooks(
-            @RequestParam(required = false) Long offset,
-            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+    public ResponseEntity<DataResponse<BookActivityListResponse>> getMyLibraryBooks(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = "ALL") OpinionCountScope opinionCountScope) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
-        int clampedSize = Math.clamp(size, 1, MAX_SIZE);
-        return ResponseEntity.ok(DataResponse.from(
-                BookMapper.toCarouselListResponse(bookService.getMyLibraryBooks(currentUserId, offset, clampedSize))));
+        return ResponseEntity.ok(DataResponse.from(BookMapper.toActivityListResponse(
+                bookService.getMyLibraryBooks(currentUserId, pageable(page, size), opinionCountScope))));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -43,7 +43,7 @@ public class OpinionService {
     // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순. currentUserId는 비로그인 시 null(liked는 항상 false).
     public Page<OpinionSummaryProjection> getOpinions(
             Long passageId, OpinionSortType sortType, Pageable pageable, Long currentUserId) {
-        if (!passageRepository.existsById(passageId)) {
+        if (!passageRepository.existsByIdAndDeletedAtIsNull(passageId)) {
             throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
         }
         return opinionQueryRepository.findOpinions(passageId, sortType, pageable, currentUserId);
@@ -62,11 +62,18 @@ public class OpinionService {
         return opinion;
     }
 
+    // 대목은 여러 사용자가 공유하는 단위이므로, 이 삭제로 그 대목에 살아있는 흔적이 하나도 남지 않을 때만
+    // 대목도 함께 소프트 삭제한다 (PM 요구사항: 흔적 0개인 대목은 존재할 수 없다).
     @Transactional
     public void removeOpinion(Long opinionId, Long userId) {
         Opinion opinion = getExistingOpinion(opinionId);
         validateOwner(opinion, userId);
         opinion.delete();
+
+        Long passageId = opinion.getPassage().getId();
+        if (!opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(passageId, opinion.getId())) {
+            opinion.getPassage().delete();
+        }
     }
 
     private Opinion getExistingOpinion(Long opinionId) {
@@ -110,6 +117,9 @@ public class OpinionService {
     private Passage mergeIntoExistingPassage(CreateOpinionRequest request) {
         Passage existing = passageRepository.findById(request.passageId())
                 .orElseThrow(() -> new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
+        if (existing.isDeleted()) {
+            throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
+        }
         if (!existing.getBook().getId().equals(request.bookId())) {
             throw new PassageException(PassageErrorCode.PASSAGE_BOOK_MISMATCH);
         }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -10,6 +10,9 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
 
     long countByUserIdAndDeletedAtIsNull(Long userId);
 
+    // 흔적 삭제 시 그 대목에 남은 다른 살아있는 흔적이 있는지 확인하기 위함 (없으면 대목도 함께 삭제).
+    boolean existsByPassageIdAndDeletedAtIsNullAndIdNot(Long passageId, Long id);
+
     // open-in-view: false 환경에서 컨트롤러 단 응답 매핑이 opinion.getUser()/getDecorations()를
     // 참조하므로 트랜잭션 안에서 미리 로딩해야 LazyInitializationException을 피할 수 있다.
     @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations where o.id = :id")

--- a/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
+++ b/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,6 +61,10 @@ public class Passage extends BaseEntity {
     @Column(name = "normalized_hash", length = 64, nullable = false)
     private String normalizedHash;
 
+    // 대목에 달린 마지막 흔적이 삭제되면(OpinionService) 대목도 함께 소프트 삭제된다 (PM 요구사항).
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     private Passage(Book book, User creator, int pageNumber, String quotedText, boolean isSpoiler, String normalizedHash) {
         this.book = book;
@@ -68,5 +73,13 @@ public class Passage extends BaseEntity {
         this.quotedText = quotedText;
         this.isSpoiler = isSpoiler;
         this.normalizedHash = normalizedHash;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -31,6 +31,7 @@ public class PassageQueryRepository {
                 .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .where(
                         passage.book.id.eq(bookId),
+                        passage.deletedAt.isNull(),
                         passage.pageNumber.between(pageNumber - 1, pageNumber + 1),
                         passage.normalizedHash.eq(normalizedHash)
                 )
@@ -46,7 +47,7 @@ public class PassageQueryRepository {
         List<Integer> content = queryFactory
                 .select(passage.pageNumber)
                 .from(passage)
-                .where(passage.book.id.eq(bookId))
+                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull())
                 .groupBy(passage.pageNumber)
                 .orderBy(passage.pageNumber.asc())
                 .offset(pageable.getOffset())
@@ -56,7 +57,7 @@ public class PassageQueryRepository {
         Long total = queryFactory
                 .select(passage.pageNumber.countDistinct())
                 .from(passage)
-                .where(passage.book.id.eq(bookId))
+                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull())
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
@@ -68,7 +69,7 @@ public class PassageQueryRepository {
 
         return queryFactory
                 .selectFrom(passage)
-                .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber))
+                .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber), passage.deletedAt.isNull())
                 .orderBy(passage.id.asc())
                 .fetch();
     }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
@@ -4,4 +4,6 @@ import com.nexters.palang.domain.passage.domain.Passage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PassageRepository extends JpaRepository<Passage, Long> {
+
+    boolean existsByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -21,9 +21,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      # 운영에서는 스키마를 자동 변경하지 않는다. 마이그레이션 도구(Flyway/Liquibase) 도입 전까지는
-      # 스키마를 미리 반영해두고 검증만 수행한다. 스키마가 자주 바뀌는 환경은 application-dev.yaml을 쓸 것.
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -195,27 +195,27 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("내 서재는 offset을 지정하지 않으면 가장 최근에 흔적을 남긴 도서부터(offset 0) 조회한다")
-    void getMyLibraryBooksDefaultsToZeroOffsetWhenOffsetIsNull() {
-        given(bookQueryRepository.countMyLibraryBooks(10L)).willReturn(100L);
-        given(bookQueryRepository.findMyLibraryBooks(10L, 0L, 20))
-                .willReturn(List.of(new BookActivityProjection(1L, "책1", "작가", "cover", 5, 10)));
+    @DisplayName("내 서재 조회는 표준 page/size 페이지네이션과 opinionCountScope를 그대로 리포지토리에 위임한다")
+    void getMyLibraryBooksDelegatesToRepository() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<BookActivityProjection> expected = new PageImpl<>(
+                List.of(new BookActivityProjection(1L, "책1", "작가", "cover", 5, 10)), pageable, 1);
+        given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.ALL)).willReturn(expected);
 
-        BookCarouselPage result = bookService.getMyLibraryBooks(10L, null, 20);
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.ALL);
 
-        assertThat(result.offset()).isEqualTo(0L);
-        assertThat(result.totalElements()).isEqualTo(100L);
-        assertThat(result.books()).hasSize(1);
+        assertThat(results).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("내 서재는 offset을 직접 지정하면 그 값을 그대로 사용해 조회한다")
-    void getMyLibraryBooksUsesGivenOffset() {
-        given(bookQueryRepository.countMyLibraryBooks(10L)).willReturn(100L);
-        given(bookQueryRepository.findMyLibraryBooks(10L, 60L, 20)).willReturn(List.of());
+    @DisplayName("내 서재 조회는 opinionCountScope가 MINE이어도 그대로 리포지토리에 위임한다")
+    void getMyLibraryBooksDelegatesMineScopeToRepository() {
+        Pageable pageable = PageRequest.of(1, 20);
+        Page<BookActivityProjection> expected = new PageImpl<>(List.of(), pageable, 0);
+        given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.MINE)).willReturn(expected);
 
-        BookCarouselPage result = bookService.getMyLibraryBooks(10L, 60L, 20);
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.MINE);
 
-        assertThat(result.offset()).isEqualTo(60L);
+        assertThat(results).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -106,6 +106,23 @@ class BookQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("흔적이 없는 대목도 도서의 passageCount 집계에 포함한다")
+    void searchByTitleCountsPassagesWithoutOpinionsToo() {
+        User writer = user("wsr-cnt");
+        Book book = book("여러 대목 검색용 책");
+        Passage withOpinion = passage(book, writer, 1);
+        passage(book, writer, 2); // 흔적 없는 대목
+        opinion(withOpinion, writer);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "여러 대목", BookSearchSort.RECENT, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).hasSize(1);
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(2);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("검색어가 빈 문자열이면 흔적이 있는 전체 도서 목록을 반환한다")
     void searchByTitleReturnsAllBooksWhenKeywordIsBlank() {
         User writer = user("wsr3");

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -123,6 +123,28 @@ class BookQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("소프트 삭제된 대목은 passageCount 집계에서 제외된다")
+    void searchByTitleExcludesDeletedPassageFromCount() {
+        User writer = user("wsr-del");
+        Book book = book("삭제된 대목이 있는 책");
+        Passage withOpinion = passage(book, writer, 1);
+        opinion(withOpinion, writer);
+        // 대목은 그 대목의 마지막 흔적이 삭제될 때만 함께 삭제되므로(PM 요구사항), 흔적도 함께 삭제된 상태를 만든다.
+        Passage deleted = passage(book, writer, 2);
+        Opinion deletedOpinion = opinion(deleted, writer);
+        deletedOpinion.delete();
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "삭제된 대목", BookSearchSort.RECENT, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).hasSize(1);
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(1);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("검색어가 빈 문자열이면 흔적이 있는 전체 도서 목록을 반환한다")
     void searchByTitleReturnsAllBooksWhenKeywordIsBlank() {
         User writer = user("wsr3");

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookSearchSort;
+import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.domain.Passage;
@@ -260,7 +261,7 @@ class BookQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("내 서재는 내가 흔적을 남긴 도서만 포함하고 대목/흔적 수는 도서 전체 기준으로 집계한다")
+    @DisplayName("내 서재는 내가 흔적을 남긴 도서만 포함하고, ALL 스코프에서는 대목/흔적 수를 도서 전체 기준으로 집계한다")
     void findMyLibraryBooksOnlyIncludesBooksWithMyOpinion() {
         User me = user("me-lib");
         User other = user("other-lib");
@@ -271,16 +272,36 @@ class BookQueryRepositoryTest {
         opinion(myPassage, other);
         opinion(passage(othersBook, other, 1), other);
 
-        List<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(me.getId(), 0, 20);
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.ALL);
 
-        assertThat(results).extracting(BookActivityProjection::bookId).containsExactly(myBook.getId());
-        assertThat(results.get(0).passageCount()).isEqualTo(1);
-        assertThat(results.get(0).opinionCount()).isEqualTo(2);
-        assertThat(bookQueryRepository.countMyLibraryBooks(me.getId())).isEqualTo(1);
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId).containsExactly(myBook.getId());
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(1);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(2);
+        assertThat(results.getTotalElements()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("내 서재는 내가 가장 최근에 흔적을 남긴 도서부터 반환한다")
+    @DisplayName("내 서재는 MINE 스코프에서 흔적 수를 로그인 사용자가 남긴 것만으로 집계한다")
+    void findMyLibraryBooksCountsOnlyMyOpinionsWhenScopeIsMine() {
+        User me = user("me-mine");
+        User other = user("other-mine");
+        Book myBook = book("내가 흔적을 남긴 책 - mine scope");
+        Passage myPassage = passage(myBook, me, 1);
+        opinion(myPassage, me);
+        opinion(myPassage, other);
+        opinion(myPassage, other);
+
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.MINE);
+
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId).containsExactly(myBook.getId());
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(1);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("내 서재는 스코프와 무관하게 내가 가장 최근에 흔적을 남긴 도서부터 반환한다")
     void findMyLibraryBooksOrdersByMyMostRecentOpinion() throws InterruptedException {
         User me = user("me-lib-order");
         Book olderBook = book("먼저 흔적을 남긴 책");
@@ -289,9 +310,10 @@ class BookQueryRepositoryTest {
         Thread.sleep(10);
         opinion(passage(newerBook, me, 1), me);
 
-        List<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(me.getId(), 0, 20);
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.ALL);
 
-        assertThat(results).extracting(BookActivityProjection::bookId)
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId)
                 .containsExactly(newerBook.getId(), olderBook.getId());
     }
 

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -282,6 +282,26 @@ class BookQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("내가 흔적을 남기지 않은 같은 도서의 다른 대목/흔적도 도서 전체 집계에 포함한다")
+    void findMyLibraryBooksCountsWholeBookEvenForPassagesWithoutMyOpinion() {
+        User me = user("me-whole");
+        User other = user("other-whole");
+        Book myBook = book("여러 대목이 있는 책");
+        Passage myPassage = passage(myBook, me, 1);
+        Passage othersPassage = passage(myBook, other, 2);
+        opinion(myPassage, me);
+        opinion(othersPassage, other);
+        opinion(othersPassage, other);
+
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.ALL);
+
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId).containsExactly(myBook.getId());
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(2);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("내 서재는 MINE 스코프에서 흔적 수를 로그인 사용자가 남긴 것만으로 집계한다")
     void findMyLibraryBooksCountsOnlyMyOpinionsWhenScopeIsMine() {
         User me = user("me-mine");

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -19,6 +19,7 @@ import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.BookService;
 import com.nexters.palang.domain.book.application.ExternalBookResult;
+import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.book.presentation.dto.CreateBookRequest;
@@ -180,17 +181,31 @@ class BookControllerTest {
     }
 
     @Test
-    @DisplayName("내 서재 도서 목록을 요청하면 현재 사용자 기준으로 조회한다")
+    @DisplayName("내 서재 도서 목록을 요청하면 현재 사용자 기준, opinionCountScope 기본값 ALL로 조회한다")
     void getMyLibraryBooks() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(bookService.getMyLibraryBooks(eq(1L), isNull(), anyInt())).willReturn(
-                new BookCarouselPage(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)), 0, 20, 1));
+        given(bookService.getMyLibraryBooks(eq(1L), any(Pageable.class), eq(OpinionCountScope.ALL))).willReturn(
+                new PageImpl<>(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 7)),
+                        DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/books/my-library"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books[0].bookId").value(1))
                 .andExpect(jsonPath("$.data.books[0].passageCount").value(3))
                 .andExpect(jsonPath("$.data.books[0].opinionCount").value(7));
+    }
+
+    @Test
+    @DisplayName("내 서재 도서 목록 조회 시 opinionCountScope=MINE을 지정하면 그대로 서비스에 전달한다")
+    void getMyLibraryBooksWithMineScope() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(bookService.getMyLibraryBooks(eq(1L), any(Pageable.class), eq(OpinionCountScope.MINE))).willReturn(
+                new PageImpl<>(List.of(new BookActivityProjection(1L, "제목", "작가", "cover", 3, 2)),
+                        DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/books/my-library").param("opinionCountScope", "MINE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].opinionCount").value(2));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -127,6 +127,19 @@ class OpinionServiceTest {
     }
 
     @Test
+    @DisplayName("passageId가 삭제된 대목을 가리키면 예외가 발생한다")
+    void createOpinionThrowsExceptionWhenPassageIsDeleted() {
+        Book book = book(10L);
+        Passage deleted = passage(100L, book);
+        deleted.delete();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(passageRepository.findById(100L)).willReturn(Optional.of(deleted));
+
+        assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, 100L)))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
     @DisplayName("passageId가 요청의 bookId와 다른 도서에 속하면 예외가 발생한다")
     void createOpinionThrowsExceptionWhenPassageBelongsToDifferentBook() {
         Book otherBook = book(99L);
@@ -151,7 +164,7 @@ class OpinionServiceTest {
     @Test
     @DisplayName("존재하는 대목으로 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
     void getOpinionsReturnsQueryRepositoryResult() {
-        given(passageRepository.existsById(100L)).willReturn(true);
+        given(passageRepository.existsByIdAndDeletedAtIsNull(100L)).willReturn(true);
         Pageable pageable = PageRequest.of(0, 20);
 
         opinionService.getOpinions(100L, OpinionSortType.LATEST, pageable, 1L);
@@ -162,7 +175,7 @@ class OpinionServiceTest {
     @Test
     @DisplayName("존재하지 않는 대목으로 흔적 목록을 조회하면 예외가 발생한다")
     void getOpinionsThrowsExceptionWhenPassageDoesNotExist() {
-        given(passageRepository.existsById(100L)).willReturn(false);
+        given(passageRepository.existsByIdAndDeletedAtIsNull(100L)).willReturn(false);
 
         assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20), 1L))
                 .isInstanceOf(PassageException.class);
@@ -216,10 +229,35 @@ class OpinionServiceTest {
     void removeOpinionDeletesWhenOwner() {
         Opinion opinion = opinionOwnedBy(1L, 10L);
         given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(true);
 
         opinionService.removeOpinion(1L, 10L);
 
         assertThat(opinion.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("삭제 후에도 대목에 다른 살아있는 흔적이 남아있으면 대목은 삭제되지 않는다")
+    void removeOpinionKeepsPassageWhenOtherOpinionRemains() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(true);
+
+        opinionService.removeOpinion(1L, 10L);
+
+        assertThat(opinion.getPassage().isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("삭제 후 대목에 살아있는 흔적이 하나도 남지 않으면 대목도 함께 삭제된다 (PM 요구사항)")
+    void removeOpinionDeletesPassageWhenNoOpinionsRemain() {
+        Opinion opinion = opinionOwnedBy(1L, 10L);
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(false);
+
+        opinionService.removeOpinion(1L, 10L);
+
+        assertThat(opinion.getPassage().isDeleted()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -119,6 +119,20 @@ class PassageQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("소프트 삭제된 대목은 유사 후보에서 제외된다")
+    void findSimilarCandidatesExcludesDeletedPassage() {
+        User writer = user("writer-4");
+        Book book = book("책");
+        Passage deleted = passage(book, writer, 5, "발췌 문장", "hash-1");
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
     @DisplayName("서로 다른 페이지 번호만 오름차순으로 조회한다 (스포일러 페이지도 포함)")
     void findPageNumbersReturnsDistinctPagesInAscendingOrderIncludingSpoilers() {
         User writer = user("writer-5");
@@ -131,6 +145,22 @@ class PassageQueryRepositoryTest {
         Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), PageRequest.of(0, 10));
 
         assertThat(result.getContent()).containsExactly(1, 2, 5);
+    }
+
+    @Test
+    @DisplayName("소프트 삭제된 대목의 페이지 번호는 제외된다")
+    void findPageNumbersExcludesDeletedPassage() {
+        User writer = user("writer-7");
+        Book book = book("책");
+        passage(book, writer, 1, false);
+        Passage deleted = passage(book, writer, 9, false);
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).containsExactly(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
     }
 
     @Test
@@ -156,5 +186,20 @@ class PassageQueryRepositoryTest {
 
         assertThat(result).extracting(Passage::getId)
                 .containsExactly(first.getId(), second.getId(), spoiler.getId());
+    }
+
+    @Test
+    @DisplayName("소프트 삭제된 대목은 페이지 전환 조회에서 제외된다")
+    void findPassagesByPageExcludesDeletedPassage() {
+        User writer = user("writer-8");
+        Book book = book("책");
+        Passage alive = passage(book, writer, 3, false);
+        Passage deleted = passage(book, writer, 3, false);
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), 3);
+
+        assertThat(result).extracting(Passage::getId).containsExactly(alive.getId());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #107

## 🚀 개요
마이페이지에서 노출할 "내 서재" 목록은 도서 전체 의견 수가 아닌 내가 남긴 의견 수를 보여줘야 하는 요구사항이 추가됨에 따라, 별도 엔드포인트를 새로 만드는 대신 기존 `GET /api/books/my-library`에 `opinionCountScope` 파라미터를 추가해 홈/마이페이지 두 화면을 하나의 API로 처리한다. 또한 offset/size 캐러셀 방식이던 페이지네이션을 다른 목록 API와 동일한 page/size 표준 방식으로 변경한다.

리뷰 과정에서 조인 구조상 도서 전체 대목/흔적 집계가 실제로는 일부만 반영되던 버그 2건을 발견해 함께 수정했고, 그 버그를 조사하는 과정에서 확인된 PM 요구사항("대목에 남은 흔적이 0개가 되면 안 된다")도 이번 PR 범위에서 함께 구현했다.

## 📄 작업 내용
| Method | Path | 변경 내용 |
|---|---|---|
| GET | `/api/books/my-library` | (수정) `offset`/`size` → `page`/`size` 표준 페이지네이션, `opinionCountScope`(ALL 기본값/MINE) 파라미터 추가, 응답을 `BookCarouselListResponse`(offset 기반)에서 `BookActivityListResponse`(`PageInfo` 기반)로 변경 |

**1. 내 서재 API 변경**
- `OpinionCountScope` enum(`ALL`/`MINE`) 추가
- `BookQueryRepository.findMyLibraryBooks`를 `Pageable` + `opinionCountScope` 기반으로 재작성
- `opinionCountScope=MINE`이면 로그인 사용자 본인이 남긴 의견 수만, `ALL`이면 도서 전체 의견 수를 집계 (정렬은 스코프와 무관하게 "가장 최근에 내가 남긴 의견순" 유지)

**2. 집계 조인 버그 수정** (`my-library`, `internal-search` 두 곳)
- `opinionMine`(필터용 조인)이 특정 `passage` 행에 걸려 있어, 그 제약이 `passageCount`/전체 `opinionCount` 집계까지 새어 들어가 "내가(또는 아무도) 의견을 안 남긴 다른 대목"이 누락되던 문제 수정
- `opinion`을 특정 `passage` 행이 아니라 `passage.book`으로 book에 직접 연결해 도서 전체 기준 집계가 되도록 분리

**3. 대목-흔적 정합성 정책 구현 (PM 요구사항)**
- `Passage`에 `deletedAt` 추가, 대목에 남은 살아있는 흔적이 0개가 되는 순간(=마지막 흔적 삭제 시) 대목도 함께 소프트 삭제 (`OpinionService.removeOpinion`)
- 삭제된 대목이 새 흔적 병합 대상으로 선택되지 않도록 `mergeIntoExistingPassage`/`getOpinions`에도 방어 로직 추가
- 대목을 조회하는 모든 쿼리(도서 검색/캐러셀/내서재/인기도서, 유사 대목 후보, 페이지 번호/전환 조회)에 `deletedAt IS NULL` 필터 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 전체 통과 확인 (신규 회귀 테스트 다수 포함: 조인 버그 재현/수정 검증, cascade 삭제 검증, 삭제된 대목 제외 검증)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- **⚠️ 운영 DB 마이그레이션 필요**: `passages` 테이블에 `deleted_at` 컬럼을 추가했다. dev는 `ddl-auto: update`라 자동 반영되지만, prod는 `ddl-auto: validate`라 배포 전 수동으로 `ALTER TABLE passages ADD COLUMN deleted_at DATETIME NULL;`을 실행해야 앱이 기동한다. 배포 순서 조율이 필요하다.
- 신규 엔드포인트를 분리하지 않고 기존 `my-library`에 `opinionCountScope` 쿼리 파라미터를 얹는 방식으로 처리했습니다. 홈/마이페이지 두 화면의 정렬·필터링 로직이 완전히 동일하고 집계 필드만 다르다는 전제하에 내린 결정인데, 이 설계 방향에 이견 없으신지 확인 부탁드립니다.
- 기존 `my-library` 응답을 쓰던 클라이언트가 있다면 offset 기반 `CarouselPageInfo` → page 기반 `PageInfo`로 바뀌는 breaking change이니, 프론트 반영 타이밍 확인이 필요합니다.
- 대목-흔적 cascade 삭제는 하드 삭제가 아닌 소프트 삭제로 구현했습니다 (이유: `Opinion.passage_id`가 `NOT NULL` FK이고 흔적은 소프트 삭제로 남기 때문에, 대목을 하드 삭제하면 참조 무결성이 깨집니다). 이 판단에 이견 없으신지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 내 서재 조회가 오프셋 방식에서 페이지 기반 조회로 변경되었습니다.
  - 페이지 번호와 크기로 도서 활동 목록을 탐색할 수 있습니다.
  - 의견 수를 전체 의견 또는 내 의견 기준으로 선택할 수 있습니다.

- **개선 사항**
  - 최근 활동 순으로 도서가 정렬됩니다.
  - 삭제된 대목과 관련 의견이 조회 결과에서 제외됩니다.
  - 활성 의견이 없으면 해당 대목도 삭제 처리됩니다.
  - 도서별 의견 수가 선택한 기준에 따라 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->