### PR TITLE
Refactor/#110 도서 내부 검색 - 흔적 유무와 무관하게 전체 도서 반환

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -25,7 +25,7 @@ public class BookQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     // 띄어쓰기 차이를 무시하고 검색할 수 있도록 제목/키워드 모두에서 공백을 제거한 뒤 비교한다.
-    // 흔적(Opinion)이 하나도 없는 도서는 결과에서 제외하므로 leftJoin이 아닌 innerJoin을 사용한다.
+    // 흔적(Opinion)/대목(Passage) 유무와 무관하게 DB에 저장된 도서 전부를 대상으로 하므로 leftJoin을 사용한다.
     public Page<BookSearchProjection> searchByTitle(String keyword, BookSearchSort sort, Pageable pageable) {
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
@@ -40,8 +40,8 @@ public class BookQueryRepository {
                         book.isbn, book.coverImageUrl, book.source,
                         passage.countDistinct(), opinion.countDistinct()))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
+                .leftJoin(passage).on(passage.book.eq(book))
+                .leftJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.pageCount,
                         book.isbn, book.coverImageUrl, book.source)
@@ -50,11 +50,10 @@ public class BookQueryRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        // 흔적/대목 유무로 필터링하지 않으므로 count 쪽은 join 없이 제목 조건만으로 센다.
         Long total = queryFactory
                 .select(book.countDistinct())
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinion).on(opinion.passage.eq(passage).and(opinion.deletedAt.isNull()))
                 .where(normalizedTitle.containsIgnoreCase(normalizedKeyword))
                 .fetchOne();
 

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -42,8 +42,8 @@ public interface BookApi {
     );
 
     @Operation(summary = "도서 내부 검색",
-            description = "서비스 DB에 등록된 도서 중 흔적(Opinion)이 하나 이상 있는 도서만 제목으로 검색하며, "
-                    + "도서별 대목/흔적 수를 함께 반환합니다. "
+            description = "서비스 DB에 등록된 도서 전체를 흔적(Opinion) 유무와 무관하게 제목으로 검색하며, "
+                    + "도서별 대목/흔적 수를 함께 반환합니다(흔적이 없으면 0). "
                     + "제목과 검색어의 띄어쓰기 차이는 무시하고 매칭합니다. keyword에 빈 문자열을 넘기면 전체 목록을 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.book.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.nexters.palang.domain.book.application.BookActivityProjection;
 import com.nexters.palang.domain.book.application.BookSearchProjection;
@@ -90,8 +91,8 @@ class BookQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("흔적(Opinion)이 없는 도서는 검색 결과에서 제외된다")
-    void searchByTitleExcludesBooksWithoutOpinions() {
+    @DisplayName("흔적(Opinion)이나 대목(Passage)이 없는 도서도 검색 결과에 포함된다")
+    void searchByTitleIncludesBooksWithoutOpinions() {
         User writer = user("wsr2");
         Book bookWithoutPassage = book("대목도 없는 책");
         Book bookWithoutOpinion = book("대목만 있는 책");
@@ -100,23 +101,28 @@ class BookQueryRepositoryTest {
         Page<BookSearchProjection> results = bookQueryRepository.searchByTitle("책", BookSearchSort.RECENT,
                 PageRequest.of(0, 20));
 
-        assertThat(results.getContent()).isEmpty();
-        assertThat(bookWithoutPassage.getId()).isNotNull();
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .containsExactlyInAnyOrder(bookWithoutPassage.getId(), bookWithoutOpinion.getId());
+        assertThat(results.getContent()).extracting(BookSearchProjection::passageCount, BookSearchProjection::opinionCount)
+                .containsExactlyInAnyOrder(tuple(0L, 0L), tuple(1L, 0L));
     }
 
     @Test
-    @DisplayName("검색어가 빈 문자열이면 흔적이 있는 전체 도서 목록을 반환한다")
+    @DisplayName("검색어가 빈 문자열이면 흔적 유무와 무관하게 전체 도서 목록을 반환한다")
     void searchByTitleReturnsAllBooksWhenKeywordIsBlank() {
         User writer = user("wsr3");
         Book book1 = book("책1");
         Book book2 = book("책2");
+        Book bookWithoutOpinion = book("책3");
         opinion(passage(book1, writer, 1), writer);
         opinion(passage(book2, writer, 1), writer);
 
         Page<BookSearchProjection> results = bookQueryRepository.searchByTitle(
                 "", BookSearchSort.RECENT, PageRequest.of(0, 20));
 
-        assertThat(results.getTotalElements()).isEqualTo(2);
+        assertThat(results.getTotalElements()).isEqualTo(3);
+        assertThat(results.getContent()).extracting(BookSearchProjection::bookId)
+                .contains(bookWithoutOpinion.getId());
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #110

## 🚀 개요
`GET /api/books/internal-search`가 흔적(Opinion)이 있는 도서만 반환하던 것을, 흔적 유무와 무관하게 DB에 저장된 도서 전체를 반환하도록 변경합니다.

## 📄 작업 내용
- `BookQueryRepository#searchByTitle`의 `passage`/`opinion` `innerJoin`을 `leftJoin`으로 변경 — 대목(Passage)/흔적(Opinion)이 하나도 없는 도서도 검색 결과에 포함되도록 함
- 흔적/대목 유무로 더 이상 필터링하지 않으므로, `total` count 쿼리에서 불필요해진 join 제거
- `BookApi`의 도서 내부 검색 Swagger 설명을 새 동작("흔적 유무와 무관하게 전체 도서 검색, 흔적 없으면 0")에 맞게 수정
- `BookQueryRepositoryTest`의 관련 테스트 2건을 새 동작에 맞게 재작성
  - 흔적/대목이 없는 도서도 결과에 포함되고 `passageCount`/`opinionCount`가 0으로 집계되는지 검증
  - 검색어가 빈 문자열일 때 흔적 없는 도서까지 포함한 전체 개수를 반환하는지 검증

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava compileTestJava` 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `RECENT`/`OPINION` 정렬 기준(`opinion.createdAt.max()`, `opinion.countDistinct()`)이 흔적 없는 도서에서 각각 NULL/0으로 집계되는데, DB의 NULL 정렬 기본 동작(`DESC`에서 NULL을 마지막에 배치)에 기대어 별도 처리 없이 "흔적 있는 책 먼저" 순서를 유지하도록 했습니다. 