### PR TITLE
Feat/#118 내 스포일러 대목 목록

### DIFF
--- a/src/main/java/com/nexters/palang/domain/passage/application/MyPassageProjection.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/MyPassageProjection.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.passage.application;
+
+import java.time.LocalDateTime;
+
+public record MyPassageProjection(
+        Long passageId,
+        Long bookId,
+        int pageNumber,
+        String quotedText,
+        boolean isSpoiler,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -41,6 +41,11 @@ public class PassageService {
         return passageQueryRepository.findPassagesByPage(bookId, pageNumber);
     }
 
+    // 내가 남긴 대목 목록: bookId 미지정 시 전체 도서, spoilerOnly=true 시 스포일러 대목만.
+    public Page<MyPassageProjection> getMyPassages(Long userId, Long bookId, boolean spoilerOnly, Pageable pageable) {
+        return passageQueryRepository.findMyPassages(userId, bookId, spoilerOnly, pageable);
+    }
+
     public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {
         Map<Long, List<DecorationMergeCandidate>> mergedByPassageId = new LinkedHashMap<>();
         for (Passage passage : passages) {

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -1,10 +1,12 @@
 package com.nexters.palang.domain.passage.infrastructure;
 
 import com.nexters.palang.domain.opinion.domain.QOpinion;
+import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -72,5 +74,40 @@ public class PassageQueryRepository {
                 .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber), passage.deletedAt.isNull())
                 .orderBy(passage.id.asc())
                 .fetch();
+    }
+
+    // 내가 남긴 대목(FR-...): 소유 기준은 흔적을 남긴 사용자다(최초 생성자가 아니어도 병합된 대목에 흔적을 남겼으면 포함).
+    // 같은 대목에 흔적을 여러 번 남긴 경우 중복 제거를 위해 대목 단위로 group by 한다.
+    public Page<MyPassageProjection> findMyPassages(Long userId, Long bookId, boolean spoilerOnly, Pageable pageable) {
+        QOpinion opinion = QOpinion.opinion;
+        QPassage passage = QPassage.passage;
+
+        BooleanExpression bookFilter = bookId != null ? passage.book.id.eq(bookId) : null;
+        BooleanExpression spoilerFilter = spoilerOnly ? passage.isSpoiler.isTrue() : null;
+
+        List<MyPassageProjection> content = queryFactory
+                .select(Projections.constructor(MyPassageProjection.class,
+                        passage.id, passage.book.id, passage.pageNumber, passage.quotedText,
+                        passage.isSpoiler, passage.createdAt))
+                .from(opinion)
+                .join(opinion.passage, passage)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
+                        bookFilter, spoilerFilter)
+                .groupBy(passage.id, passage.book.id, passage.pageNumber, passage.quotedText,
+                        passage.isSpoiler, passage.createdAt)
+                .orderBy(passage.createdAt.desc(), passage.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(passage.countDistinct())
+                .from(opinion)
+                .join(opinion.passage, passage)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
+                        bookFilter, spoilerFilter)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -77,7 +77,8 @@ public class PassageQueryRepository {
     }
 
     // 내가 남긴 대목(FR-...): 소유 기준은 흔적을 남긴 사용자다(최초 생성자가 아니어도 병합된 대목에 흔적을 남겼으면 포함).
-    // 같은 대목에 흔적을 여러 번 남긴 경우 중복 제거를 위해 대목 단위로 group by 한다.
+    // createdAt/정렬 기준은 대목 자체가 아니라 "내가 그 대목에 흔적을 남긴 시점"이어야 사용자 관점에서 의미가 있으므로
+    // opinion.createdAt의 최댓값을 쓴다(같은 대목에 흔적을 여러 번 남긴 경우 가장 최근 흔적 기준, 대목 단위 중복 제거).
     public Page<MyPassageProjection> findMyPassages(Long userId, Long bookId, boolean spoilerOnly, Pageable pageable) {
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
@@ -88,14 +89,13 @@ public class PassageQueryRepository {
         List<MyPassageProjection> content = queryFactory
                 .select(Projections.constructor(MyPassageProjection.class,
                         passage.id, passage.book.id, passage.pageNumber, passage.quotedText,
-                        passage.isSpoiler, passage.createdAt))
+                        passage.isSpoiler, opinion.createdAt.max()))
                 .from(opinion)
                 .join(opinion.passage, passage)
                 .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
                         bookFilter, spoilerFilter)
