### PR TITLE
Feat/#113 최근 남긴 도서 목록 keyword 검색 파라미터 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -94,8 +94,8 @@ public class BookService {
         return bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
     }
 
-    public Page<Book> getRecentBooks(Long userId, Pageable pageable) {
-        Page<Long> bookIds = bookQueryRepository.findRecentlyActiveBookIds(userId, pageable);
+    public Page<Book> getRecentBooks(Long userId, String keyword, Pageable pageable) {
+        Page<Long> bookIds = bookQueryRepository.findRecentlyActiveBookIds(userId, keyword, pageable);
         Map<Long, Book> booksById = bookRepository.findAllById(bookIds.getContent()).stream()
                 .collect(Collectors.toMap(Book::getId, book -> book));
         List<Book> books = bookIds.getContent().stream().map(booksById::get).filter(Objects::nonNull).toList();

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -193,15 +193,23 @@ public class BookQueryRepository {
 
     // "최근에 남긴 책"은 Passage를 새로 만든 책이 아니라 흔적(Opinion)을 남긴 책 기준이다 (FR-WRITE-01).
     // 기존 Passage에 Opinion만 추가한 경우도 포함해야 하므로 Opinion을 기준으로 조회한다.
-    public Page<Long> findRecentlyActiveBookIds(Long userId, Pageable pageable) {
+    // keyword가 있으면 홈 화면 검색용으로 제목을 추가 필터링한다 (searchByTitle과 동일하게
+    // title_normalized 컬럼 기준). keyword가 없거나 빈 문자열이면 필터링 없이 전체를 반환한다.
+    public Page<Long> findRecentlyActiveBookIds(Long userId, String keyword, Pageable pageable) {
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
+        QBook book = QBook.book;
+
+        String normalizedKeyword = Book.normalize(keyword);
+        boolean hasKeyword = !normalizedKeyword.isEmpty();
 
         List<Long> content = queryFactory
                 .select(passage.book.id)
                 .from(opinion)
                 .join(opinion.passage, passage)
-                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(),
+                        hasKeyword ? book.titleNormalized.contains(normalizedKeyword) : null)
                 .groupBy(passage.book.id)
                 .orderBy(opinion.createdAt.max().desc(), passage.book.id.asc())
                 .offset(pageable.getOffset())
@@ -212,7 +220,9 @@ public class BookQueryRepository {
                 .select(passage.book.countDistinct())
                 .from(opinion)
                 .join(opinion.passage, passage)
-                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(),
+                        hasKeyword ? book.titleNormalized.contains(normalizedKeyword) : null)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -118,6 +118,8 @@ public interface BookApi {
 
     @Operation(summary = "내가 최근에 남긴 도서 목록",
             description = "현재 로그인한 사용자가 최근에 대목을 남긴 도서 목록입니다. "
+                    + "홈 화면 검색에서 사용할 수 있도록 keyword로 제목을 필터링할 수 있으며, "
+                    + "생략하거나 빈 문자열이면 전체 목록을 반환합니다. 제목과 검색어의 띄어쓰기 차이는 무시하고 매칭합니다. "
                     + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -127,6 +129,7 @@ public interface BookApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookListResponse>> getRecentBooks(
+            @Parameter(description = "검색 키워드 (생략하거나 빈 문자열이면 전체 목록)") String keyword,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -92,11 +92,12 @@ public class BookController implements BookApi {
     @Override
     @GetMapping("/api/books/recent")
     public ResponseEntity<DataResponse<BookListResponse>> getRecentBooks(
+            @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
-        return ResponseEntity.ok(DataResponse.from(
-                BookMapper.toListResponse(bookService.getRecentBooks(currentUserId, pageable(page, size)))));
+        return ResponseEntity.ok(DataResponse.from(BookMapper.toListResponse(
+                bookService.getRecentBooks(currentUserId, keyword, pageable(page, size)))));
     }
 
     @Override

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -158,15 +158,29 @@ class BookServiceTest {
         Book book1 = book(1L, "책1");
         Book book2 = book(2L, "책2");
         Book book3 = book(3L, "책3");
-        given(bookQueryRepository.findRecentlyActiveBookIds(10L, pageable))
+        given(bookQueryRepository.findRecentlyActiveBookIds(10L, null, pageable))
                 .willReturn(new PageImpl<>(List.of(3L, 1L, 2L), pageable, 3));
         given(bookRepository.findAllById(List.of(3L, 1L, 2L)))
                 .willReturn(List.of(book1, book2, book3));
 
-        Page<Book> results = bookService.getRecentBooks(10L, pageable);
+        Page<Book> results = bookService.getRecentBooks(10L, null, pageable);
 
         assertThat(results.getContent()).containsExactly(book3, book1, book2);
         assertThat(results.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("내가 최근에 남긴 도서 목록 조회 시 keyword를 QueryRepository로 그대로 전달한다")
+    void getRecentBooksForwardsKeyword() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Book book1 = book(1L, "책1");
+        given(bookQueryRepository.findRecentlyActiveBookIds(10L, "책1", pageable))
+                .willReturn(new PageImpl<>(List.of(1L), pageable, 1));
+        given(bookRepository.findAllById(List.of(1L))).willReturn(List.of(book1));
+
+        Page<Book> results = bookService.getRecentBooks(10L, "책1", pageable);
+
+        assertThat(results.getContent()).containsExactly(book1);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -317,10 +317,40 @@ class BookQueryRepositoryTest {
         opinion(passage(othersBook, other, 1), other);
 
         Pageable pageable = PageRequest.of(0, 10);
-        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), pageable);
+        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), null, pageable);
 
         assertThat(results.getContent()).containsExactly(myBook.getId());
         assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("keyword로 최근 흔적을 남긴 도서 제목을 필터링한다 (띄어쓰기 무시)")
+    void findRecentlyActiveBookIdsFiltersByKeyword() {
+        User me = user("me-keyword");
+        Book matchingBook = book("작별 인사");
+        Book otherBook = book("불편한 편의점");
+        opinion(passage(matchingBook, me, 1), me);
+        opinion(passage(otherBook, me, 1), me);
+
+        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), "작별인사", PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).containsExactly(matchingBook.getId());
+        assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("keyword가 빈 문자열이면 필터링 없이 전체 목록을 반환한다")
+    void findRecentlyActiveBookIdsReturnsAllWhenKeywordBlank() {
+        User me = user("me-kw-blank");
+        Book book1 = book("작별 인사");
+        Book book2 = book("불편한 편의점");
+        opinion(passage(book1, me, 1), me);
+        opinion(passage(book2, me, 1), me);
+
+        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), "", PageRequest.of(0, 10));
+
+        assertThat(results.getContent()).containsExactlyInAnyOrder(book1.getId(), book2.getId());
+        assertThat(results.getTotalElements()).isEqualTo(2);
     }
 
     @Test
@@ -410,7 +440,7 @@ class BookQueryRepositoryTest {
 
         opinion(existingPassage, me);
 
-        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), PageRequest.of(0, 10));
+        Page<Long> results = bookQueryRepository.findRecentlyActiveBookIds(me.getId(), null, PageRequest.of(0, 10));
 
         assertThat(results.getContent()).containsExactly(book.getId());
     }

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -222,12 +222,24 @@ class BookControllerTest {
     @DisplayName("내가 최근에 남긴 도서 목록을 요청하면 현재 사용자 기준으로 조회한다")
     void getRecentBooks() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(bookService.getRecentBooks(eq(1L), any(Pageable.class))).willReturn(
+        given(bookService.getRecentBooks(eq(1L), isNull(), any(Pageable.class))).willReturn(
                 new PageImpl<>(List.of(book(1L, "최근 책")), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/books/recent"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.books[0].title").value("최근 책"));
+    }
+
+    @Test
+    @DisplayName("내가 최근에 남긴 도서 목록을 keyword로 요청하면 keyword를 그대로 전달한다")
+    void getRecentBooksWithKeyword() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(bookService.getRecentBooks(eq(1L), eq("작별인사"), any(Pageable.class))).willReturn(
+                new PageImpl<>(List.of(book(1L, "작별인사")), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/books/recent").param("keyword", "작별인사"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].title").value("작별인사"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #113

## 🚀 개요
홈 화면 검색에서 최근 남긴 도서 중 제목으로 필터링할 수 있도록 `GET /api/books/recent`에 선택적 keyword 파라미터를 추가했습니다.

## 📄 작업 내용
- `BookController#getRecentBooks`: `keyword` 쿼리 파라미터(선택) 추가
- `BookService#getRecentBooks`: keyword를 `BookQueryRepository`로 전달
- `BookQueryRepository#findRecentlyActiveBookIds`: keyword가 있으면 `Book`과 조인해 `titleNormalized` 컬럼 기준으로 제목 필터링 (기존 `searchByTitle`과 동일한 정규화 방식, 띄어쓰기 무시). keyword가 없거나 빈 문자열이면 기존과 동일하게 전체 목록 반환
- `BookApi` Swagger 문서에 keyword 파라미터 설명 추가
- `BookServiceTest`, `BookQueryRepositoryTest`, `BookControllerTest`에 keyword 관련 테스트 케이스 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test --tests "com.nexters.palang.domain.book.infrastructure.BookQueryRepositoryTest" --tests "com.nexters.palang.domain.book.application.BookServiceTest" --tests "com.nexters.palang.domain.book.presentation.BookControllerTest"` 통과
- (참고) 로컬 환경에 Redis가 없어 `AladinBookApiClientCacheTest` 3건은 이번 변경과 무관하게 실패합니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- keyword가 빈 문자열/공백일 때 필터링 없이 전체 목록을 반환하도록 했는데, 이 하위 호환 동작이 홈 화면 검색 UX와 맞는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 최근 활동 도서 목록에서 제목으로 검색할 수 있습니다.
  * 검색어 입력 시 공백을 무시하고 제목을 기준으로 필터링합니다.
  * 검색어 없이 조회하면 기존처럼 전체 목록이 표시됩니다.

* **테스트**
  * 제목 검색, 빈 검색어 조회 및 검색 결과 응답에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->