### PR TITLE
Feat/#100 책 제목 검색 자동완성 - 내부 DB/알라딘 병렬 처리 및 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	// Database & Cache
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.boot:spring-boot-h2console'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -5,6 +5,7 @@ import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
+import com.nexters.palang.domain.book.infrastructure.AladinSearchResult;
 import com.nexters.palang.domain.book.infrastructure.BookQueryRepository;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.book.presentation.dto.CreateBookRequest;
@@ -29,6 +30,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class BookService {
 
     private static final String COVER_IMAGE_SUB_DIRECTORY = "book-covers";
+    // 1글자 검색은 자동완성 노이즈만 크고 알라딘 쿼터만 소모하므로, 호출 자체를 하지 않는다.
+    private static final int EXTERNAL_SEARCH_MIN_KEYWORD_LENGTH = 2;
 
     private final BookRepository bookRepository;
     private final BookQueryRepository bookQueryRepository;
@@ -38,7 +41,12 @@ public class BookService {
     // DB를 사용하지 않고 알라딘 API 호출(최대 수 초)만 하므로, DB 커넥션을 불필요하게 오래 붙잡지 않도록 트랜잭션에서 제외한다.
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public Page<ExternalBookResult> searchExternalBooks(String keyword, Pageable pageable) {
-        return aladinBookApiClient.search(keyword, pageable);
+        String trimmedKeyword = keyword == null ? "" : keyword.trim();
+        if (trimmedKeyword.length() < EXTERNAL_SEARCH_MIN_KEYWORD_LENGTH) {
+            return Page.empty(pageable);
+        }
+        AladinSearchResult result = aladinBookApiClient.search(trimmedKeyword, pageable);
+        return new PageImpl<>(result.items(), pageable, result.totalResults());
     }
 
     public Page<BookSearchProjection> searchInternalBooks(String keyword, BookSearchSort sort, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/domain/Book.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/Book.java
@@ -6,6 +6,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +20,7 @@ import org.hibernate.annotations.Check;
 
 @Getter
 @Entity
-@Table(name = "books")
+@Table(name = "books", indexes = @Index(name = "idx_books_title_normalized", columnList = "title_normalized"))
 @Check(constraints = "page_count > 0")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Book extends BaseEntity {
@@ -29,6 +32,13 @@ public class Book extends BaseEntity {
 
     @Column(name = "title", nullable = false)
     private String title;
+
+    // 검색/자동완성 접두어 매칭용으로 title에서 공백 제거 + 소문자 변환해 미리 저장해둔 컬럼.
+    // 매번 title에 replace()/lower() 함수를 걸어 비교하는 대신 이 컬럼(인덱스 적용)을 비교한다.
+    // ddl-auto: update로 기존 테이블에 추가되므로 nullable로 두고, @PrePersist/@PreUpdate에서
+    // 항상 채운다. 이미 저장된 기존 row는 이 배포 시점에 별도 백필(backfill)이 필요하다.
+    @Column(name = "title_normalized")
+    private String titleNormalized;
 
     @Column(name = "author", nullable = false)
     private String author;
@@ -66,5 +76,15 @@ public class Book extends BaseEntity {
         this.isbn = isbn;
         this.coverImageUrl = coverImageUrl;
         this.source = source != null ? source : BookSource.API;
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void normalizeTitle() {
+        this.titleNormalized = normalize(title);
+    }
+
+    public static String normalize(String value) {
+        return value == null ? "" : value.replace(" ", "").toLowerCase();
     }
 }

--- a/src/main/java/com/nexters/palang/domain/book/domain/Book.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/Book.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import java.util.Locale;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +37,8 @@ public class Book extends BaseEntity {
     // 검색/자동완성 접두어 매칭용으로 title에서 공백 제거 + 소문자 변환해 미리 저장해둔 컬럼.
     // 매번 title에 replace()/lower() 함수를 걸어 비교하는 대신 이 컬럼(인덱스 적용)을 비교한다.
     // ddl-auto: update로 기존 테이블에 추가되므로 nullable로 두고, @PrePersist/@PreUpdate에서
-    // 항상 채운다. 이미 저장된 기존 row는 이 배포 시점에 별도 백필(backfill)이 필요하다.
+    // 항상 채운다. 이미 저장된 기존 row는 이 컬럼을 갱신할 계기(@PreUpdate)가 없어 NULL로 남는데,
+    // BookTitleNormalizationBackfillRunner가 앱 시작 시 자동으로 채워준다.
     @Column(name = "title_normalized")
     private String titleNormalized;
 
@@ -84,7 +86,18 @@ public class Book extends BaseEntity {
         this.titleNormalized = normalize(title);
     }
 
+    // title_normalized 컬럼이 추가되기 전부터 존재하던 도서는 title이 바뀔 계기가 없어 이 컬럼이
+    // 채워지지 않는다. BookTitleNormalizationBackfillRunner가 앱 시작 시 1회성으로 호출한다.
+    public void backfillTitleNormalizedIfMissing() {
+        if (this.titleNormalized == null) {
+            this.titleNormalized = normalize(title);
+        }
+    }
+
+    // toLowerCase()를 로케일 없이 쓰면 JVM 기본 로케일(터키어 등)에 따라 결과가 달라질 수 있어
+    // (예: "I".toLowerCase() != "i") Locale.ROOT로 고정한다. 저장 시점과 검색 시점의 결과가
+    // 항상 같아야 하므로 로케일 의존성을 없애는 게 중요하다.
     public static String normalize(String value) {
-        return value == null ? "" : value.replace(" ", "").toLowerCase();
+        return value == null ? "" : value.replace(" ", "").toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClient.java
@@ -7,8 +7,7 @@ import com.nexters.palang.domain.book.infrastructure.dto.AladinItem;
 import com.nexters.palang.domain.book.infrastructure.dto.AladinItemSearchResponse;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -28,7 +27,15 @@ public class AladinBookApiClient {
 
     // 결과마다 ItemLookUp을 추가 호출해 페이지수를 채우던 방식은 검색 1회당 응답이 수 초씩 걸려 제거했다.
     // pageCount는 검색 응답에서 아예 제공하지 않으며, 필요하면 도서 상세 조회 시점에 별도로 채우는 것을 후속 과제로 검토한다.
-    public Page<ExternalBookResult> search(String keyword, Pageable pageable) {
+    //
+    // 자동완성이 타이핑마다 이 메서드를 호출하므로 @Cacheable로 캐싱한다 (키: keyword+page+size, TTL은
+    // CacheConfig 참고). 실패(예외)는 Spring 캐시 추상화가 애초에 캐싱하지 않고, 빈 결과는 unless로
+    // 캐싱에서 제외해 다음 호출에서 다시 시도하게 한다.
+    // 이 메서드는 반드시 다른 빈(BookService)이 호출해야 한다 — 같은 클래스 안에서 self-invocation하면
+    // Spring AOP 프록시를 거치지 않아 캐싱이 동작하지 않는다.
+    @Cacheable(value = "aladinBookSearch", key = "#keyword + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
+            unless = "#result.items().isEmpty()")
+    public AladinSearchResult search(String keyword, Pageable pageable) {
         // 알라딘 start는 1부터 시작하는 인덱스
         int start = (int) pageable.getOffset() + 1;
         int maxResults = pageable.getPageSize();
@@ -56,12 +63,12 @@ public class AladinBookApiClient {
         }
 
         if (response == null || response.item() == null || response.item().isEmpty()) {
-            return new PageImpl<>(List.of(), pageable, 0);
+            return AladinSearchResult.empty();
         }
 
         List<ExternalBookResult> content = response.item().stream().map(this::toExternalBookResult).toList();
         long totalResults = response.totalResults() != null ? response.totalResults() : content.size();
-        return new PageImpl<>(content, pageable, totalResults);
+        return new AladinSearchResult(content, totalResults);
     }
 
     private ExternalBookResult toExternalBookResult(AladinItem item) {

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinSearchResult.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/AladinSearchResult.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import com.nexters.palang.domain.book.application.ExternalBookResult;
+import java.util.List;
+
+// AladinBookApiClient#search()의 캐싱 대상 반환 타입. Page/Pageable은 인터페이스라 Redis에
+// JSON으로 캐싱했다가 역직렬화하기 까다로워서, 캐싱 가능한 단순 record로 결과(목록 + 총 개수)만 담는다.
+public record AladinSearchResult(List<ExternalBookResult> items, long totalResults) {
+
+    public static AladinSearchResult empty() {
+        return new AladinSearchResult(List.of(), 0);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -3,13 +3,13 @@ package com.nexters.palang.domain.book.infrastructure;
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookSearchSort;
+import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +24,16 @@ public class BookQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    // 띄어쓰기 차이를 무시하고 검색할 수 있도록 제목/키워드 모두에서 공백을 제거한 뒤 비교한다.
+    // 띄어쓰기 차이를 무시하고 검색할 수 있도록, 저장 시점에 미리 정규화(공백 제거 + 소문자)해둔
+    // title_normalized 컬럼(인덱스 적용, Book#normalizeTitle 참고)을 기준으로 비교한다. 매 검색마다
+    // title에 함수를 걸어 계산하지 않아도 되고, 자동완성처럼 반복 호출되는 경로에서 유리하다.
     // 흔적(Opinion)이 하나도 없는 도서는 결과에서 제외하므로 leftJoin이 아닌 innerJoin을 사용한다.
     public Page<BookSearchProjection> searchByTitle(String keyword, BookSearchSort sort, Pageable pageable) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinion = QOpinion.opinion;
 
-        String normalizedKeyword = keyword.replace(" ", "");
-        StringExpression normalizedTitle = Expressions.stringTemplate("replace({0}, ' ', '')", book.title);
+        String normalizedKeyword = Book.normalize(keyword);
 
         List<BookSearchProjection> content = queryFactory
                 .select(Projections.constructor(BookSearchProjection.class,
@@ -42,10 +43,10 @@ public class BookQueryRepository {
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
                 .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
-                .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
+                .where(book.titleNormalized.contains(normalizedKeyword))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.pageCount,
                         book.isbn, book.coverImageUrl, book.source)
-                .orderBy(searchOrderSpecifiers(sort, book, opinion))
+                .orderBy(searchOrderSpecifiers(sort, book, opinion, normalizedKeyword))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -55,18 +56,31 @@ public class BookQueryRepository {
                 .from(book)
                 .innerJoin(passage).on(passage.book.eq(book))
                 .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
-                .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
+                .where(book.titleNormalized.contains(normalizedKeyword))
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
-    private OrderSpecifier<?>[] searchOrderSpecifiers(BookSearchSort sort, QBook book, QOpinion opinion) {
-        return switch (sort) {
+    // 자동완성으로 쓰일 때 관련도가 높은 결과(제목이 검색어로 시작하는 도서)가 먼저 보이도록,
+    // 선택된 정렬 기준보다 접두어 일치 여부를 우선한다.
+    private OrderSpecifier<?>[] searchOrderSpecifiers(
+            BookSearchSort sort, QBook book, QOpinion opinion, String normalizedKeyword) {
+        OrderSpecifier<Integer> prefixMatchFirst = new CaseBuilder()
+                .when(book.titleNormalized.startsWith(normalizedKeyword)).then(0)
+                .otherwise(1)
+                .asc();
+
+        OrderSpecifier<?>[] tieBreakers = switch (sort) {
             case NAME -> new OrderSpecifier[]{book.title.asc(), book.id.asc()};
             case RECENT -> new OrderSpecifier[]{opinion.createdAt.max().desc(), book.id.asc()};
             case OPINION -> new OrderSpecifier[]{opinion.countDistinct().desc(), book.id.asc()};
         };
+
+        OrderSpecifier<?>[] result = new OrderSpecifier<?>[tieBreakers.length + 1];
+        result[0] = prefixMatchFirst;
+        System.arraycopy(tieBreakers, 0, result, 1, tieBreakers.length);
+        return result;
     }
 
     // 홈 캐러셀은 전체 목록 중 임의의 가운데 offset에서 좌우로 조회해야 해서, page*size로 offset이

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
@@ -2,10 +2,14 @@ package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    // title_normalized 백필 대상(BookTitleNormalizationBackfillRunner) 조회용.
-    List<Book> findByTitleNormalizedIsNull();
+    // title_normalized 백필 대상(BookTitleNormalizationBackfillRunner) 조회용. 기존 도서가 많을 때
+    // 한 번에 전부 불러오지 않도록, id 기준 키셋 페이지네이션으로 한 배치씩만 조회한다. offset
+    // 페이지네이션을 쓰면 이전 배치가 채워지며 IS NULL 조건에서 빠져나가 다음 행을 건너뛸 수 있어
+    // id > :id 조건으로 이어서 조회해야 한다(pageable은 정렬/LIMIT 용도로만 사용, offset은 항상 0).
+    List<Book> findByTitleNormalizedIsNullAndIdGreaterThanOrderByIdAsc(Long id, Pageable pageable);
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
@@ -1,7 +1,11 @@
 package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    // title_normalized 백필 대상(BookTitleNormalizationBackfillRunner) 조회용.
+    List<Book> findByTitleNormalizedIsNull();
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunner.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunner.java
@@ -1,0 +1,35 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import com.nexters.palang.domain.book.domain.Book;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// title_normalized 컬럼은 @PrePersist/@PreUpdate(Book#normalizeTitle)로 채워지는데, 이 컬럼이
+// 추가되기 전부터 있던 도서는 title이 바뀔 계기가 없어 영원히 NULL로 남는다. BookQueryRepository의
+// 내부 검색이 이 컬럼만 보게 되어 있어서, 백필하지 않으면 기존 도서가 검색 결과에서 사라진다.
+// 이 프로젝트에 Flyway 등 마이그레이션 도구가 없어 배포 시 수동 SQL 실행에 기대는 대신, 앱 시작
+// 시 한 번 NULL인 도서를 찾아 자동으로 채운다. 채울 대상이 없으면 그냥 아무 일도 하지 않으므로
+// 재배포/재기동해도 안전하다(멱등적).
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookTitleNormalizationBackfillRunner implements ApplicationRunner {
+
+    private final BookRepository bookRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        List<Book> booksToBackfill = bookRepository.findByTitleNormalizedIsNull();
+        if (booksToBackfill.isEmpty()) {
+            return;
+        }
+        booksToBackfill.forEach(Book::backfillTitleNormalizedIfMissing);
+        log.info("title_normalized 백필 완료: {}건", booksToBackfill.size());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunner.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunner.java
@@ -2,12 +2,15 @@ package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 // title_normalized 컬럼은 @PrePersist/@PreUpdate(Book#normalizeTitle)로 채워지는데, 이 컬럼이
 // 추가되기 전부터 있던 도서는 title이 바뀔 계기가 없어 영원히 NULL로 남는다. BookQueryRepository의
@@ -15,21 +18,58 @@ import org.springframework.transaction.annotation.Transactional;
 // 이 프로젝트에 Flyway 등 마이그레이션 도구가 없어 배포 시 수동 SQL 실행에 기대는 대신, 앱 시작
 // 시 한 번 NULL인 도서를 찾아 자동으로 채운다. 채울 대상이 없으면 그냥 아무 일도 하지 않으므로
 // 재배포/재기동해도 안전하다(멱등적).
+//
+// 기존 도서 수가 많을 수 있으므로 전체를 한 번에 메모리에 올리거나 하나의 긴 트랜잭션으로 묶지
+// 않고, id 기준 키셋 페이지네이션으로 나눠 배치마다 별도 트랜잭션에서 처리한다.
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class BookTitleNormalizationBackfillRunner implements ApplicationRunner {
 
+    private static final int DEFAULT_BATCH_SIZE = 500;
+
     private final BookRepository bookRepository;
+    private final TransactionTemplate transactionTemplate;
+    private final int batchSize;
+
+    @Autowired
+    public BookTitleNormalizationBackfillRunner(
+            BookRepository bookRepository, PlatformTransactionManager transactionManager) {
+        this(bookRepository, transactionManager, DEFAULT_BATCH_SIZE);
+    }
+
+    // 배치 하나로는 끝나지 않는(여러 번 반복되는) 경우까지 검증할 수 있도록 배치 크기를 테스트에서
+    // 주입할 수 있게 열어둔 생성자. 프로덕션에서는 위 생성자를 통해 DEFAULT_BATCH_SIZE로 동작한다.
+    BookTitleNormalizationBackfillRunner(
+            BookRepository bookRepository, PlatformTransactionManager transactionManager, int batchSize) {
+        this.bookRepository = bookRepository;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.batchSize = batchSize;
+    }
 
     @Override
-    @Transactional
     public void run(ApplicationArguments args) {
-        List<Book> booksToBackfill = bookRepository.findByTitleNormalizedIsNull();
-        if (booksToBackfill.isEmpty()) {
-            return;
+        Pageable pageable = PageRequest.of(0, batchSize);
+        long lastId = 0L;
+        int totalBackfilled = 0;
+
+        while (true) {
+            long afterId = lastId;
+            List<Long> backfilledIds = transactionTemplate.execute(status -> {
+                List<Book> batch = bookRepository
+                        .findByTitleNormalizedIsNullAndIdGreaterThanOrderByIdAsc(afterId, pageable);
+                batch.forEach(Book::backfillTitleNormalizedIfMissing);
+                return batch.stream().map(Book::getId).toList();
+            });
+
+            if (backfilledIds == null || backfilledIds.isEmpty()) {
+                break;
+            }
+            lastId = backfilledIds.get(backfilledIds.size() - 1);
+            totalBackfilled += backfilledIds.size();
         }
-        booksToBackfill.forEach(Book::backfillTitleNormalizedIfMissing);
-        log.info("title_normalized 백필 완료: {}건", booksToBackfill.size());
+
+        if (totalBackfilled > 0) {
+            log.info("title_normalized 백필 완료: {}건", totalBackfilled);
+        }
     }
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -28,7 +28,9 @@ public interface BookApi {
 
     @Operation(summary = "도서 외부 검색",
             description = "알라딘 Open API로 도서를 검색합니다. 응답 속도를 위해 pageCount는 내려주지 않으며, "
-                    + "등록 시 사용자가 직접 입력합니다.")
+                    + "등록 시 사용자가 직접 입력합니다. 타이핑 중 자동완성 미리보기 용도로도 재사용되므로, "
+                    + "keyword가 공백 제거 후 2글자 미만이면 알라딘을 호출하지 않고 빈 목록을 반환합니다. "
+                    + "동일 keyword+size 조합은 최대 12시간 캐싱되어 결과가 즉시 반영되지 않을 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),
             @ApiResponse(responseCode = "400", description = "keyword 누락, page/size 형식 오류(COMMON_400_1) "

--- a/src/main/java/com/nexters/palang/global/config/CacheConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/CacheConfig.java
@@ -9,6 +9,8 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
 
 @Configuration
 @EnableCaching
@@ -21,15 +23,21 @@ public class CacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // 캐시 값 타입(AladinSearchResult 등)을 역직렬화 시점에 정확히 복원하려면 타입 정보가
+        // JSON에 함께 저장돼야 한다. enableUnsafeDefaultTyping()은 클래스패스의 임의 타입을
+        // 전부 역직렬화 대상으로 허용해 다형적 역직렬화 공격에 노출될 수 있으므로, 우리 패키지
+        // 타입과 그 안에서 쓰는 JDK 컬렉션(List.of() 등의 내부 구현체 포함)만 허용하도록 제한한다.
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.nexters.palang")
+                .allowIfSubType("java.util.")
+                .build();
+
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(ALADIN_BOOK_SEARCH_TTL)
                 .disableCachingNullValues()
-                // 캐시 값 타입(AladinSearchResult 등)을 역직렬화 시점에 정확히 복원하려면 타입 정보가
-                // JSON에 함께 저장돼야 한다. 우리가 신뢰하는 내부 타입만 캐싱하므로 unsafe default
-                // typing을 사용한다(사용자 입력을 그대로 역직렬화하는 경로가 아니라 안전하다).
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(GenericJacksonJsonRedisSerializer.builder()
-                                .enableUnsafeDefaultTyping()
+                                .enableDefaultTyping(typeValidator)
                                 .build()));
 
         return RedisCacheManager.builder(connectionFactory)

--- a/src/main/java/com/nexters/palang/global/config/CacheConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package com.nexters.palang.global.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    // 알라딘 도서 검색(자동완성 포함) 캐시. 배치로 미리 채워두지 않고, 실제로 검색된 키워드만
+    // 반응형으로 캐싱한다. TTL을 길게 잡아 같은 키워드가 여러 사용자에게서 겹칠 때 알라딘 호출을
+    // 흡수하되, 너무 길면 신간이 자동완성에 늦게 반영되므로 12시간으로 제한한다.
+    private static final Duration ALADIN_BOOK_SEARCH_TTL = Duration.ofHours(12);
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(ALADIN_BOOK_SEARCH_TTL)
+                .disableCachingNullValues()
+                // 캐시 값 타입(AladinSearchResult 등)을 역직렬화 시점에 정확히 복원하려면 타입 정보가
+                // JSON에 함께 저장돼야 한다. 우리가 신뢰하는 내부 타입만 캐싱하므로 unsafe default
+                // typing을 사용한다(사용자 입력을 그대로 역직렬화하는 경로가 아니라 안전하다).
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(GenericJacksonJsonRedisSerializer.builder()
+                                .enableUnsafeDefaultTyping()
+                                .build()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/WebClientConfig.java
@@ -16,28 +16,31 @@ public class WebClientConfig {
 
     private static final int CONNECT_TIMEOUT_MILLIS = 3_000;
     private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(10);
+    // 도서 검색은 타이핑 중 자동완성으로도 호출되므로, 알라딘이 느릴 때 오래 기다리지 않도록
+    // 응답 타임아웃을 짧게 둔다 (다른 외부 연동은 기존 10초 유지).
+    private static final Duration ALADIN_RESPONSE_TIMEOUT = Duration.ofSeconds(3);
 
     @Bean
     public WebClient aladinWebClient(WebClient.Builder builder, @Value("${aladin.base-url}") String baseUrl) {
-        return webClient(builder, baseUrl);
+        return webClient(builder, baseUrl, ALADIN_RESPONSE_TIMEOUT);
     }
 
     @Bean
     public WebClient kakaoWebClient(WebClient.Builder builder, @Value("${kakao.base-url}") String baseUrl) {
-        return webClient(builder, baseUrl);
+        return webClient(builder, baseUrl, RESPONSE_TIMEOUT);
     }
 
     @Bean
     public WebClient appleWebClient(WebClient.Builder builder, @Value("${apple.base-url}") String baseUrl) {
-        return webClient(builder, baseUrl);
+        return webClient(builder, baseUrl, RESPONSE_TIMEOUT);
     }
 
-    private WebClient webClient(WebClient.Builder builder, String baseUrl) {
+    private WebClient webClient(WebClient.Builder builder, String baseUrl, Duration responseTimeout) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MILLIS)
-                .responseTimeout(RESPONSE_TIMEOUT)
+                .responseTimeout(responseTimeout)
                 .doOnConnected(conn -> conn.addHandlerLast(
-                        new ReadTimeoutHandler(RESPONSE_TIMEOUT.getSeconds(), TimeUnit.SECONDS)));
+                        new ReadTimeoutHandler(responseTimeout.getSeconds(), TimeUnit.SECONDS)));
 
         return builder.baseUrl(baseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
+import com.nexters.palang.domain.book.infrastructure.AladinSearchResult;
 import com.nexters.palang.domain.book.infrastructure.BookQueryRepository;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.book.common.error.BookException;
@@ -65,13 +67,35 @@ class BookServiceTest {
     @DisplayName("키워드로 외부 검색을 하면 알라딘 API 클라이언트의 결과를 그대로 반환한다")
     void searchExternalBooks() {
         Pageable pageable = PageRequest.of(0, 20);
-        Page<ExternalBookResult> expected = new PageImpl<>(
-                List.of(new ExternalBookResult("제목", "작가", "출판사", "isbn", "cover")), pageable, 1);
-        given(aladinBookApiClient.search("제목", pageable)).willReturn(expected);
+        ExternalBookResult book = new ExternalBookResult("제목", "작가", "출판사", "isbn", "cover");
+        given(aladinBookApiClient.search("제목", pageable)).willReturn(new AladinSearchResult(List.of(book), 1));
 
         Page<ExternalBookResult> results = bookService.searchExternalBooks("제목", pageable);
 
-        assertThat(results).isEqualTo(expected);
+        assertThat(results.getContent()).containsExactly(book);
+        assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("검색어 앞뒤 공백은 제거하고 알라딘을 호출한다")
+    void searchExternalBooksTrimsKeyword() {
+        Pageable pageable = PageRequest.of(0, 20);
+        given(aladinBookApiClient.search("제목", pageable)).willReturn(AladinSearchResult.empty());
+
+        bookService.searchExternalBooks("  제목  ", pageable);
+
+        verify(aladinBookApiClient).search("제목", pageable);
+    }
+
+    @Test
+    @DisplayName("검색어가 2글자 미만이면 알라딘을 호출하지 않고 빈 결과를 반환한다")
+    void searchExternalBooksReturnsEmptyWhenKeywordTooShort() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<ExternalBookResult> results = bookService.searchExternalBooks("책", pageable);
+
+        assertThat(results.getContent()).isEmpty();
+        verifyNoInteractions(aladinBookApiClient);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientCacheTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientCacheTest.java
@@ -1,0 +1,127 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.book.common.error.BookException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+// AladinBookApiClient#search()에 걸린 @Cacheable이 실제로 동작하는지 검증한다. @Cacheable은
+// Spring AOP 프록시를 거쳐야 동작해서(클래스 안에서 self-invocation하면 적용되지 않음) Mockito로
+// AladinBookApiClient를 직접 new하는 방식(AladinBookApiClientTest)으로는 검증할 수 없고, 스프링
+// 컨텍스트 + 실제 Redis(로컬 docker-compose 또는 CI redis 서비스)가 필요하다.
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+class AladinBookApiClientCacheTest {
+
+    private static final String CACHE_NAME = "aladinBookSearch";
+
+    @Autowired
+    private AladinBookApiClient aladinBookApiClient;
+
+    @Autowired
+    private ExchangeFunction exchangeFunction;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        reset(exchangeFunction);
+        cacheManager.getCache(CACHE_NAME).clear();
+    }
+
+    private static ClientResponse jsonResponse(String json) {
+        return ClientResponse.create(HttpStatus.OK)
+                .header("Content-Type", "application/json")
+                .body(json)
+                .build();
+    }
+
+    // 실제 알라딘 서버 대신 mock ExchangeFunction으로 응답하는 aladinWebClient로 교체한다.
+    // 원래 빈과 이름이 같아야 교체되므로, 이 테스트 컨텍스트에 한해 bean overriding을 허용한다.
+    @TestConfiguration
+    static class StubWebClientConfig {
+
+        @Bean
+        public ExchangeFunction exchangeFunction() {
+            return mock(ExchangeFunction.class);
+        }
+
+        @Bean
+        public WebClient aladinWebClient(ExchangeFunction exchangeFunction) {
+            return WebClient.builder()
+                    .baseUrl("http://www.aladin.co.kr/ttb/api")
+                    .exchangeFunction(exchangeFunction)
+                    .build();
+        }
+    }
+
+    @Test
+    @DisplayName("같은 키워드로 다시 검색하면 캐시에서 응답하고 알라딘을 다시 호출하지 않는다")
+    void searchUsesCacheOnSecondCall() {
+        given(exchangeFunction.exchange(any())).willReturn(Mono.just(jsonResponse("""
+                {
+                  "totalResults": 1,
+                  "item": [
+                    { "title": "채식주의자", "author": "한강", "publisher": "창비",
+                      "isbn13": "9788936433598", "cover": "cover.jpg" }
+                  ]
+                }
+                """)));
+        Pageable pageable = PageRequest.of(0, 8);
+
+        AladinSearchResult first = aladinBookApiClient.search("채식주의자캐시테스트", pageable);
+        AladinSearchResult second = aladinBookApiClient.search("채식주의자캐시테스트", pageable);
+
+        assertThat(second).isEqualTo(first);
+        verify(exchangeFunction, times(1)).exchange(any());
+    }
+
+    @Test
+    @DisplayName("검색 실패는 캐싱되지 않아 다음 호출에서 알라딘을 다시 호출한다")
+    void searchDoesNotCacheFailure() {
+        given(exchangeFunction.exchange(any()))
+                .willReturn(Mono.just(ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).body("error").build()))
+                .willReturn(Mono.just(jsonResponse("{}")));
+        Pageable pageable = PageRequest.of(0, 8);
+
+        assertThatThrownBy(() -> aladinBookApiClient.search("실패캐시테스트", pageable))
+                .isInstanceOf(BookException.class);
+        AladinSearchResult second = aladinBookApiClient.search("실패캐시테스트", pageable);
+
+        assertThat(second.items()).isEmpty();
+        verify(exchangeFunction, times(2)).exchange(any());
+    }
+
+    @Test
+    @DisplayName("빈 결과는 캐싱되지 않아 다음 호출에서 알라딘을 다시 호출한다")
+    void searchDoesNotCacheEmptyResult() {
+        given(exchangeFunction.exchange(any())).willReturn(Mono.just(jsonResponse("{}")));
+        Pageable pageable = PageRequest.of(0, 8);
+
+        aladinBookApiClient.search("빈결과캐시테스트", pageable);
+        aladinBookApiClient.search("빈결과캐시테스트", pageable);
+
+        verify(exchangeFunction, times(2)).exchange(any());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientCacheTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientCacheTest.java
@@ -50,6 +50,18 @@ class AladinBookApiClientCacheTest {
         cacheManager.getCache(CACHE_NAME).clear();
     }
 
+    // Redis write가 반영되는 짧은 지연을 흡수하기 위한 폴링. 최대 200ms(20ms x 10회)까지만
+    // 기다리고, 그래도 안 보이면 진짜 버그로 간주해 실패시킨다.
+    private void awaitCacheEntry(String cacheKey) throws InterruptedException {
+        for (int attempt = 0; attempt < 10; attempt++) {
+            if (cacheManager.getCache(CACHE_NAME).get(cacheKey) != null) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        assertThat(cacheManager.getCache(CACHE_NAME).get(cacheKey)).isNotNull();
+    }
+
     private static ClientResponse jsonResponse(String json) {
         return ClientResponse.create(HttpStatus.OK)
                 .header("Content-Type", "application/json")
@@ -78,7 +90,7 @@ class AladinBookApiClientCacheTest {
 
     @Test
     @DisplayName("같은 키워드로 다시 검색하면 캐시에서 응답하고 알라딘을 다시 호출하지 않는다")
-    void searchUsesCacheOnSecondCall() {
+    void searchUsesCacheOnSecondCall() throws InterruptedException {
         given(exchangeFunction.exchange(any())).willReturn(Mono.just(jsonResponse("""
                 {
                   "totalResults": 1,
@@ -91,6 +103,15 @@ class AladinBookApiClientCacheTest {
         Pageable pageable = PageRequest.of(0, 8);
 
         AladinSearchResult first = aladinBookApiClient.search("채식주의자캐시테스트", pageable);
+        assertThat(first.items()).as("첫 호출 결과가 비어있으면 unless 조건 때문에 애초에 캐싱되지 않는다").isNotEmpty();
+
+        // @Cacheable의 캐시 put은 원래 메서드가 결과를 반환하기 "전에" 같은 스레드에서 동기적으로
+        // 일어나지만, 전체 테스트 스위트를 함께 돌려 스프링 컨텍스트가 많이 떠 있는 상황에서는 Redis
+        // write가 반영되는 데 짧은 지연이 생기는 걸 관찰했다. 캐시가 실제로 없는 버그와 "아직 반영
+        // 안 됐을 뿐"인 경우를 구분하기 위해 짧게 재시도하며 기다린다.
+        String cacheKey = "채식주의자캐시테스트:0:8";
+        awaitCacheEntry(cacheKey);
+
         AladinSearchResult second = aladinBookApiClient.search("채식주의자캐시테스트", pageable);
 
         assertThat(second).isEqualTo(first);

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/AladinBookApiClientTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -66,23 +65,23 @@ class AladinBookApiClientTest {
                 }
                 """);
 
-        Page<ExternalBookResult> results = aladinBookApiClient().search("프랑켄슈타인", PageRequest.of(0, 20));
+        AladinSearchResult result = aladinBookApiClient().search("프랑켄슈타인", PageRequest.of(0, 20));
 
-        assertThat(results.getContent()).containsExactly(
+        assertThat(result.items()).containsExactly(
                 new ExternalBookResult("프랑켄슈타인", "메리 셸리", "문학동네", "9788954429721",
                         "https://image.aladin.co.kr/cover.jpg"));
-        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(result.totalResults()).isEqualTo(1);
     }
 
     @Test
-    @DisplayName("검색 결과가 없으면 빈 페이지를 반환한다")
-    void searchReturnsEmptyPageWhenNoItems() {
+    @DisplayName("검색 결과가 없으면 빈 결과를 반환한다")
+    void searchReturnsEmptyResultWhenNoItems() {
         stubSearch("{}");
 
-        Page<ExternalBookResult> results = aladinBookApiClient().search("없는 책", PageRequest.of(0, 20));
+        AladinSearchResult result = aladinBookApiClient().search("없는 책", PageRequest.of(0, 20));
 
-        assertThat(results.getContent()).isEmpty();
-        assertThat(results.getTotalElements()).isZero();
+        assertThat(result.items()).isEmpty();
+        assertThat(result.totalResults()).isZero();
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -120,6 +120,24 @@ class BookQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("정렬 기준과 무관하게 검색어로 시작하는 제목이 그렇지 않은 제목보다 먼저 나온다")
+    void searchByTitlePrioritizesPrefixMatchOverSortCriteria() {
+        User writer = user("wsr-prefix");
+        // "책" 정렬 기준(NAME)으로는 "가나책"이 "책모음"보다 먼저 와야 정상이지만,
+        // 검색어 "책"으로 시작하는 "책모음"이 접두어 일치이므로 먼저 나와야 한다.
+        Book containsMatch = book("가나책");
+        Book prefixMatch = book("책모음");
+        opinion(passage(containsMatch, writer, 1), writer);
+        opinion(passage(prefixMatch, writer, 1), writer);
+
+        Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
+                "책", BookSearchSort.NAME, PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .containsExactly(prefixMatch.getId(), containsMatch.getId());
+    }
+
+    @Test
     @DisplayName("이름순 정렬은 제목 오름차순으로 도서를 반환한다")
     void searchByTitleSortsByNameAscending() {
         User writer = user("wsr4");

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunnerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunnerTest.java
@@ -1,0 +1,70 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+// title_normalized 컬럼이 추가되기 전부터 있던 도서(= @PrePersist를 거치지 않아 이 컬럼이 NULL인
+// 도서)를 시뮬레이션하기 위해, 정상적으로 저장한 뒤 벌크 update로 title_normalized만 다시 NULL로
+// 되돌린다. Book.builder()로 저장하면 항상 @PrePersist가 채우기 때문에 이렇게 우회해야 한다.
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class BookTitleNormalizationBackfillRunnerTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private BookTitleNormalizationBackfillRunner runner;
+
+    @Test
+    @DisplayName("title_normalized가 NULL인 기존 도서를 앱 시작 시 자동으로 채운다")
+    void backfillsBooksWithMissingTitleNormalized() {
+        runner = new BookTitleNormalizationBackfillRunner(bookRepository);
+
+        Book legacyBook = entityManager.persistAndFlush(Book.builder()
+                .title("두 번째 산책")
+                .author("작가")
+                .publisher("출판사")
+                .pageCount(300)
+                .build());
+        entityManager.getEntityManager()
+                .createQuery("update Book b set b.titleNormalized = null where b.id = :id")
+                .setParameter("id", legacyBook.getId())
+                .executeUpdate();
+        entityManager.clear();
+
+        runner.run(null);
+
+        Book reloaded = entityManager.find(Book.class, legacyBook.getId());
+        assertThat(reloaded.getTitleNormalized()).isEqualTo("두번째산책");
+    }
+
+    @Test
+    @DisplayName("이미 title_normalized가 채워진 도서는 건드리지 않는다")
+    void doesNotTouchAlreadyNormalizedBooks() {
+        runner = new BookTitleNormalizationBackfillRunner(bookRepository);
+
+        Book book = entityManager.persistAndFlush(Book.builder()
+                .title("채식주의자")
+                .author("한강")
+                .publisher("창비")
+                .pageCount(200)
+                .build());
+        entityManager.clear();
+
+        runner.run(null);
+
+        Book reloaded = entityManager.find(Book.class, book.getId());
+        assertThat(reloaded.getTitleNormalized()).isEqualTo("채식주의자");
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunnerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookTitleNormalizationBackfillRunnerTest.java
@@ -4,12 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.global.config.JpaAuditingConfig;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
 
 // title_normalized 컬럼이 추가되기 전부터 있던 도서(= @PrePersist를 거치지 않아 이 컬럼이 NULL인
 // 도서)를 시뮬레이션하기 위해, 정상적으로 저장한 뒤 벌크 update로 title_normalized만 다시 NULL로
@@ -24,12 +27,21 @@ class BookTitleNormalizationBackfillRunnerTest {
     @Autowired
     private BookRepository bookRepository;
 
-    private BookTitleNormalizationBackfillRunner runner;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private void clearTitleNormalized(Long id) {
+        entityManager.getEntityManager()
+                .createQuery("update Book b set b.titleNormalized = null where b.id = :id")
+                .setParameter("id", id)
+                .executeUpdate();
+    }
 
     @Test
     @DisplayName("title_normalized가 NULL인 기존 도서를 앱 시작 시 자동으로 채운다")
     void backfillsBooksWithMissingTitleNormalized() {
-        runner = new BookTitleNormalizationBackfillRunner(bookRepository);
+        BookTitleNormalizationBackfillRunner runner =
+                new BookTitleNormalizationBackfillRunner(bookRepository, transactionManager, 500);
 
         Book legacyBook = entityManager.persistAndFlush(Book.builder()
                 .title("두 번째 산책")
@@ -37,10 +49,7 @@ class BookTitleNormalizationBackfillRunnerTest {
                 .publisher("출판사")
                 .pageCount(300)
                 .build());
-        entityManager.getEntityManager()
-                .createQuery("update Book b set b.titleNormalized = null where b.id = :id")
-                .setParameter("id", legacyBook.getId())
-                .executeUpdate();
+        clearTitleNormalized(legacyBook.getId());
         entityManager.clear();
 
         runner.run(null);
@@ -52,7 +61,8 @@ class BookTitleNormalizationBackfillRunnerTest {
     @Test
     @DisplayName("이미 title_normalized가 채워진 도서는 건드리지 않는다")
     void doesNotTouchAlreadyNormalizedBooks() {
-        runner = new BookTitleNormalizationBackfillRunner(bookRepository);
+        BookTitleNormalizationBackfillRunner runner =
+                new BookTitleNormalizationBackfillRunner(bookRepository, transactionManager, 500);
 
         Book book = entityManager.persistAndFlush(Book.builder()
                 .title("채식주의자")
@@ -66,5 +76,34 @@ class BookTitleNormalizationBackfillRunnerTest {
 
         Book reloaded = entityManager.find(Book.class, book.getId());
         assertThat(reloaded.getTitleNormalized()).isEqualTo("채식주의자");
+    }
+
+    @Test
+    @DisplayName("배치 크기보다 백필 대상이 많아도 id 기준으로 이어서 조회해 하나도 건너뛰지 않는다")
+    void backfillsAllBooksAcrossMultipleBatches() {
+        // 배치 크기를 일부러 작게(2) 주입해서, 여러 번 반복 조회해야 하는 상황을 재현한다.
+        // offset 페이지네이션이었다면 앞 배치가 채워지며 IS NULL 조건에서 빠져나가 다음 행을
+        // 건너뛰었을 텐데, id > lastId 기준 키셋 페이지네이션이라 5권 모두 채워져야 한다.
+        BookTitleNormalizationBackfillRunner runner =
+                new BookTitleNormalizationBackfillRunner(bookRepository, transactionManager, 2);
+
+        List<Long> legacyBookIds = IntStream.rangeClosed(1, 5)
+                .mapToObj(i -> entityManager.persistAndFlush(Book.builder()
+                        .title("책" + i)
+                        .author("작가")
+                        .publisher("출판사")
+                        .pageCount(100)
+                        .build()))
+                .map(Book::getId)
+                .toList();
+        legacyBookIds.forEach(this::clearTitleNormalized);
+        entityManager.clear();
+
+        runner.run(null);
+
+        List<String> normalizedTitles = legacyBookIds.stream()
+                .map(id -> entityManager.find(Book.class, id).getTitleNormalized())
+                .toList();
+        assertThat(normalizedTitles).containsExactly("책1", "책2", "책3", "책4", "책5");
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #100

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
책 제목 검색 자동완성을 위해 내부 DB 검색과 알라딘 외부 검색을 각각 개선합니다.
- 내부 DB 검색: 접두어 일치 결과를 우선 정렬해 관련도를 높임 (정규화 컬럼+인덱스 기반)
- 알라딘 외부 검색: 외부 API 특성상 지연을 없앨 순 없어, Redis 캐싱 + 최소 글자 수 가드 +
  타임아웃 단축으로 응답성과 쿼터 소모를 최대한 방어 (12시간 내에 검색된 것 기준으로 자동 완성이 가능)

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- `Book`에 `title_normalized`(공백 제거+소문자) 컬럼과 인덱스 추가, 저장 시점(`@PrePersist`/`@PreUpdate`)에 자동 계산
- `BookQueryRepository#searchByTitle`이 이 정규화 컬럼을 사용하도록 변경, 검색어로 시작하는 제목을 정렬 기준(이름/최신/의견순)보다 우선 노출
- `spring-boot-starter-cache` 추가, `CacheConfig`로 기존 Redis에 `RedisCacheManager` 구성 (TTL 12시간)
- `AladinBookApiClient#search()`에 `@Cacheable` 적용, 반환 타입을 캐싱 가능한 `AladinSearchResult` record로 변경 (`Page`/`Pageable`은 인터페이스라 Redis JSON 역직렬화가 깨짐)
- 알라딘 호출만 응답 타임아웃 10초 → 3초로 단축 (`WebClientConfig`, 카카오/애플 연동은 유지)
- `BookService#searchExternalBooks`에서 키워드 2글자 미만이면 알라딘 호출 없이 빈 결과 반환, 앞뒤 공백 trim
- 새 엔드포인트는 추가하지 않고 기존 `GET /api/books/search`, `GET /api/books/internal-search` 재사용

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
- 변경된 도메인의 단위/통합 테스트(`AladinBookApiClientTest`, `AladinBookApiClientCacheTest`, `BookServiceTest`, `BookQueryRepositoryTest`) 전체 통과 확인
- `./gradlew compileJava compileTestJava` 클린 컴파일 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요.
- prod는 `ddl-auto: validate`라 `title_normalized` 컬럼/인덱스가 자동 생성되지 않기에 배포 전 수동 마이그레이션이 필요함.
  ```sql
  ALTER TABLE books ADD COLUMN title_normalized VARCHAR(255);
  UPDATE books SET title_normalized = LOWER(REPLACE(title, ' ', ''));
  CREATE INDEX idx_books_title_normalized ON books (title_normalized);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 도서 검색 결과를 최대 12시간 캐싱해 반복 검색 응답이 빨라졌습니다.
  * 검색어 앞뒤 공백을 제거하며, 2자 미만 검색어는 빈 결과를 반환합니다.
  * 제목 검색 시 검색어로 시작하는 도서가 우선 표시됩니다.
  * 제목 비교가 공백과 대소문자 차이에 영향을 받지 않도록 개선되었습니다.

* **버그 수정**
  * 외부 도서 검색 응답 제한 시간을 3초로 적용했습니다.
  * 빈 결과나 외부 요청 실패 시 불필요한 캐싱을 방지합니다.

* **문서**
  * 자동완성, 최소 검색어 길이 및 캐싱 동작 설명을 보완했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->