-                .groupBy(passage.id, passage.book.id, passage.pageNumber, passage.quotedText,
-                        passage.isSpoiler, passage.createdAt)
-                .orderBy(passage.createdAt.desc(), passage.id.desc())
+                .groupBy(passage.id, passage.book.id, passage.pageNumber, passage.quotedText, passage.isSpoiler)
+                .orderBy(opinion.createdAt.max().desc(), passage.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -2,12 +2,15 @@ package com.nexters.palang.domain.user.application;
 
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
+import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyPassageListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyPassageResponse;
 import com.nexters.palang.global.common.response.PageInfo;
 import org.springframework.data.domain.Page;
 
@@ -44,5 +47,16 @@ public final class UserMapper {
     public static LikedOpinionListResponse toLikedOpinionListResponse(Page<LikedOpinionProjection> projections) {
         return new LikedOpinionListResponse(
                 projections.map(UserMapper::toLikedOpinionResponse).getContent(), PageInfo.from(projections));
+    }
+
+    public static MyPassageResponse toMyPassageResponse(MyPassageProjection projection) {
+        return new MyPassageResponse(
+                projection.passageId(), projection.bookId(), projection.pageNumber(), projection.quotedText(),
+                projection.isSpoiler(), projection.createdAt());
+    }
+
+    public static MyPassageListResponse toMyPassageListResponse(Page<MyPassageProjection> projections) {
+        return new MyPassageListResponse(
+                projections.map(UserMapper::toMyPassageResponse).getContent(), PageInfo.from(projections));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -179,7 +179,7 @@ public interface UserApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "내 스포일러 대목 목록", description = "내가 흔적을 남긴 대목을 최신순으로 조회합니다. "
+    @Operation(summary = "내 대목 목록", description = "내가 흔적을 남긴 대목을 최신순으로 조회합니다. "
             + "소유 기준은 최초 작성자가 아니라 해당 대목에 흔적을 남긴 사용자이며, 병합된 대목은 흔적을 남긴 모든 사용자에게 노출됩니다. "
             + "bookId를 지정하면 해당 책으로 한정하고, 생략하면 전체 책을 대상으로 합니다. "
             + "spoilerOnly=true면 스포일러 대목만 조회합니다. "

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.user.presentation;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyPassageListResponse;
 import com.nexters.palang.domain.user.presentation.dto.OnboardingCompleteResponse;
 import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
 import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
@@ -174,6 +175,29 @@ public interface UserApi {
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
     })
     ResponseEntity<DataResponse<LikedOpinionListResponse>> getLikedOpinions(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "내 스포일러 대목 목록", description = "내가 흔적을 남긴 대목을 최신순으로 조회합니다. "
+            + "소유 기준은 최초 작성자가 아니라 해당 대목에 흔적을 남긴 사용자이며, 병합된 대목은 흔적을 남긴 모든 사용자에게 노출됩니다. "
+            + "bookId를 지정하면 해당 책으로 한정하고, 생략하면 전체 책을 대상으로 합니다. "
+            + "spoilerOnly=true면 스포일러 대목만 조회합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/passages\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/passages\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<MyPassageListResponse>> getMyPassages(
+            @Parameter(description = "책 ID (생략 시 전체 책 대상)") Long bookId,
+            @Parameter(description = "스포일러 대목만 조회 여부 (기본값 false)") boolean spoilerOnly,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -2,12 +2,14 @@ package com.nexters.palang.domain.user.presentation;
 
 import com.nexters.palang.domain.auth.application.AuthService;
 import com.nexters.palang.domain.opinion.application.OpinionService;
+import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.user.application.UserMapper;
 import com.nexters.palang.domain.user.application.UserService;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
+import com.nexters.palang.domain.user.presentation.dto.MyPassageListResponse;
 import com.nexters.palang.domain.user.presentation.dto.OnboardingCompleteResponse;
 import com.nexters.palang.domain.user.presentation.dto.UpdateBackgroundColorRequest;
 import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
@@ -39,6 +41,7 @@ public class UserController implements UserApi {
     private final UserService userService;
     private final AuthService authService;
     private final OpinionService opinionService;
+    private final PassageService passageService;
     private final CurrentUserProvider currentUserProvider;
 
     @Override
@@ -109,6 +112,18 @@ public class UserController implements UserApi {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         return ResponseEntity.ok(DataResponse.from(UserMapper.toLikedOpinionListResponse(
                 opinionService.getLikedOpinions(currentUserId, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/users/me/passages")
+    public ResponseEntity<DataResponse<MyPassageListResponse>> getMyPassages(
+            @RequestParam(required = false) Long bookId,
+            @RequestParam(defaultValue = "false") boolean spoilerOnly,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(UserMapper.toMyPassageListResponse(
+                passageService.getMyPassages(currentUserId, bookId, spoilerOnly, pageable(page, size)))));
     }
 
     private MeResponse toMeResponse(Long userId, User user) {

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record MyPassageListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<MyPassageResponse> passages,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageResponse.java
@@ -1,0 +1,14 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record MyPassageResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
+        @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isSpoiler,
+        @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.user.domain.SnsProvider;
@@ -201,5 +202,85 @@ class PassageQueryRepositoryTest {
         List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), 3);
 
         assertThat(result).extracting(Passage::getId).containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("병합된 대목은 최초 생성자가 아니어도 흔적을 남긴 사용자에게 노출된다")
+    void findMyPassagesIncludesMergedPassageForTraceOwner() {
+        User creator = user("creator-1");
+        User merger = user("merger-1");
+        Book book = book("책");
+        Passage passage = passage(book, creator, 5, "발췌 문장", "hash-1");
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(merger).content("병합 흔적").build());
+
+        Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
+                merger.getId(), null, false, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(MyPassageProjection::passageId).containsExactly(passage.getId());
+    }
+
+    @Test
+    @DisplayName("흔적을 남긴 적 없는 대목은 조회되지 않는다")
+    void findMyPassagesExcludesPassageWithoutMyOpinion() {
+        User creator = user("creator-2");
+        User other = user("other-2");
+        Book book = book("책");
+        Passage passage = passage(book, creator, 5, "발췌 문장", "hash-1");
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(creator).content("흔적").build());
+
+        Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
+                other.getId(), null, false, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("bookId를 지정하면 해당 책의 대목만 조회된다")
+    void findMyPassagesFiltersByBookId() {
+        User writer = user("writer-9");
+        Book targetBook = book("대상 책");
+        Book otherBook = book("다른 책");
+        Passage inTargetBook = passage(targetBook, writer, 5, "발췌 문장", "hash-1");
+        Passage inOtherBook = passage(otherBook, writer, 5, "발췌 문장", "hash-2");
+        entityManager.persistAndFlush(Opinion.builder().passage(inTargetBook).user(writer).content("흔적1").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(inOtherBook).user(writer).content("흔적2").build());
+
+        Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
+                writer.getId(), targetBook.getId(), false, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(MyPassageProjection::passageId)
+                .containsExactly(inTargetBook.getId());
+    }
+
+    @Test
+    @DisplayName("spoilerOnly=true면 스포일러 대목만 조회된다")
+    void findMyPassagesFiltersBySpoilerOnly() {
+        User writer = user("writer-10");
+        Book book = book("책");
+        Passage spoiler = passage(book, writer, 1, true);
+        Passage notSpoiler = passage(book, writer, 2, false);
+        entityManager.persistAndFlush(Opinion.builder().passage(spoiler).user(writer).content("흔적1").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(notSpoiler).user(writer).content("흔적2").build());
+
+        Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
+                writer.getId(), null, true, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).extracting(MyPassageProjection::passageId).containsExactly(spoiler.getId());
+    }
+
+    @Test
+    @DisplayName("같은 대목에 흔적을 여러 번 남겨도 대목은 한 번만 조회된다")
+    void findMyPassagesDeduplicatesSamePassage() {
+        User writer = user("writer-11");
+        Book book = book("책");
+        Passage passage = passage(book, writer, 5, "발췌 문장", "hash-1");
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적1").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적2").build());
+
+        Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
+                writer.getId(), null, false, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -17,6 +17,8 @@ import com.nexters.palang.domain.auth.application.AuthService;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionService;
+import com.nexters.palang.domain.passage.application.MyPassageProjection;
+import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.user.application.UserService;
 import com.nexters.palang.domain.user.common.error.UserErrorCode;
 import com.nexters.palang.domain.user.common.error.UserException;
@@ -60,6 +62,9 @@ class UserControllerTest {
 
     @MockitoBean
     private OpinionService opinionService;
+
+    @MockitoBean
+    private PassageService passageService;
 
     @MockitoBean
     private CurrentUserProvider currentUserProvider;
@@ -293,5 +298,33 @@ class UserControllerTest {
         mockMvc.perform(get("/api/users/me/likes"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1));
+    }
+
+    @Test
+    @DisplayName("내가 남긴 스포일러 대목 목록을 조회한다")
+    void getMyPassages() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        MyPassageProjection projection = new MyPassageProjection(
+                1L, 10L, 5, "발췌 문장", true, LocalDateTime.now());
+        given(passageService.getMyPassages(eq(1L), eq(10L), eq(true), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/passages")
+                        .param("bookId", "10")
+                        .param("spoilerOnly", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passages[0].passageId").value(1))
+                .andExpect(jsonPath("$.data.passages[0].bookId").value(10))
+                .andExpect(jsonPath("$.data.passages[0].isSpoiler").value(true));
+    }
+
+    @Test
+    @DisplayName("인증 없이 내 대목 목록을 요청하면 401 에러가 발생한다")
+    void getMyPassagesFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(get("/api/users/me/passages"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #118

## 🚀 개요
> 사용자가 흔적을 남긴 대목을 스포일러 여부·책 단위로 모아 조회할 수 있는 `GET /api/users/me/passages`를 신설했습니다.

## 📄 작업 내용
- `GET /api/users/me/passages?bookId=&spoilerOnly=&page=&size=` 신규 엔드포인트 추가 (`UserController`, `UserApi`)
- "내가 남긴 대목"의 소유자 판정 기준을 흔적(Opinion)을 남긴 사용자로 정의 — 병합된 대목은 흔적을 남긴 모든 사용자에게 노출됨
- `PassageQueryRepository.findMyPassages`: Opinion-Passage 조인, `bookId`(선택)/`spoilerOnly` 필터, 대목 단위 group by로 중복 제거
- `PassageService.getMyPassages`, `MyPassageProjection`, `MyPassageResponse`, `MyPassageListResponse`, `UserMapper` 매핑 메서드 추가
- 응답: `passages: [{ passageId, bookId, pageNumber, quotedText, isSpoiler, createdAt }], pageInfo`
- `UserControllerTest`에 신규 엔드포인트 성공/401 케이스 테스트 추가

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/users/me/passages` | 내가 남긴 대목 목록 (bookId 선택, spoilerOnly 필터) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 (`AladinBookApiClientCacheTest`는 Redis 반영 지연으로 인한 기존 간헐적 플래키 실패이며 이번 변경과 무관)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 소유자 판정 기준을 "흔적을 남긴 사용자"로 정의했습니다(최초 생성자 기준이 아님). 이슈 #118에서 논의된 두 옵션 중 이 기준이 맞는지, 그리고 관련 권한 검사(예: 대목 삭제/수정 권한)에도 동일 기준을 적용해야 하는지 확인 부탁드립니다.
- 한 사용자가 같은(병합된) 대목에 여러 흔적을 남긴 경우 대목 단위로 group by하여 중복을 제거했습니다 — 이 방식이 의도에 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자가 남긴 인용문 목록을 조회할 수 있습니다.
  * 책별 조회와 스포일러 포함 여부를 기준으로 필터링할 수 있습니다.
  * 인용문, 책·페이지 정보, 스포일러 여부와 생성 시각을 함께 제공합니다.
  * 페이지 단위로 목록을 확인할 수 있습니다.
  * 동일한 인용문은 중복 없이 표시됩니다.
  * 인증되지 않은 요청은 접근이 제한됩니다.

* **테스트**
  * 조회 조건, 중복 제거 및 인증 상태에 대한 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->