### PR TITLE
Feat/#119 홈/내 의견 API 비로그인 샘플 응답 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -92,8 +92,16 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
+    // 비로그인 사용자는 홈에서 실제 서재 대신 고정 샘플 도서 1건을 본다 (기획 확정, 이슈 #119).
+    private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK = new BookActivityProjection(
+            18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
+            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 17L);
+
     // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열하며, 표준 page/size 페이지네이션을 사용한다.
     public Page<BookActivityProjection> getMyLibraryBooks(Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
+        if (userId == null) {
+            return new PageImpl<>(List.of(GUEST_SAMPLE_LIBRARY_BOOK), pageable, 1);
+        }
         return bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
     }
 

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -84,8 +84,10 @@ public interface BookApi {
             @Parameter(description = "책 표지 이미지 파일 (jpeg/png, 선택)") MultipartFile coverImage
     );
 
-    @Operation(summary = "홈 캐러셀 도서 목록",
-            description = "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다. offset을 생략하면 전체 목록 중 "
+    @Operation(summary = "홈 캐러셀 도서 목록", deprecated = true,
+            description = "(사용 중단) 더 이상 홈 화면에서 사용하지 않습니다. 홈 화면 도서 목록은 "
+                    + "GET /api/books/my-library(opinionCountScope=ALL)를 사용하세요. "
+                    + "흔적이 남은 도서를 대목/흔적 수와 함께 조회합니다. offset을 생략하면 전체 목록 중 "
                     + "정가운데 책들을 기준으로 조회하며, 좌우 스크롤 시에는 응답으로 받은 pageInfo를 참고해 "
                     + "offset - size(이전) 또는 offset + size(다음)로 다시 요청하면 됩니다.")
     @ApiResponses({
@@ -103,12 +105,11 @@ public interface BookApi {
                     + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬됩니다. opinionCountScope로 흔적 수 집계 "
                     + "기준을 선택할 수 있습니다: ALL(기본값, 도서 전체 흔적 수 - 홈 화면 노출용) 또는 "
                     + "MINE(로그인 사용자 본인이 남긴 흔적 수 - 마이페이지 노출용). "
-                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+                    + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없으면(비로그인) 샘플 도서 1건을 "
+                    + "고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<DataResponse<BookActivityListResponse>> getMyLibraryBooks(

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookController.java
@@ -86,7 +86,7 @@ public class BookController implements BookApi {
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size,
             @RequestParam(defaultValue = "ALL") OpinionCountScope opinionCountScope) {
-        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
         return ResponseEntity.ok(DataResponse.from(BookMapper.toActivityListResponse(
                 bookService.getMyLibraryBooks(currentUserId, pageable(page, size), opinionCountScope))));
     }

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -22,9 +22,11 @@ import com.nexters.palang.domain.user.common.error.UserErrorCode;
 import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -126,7 +128,30 @@ public class OpinionService {
         return existing;
     }
 
+    // 비로그인 사용자는 마이페이지 미리보기로 고정 샘플 흔적 3건을 본다 (기획 확정, 이슈 #120).
+    private static final String GUEST_SAMPLE_BOOK_TITLE = "빵충 사육 준수 사항";
+    private static final String GUEST_SAMPLE_AUTHOR = "김혜영 (지은이)";
+    private static final String GUEST_SAMPLE_COVER_IMAGE_URL =
+            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg";
+    private static final String GUEST_SAMPLE_QUOTED_TEXT = "이 모든 건 챗지피티 덕분이었다. 담당자가 준 자료를 복사해서 "
+            + "이 녀석에게 붙여넣기를 반복하니 한눈에 봐도 괜찮은 서류를 달칵 토해냈다. 세상에, AI가 사람을 구했어요.";
+    private static final LocalDateTime GUEST_SAMPLE_CREATED_AT = LocalDateTime.of(2026, 8, 1, 12, 0, 0);
+    private static final List<MyOpinionProjection> GUEST_SAMPLE_OPINIONS = List.of(
+            new MyOpinionProjection(1L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
+                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
+                    "애증의 관계", 5, GUEST_SAMPLE_CREATED_AT),
+            new MyOpinionProjection(2L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
+                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
+                    "정말… 사람 구했다", 3, GUEST_SAMPLE_CREATED_AT),
+            new MyOpinionProjection(3L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
+                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
+                    "지피티야 나랑 영원히 함께하자", 8, GUEST_SAMPLE_CREATED_AT)
+    );
+
     public Page<MyOpinionProjection> getMyOpinions(Long userId, Pageable pageable) {
+        if (userId == null) {
+            return new PageImpl<>(GUEST_SAMPLE_OPINIONS, pageable, GUEST_SAMPLE_OPINIONS.size());
+        }
         return opinionQueryRepository.findMyOpinions(userId, pageable);
     }
 

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -142,17 +142,14 @@ public interface UserApi {
     ResponseEntity<DataResponse<OnboardingCompleteResponse>> completeOnboarding();
 
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
-            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+            + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없으면(비로그인) 샘플 흔적 목록을 "
+            + "고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"COMMON_400_1\","
-                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
-            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
-                            value = "{\"type\":\"/api/users/me/opinions\",\"title\":\"AUTH_401_1\","
-                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+                                    + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}")))
     })
     ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -96,7 +96,7 @@ public class UserController implements UserApi {
     public ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
         return ResponseEntity.ok(DataResponse.from(UserMapper.toMyOpinionListResponse(
                 opinionService.getMyOpinions(currentUserId, pageable(page, size)))));
     }

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -266,6 +266,18 @@ class BookServiceTest {
     }
 
     @Test
+    @DisplayName("비로그인 사용자가 내 서재를 조회하면 리포지토리 대신 고정 샘플 도서 1건을 반환한다")
+    void getMyLibraryBooksReturnsSampleWhenGuest() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(null, pageable, OpinionCountScope.ALL);
+
+        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent().get(0).bookId()).isEqualTo(18L);
+        assertThat(results.getContent().get(0).title()).isEqualTo("빵충 사육 준수 사항");
+    }
+
+    @Test
     @DisplayName("로그인한 사용자가 도서 상세를 조회하면 myStatus/myCurrentPage를 함께 반환한다")
     void getBookDetailIncludesMyStatusWhenLoggedIn() {
         BookDetailProjection projection = new BookDetailProjection(1L, "책1", "작가", "출판사", 300, "cover", 5, 10);

--- a/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/BookControllerTest.java
@@ -192,7 +192,7 @@ class BookControllerTest {
     @Test
     @DisplayName("내 서재 도서 목록을 요청하면 현재 사용자 기준, opinionCountScope 기본값 ALL로 조회한다")
     void getMyLibraryBooks() throws Exception {
-        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(currentUserProvider.findCurrentUserId()).willReturn(java.util.Optional.of(1L));
         given(bookService.getMyLibraryBooks(eq(1L), any(Pageable.class), eq(OpinionCountScope.ALL))).willReturn(
                 new PageImpl<>(List.of(new BookActivityProjection(1L, "제목", "작가", "출판사", "cover", 3, 7)),
                         DEFAULT_PAGEABLE, 1));
@@ -207,7 +207,7 @@ class BookControllerTest {
     @Test
     @DisplayName("내 서재 도서 목록 조회 시 opinionCountScope=MINE을 지정하면 그대로 서비스에 전달한다")
     void getMyLibraryBooksWithMineScope() throws Exception {
-        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(currentUserProvider.findCurrentUserId()).willReturn(java.util.Optional.of(1L));
         given(bookService.getMyLibraryBooks(eq(1L), any(Pageable.class), eq(OpinionCountScope.MINE))).willReturn(
                 new PageImpl<>(List.of(new BookActivityProjection(1L, "제목", "작가", "출판사", "cover", 3, 2)),
                         DEFAULT_PAGEABLE, 1));
@@ -218,13 +218,16 @@ class BookControllerTest {
     }
 
     @Test
-    @DisplayName("인증 없이 내 서재 도서 목록을 요청하면 401 에러가 발생한다")
-    void getMyLibraryBooksFailsWhenUnauthenticated() throws Exception {
-        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+    @DisplayName("인증 없이 내 서재 도서 목록을 요청하면 샘플 도서 목록을 반환한다")
+    void getMyLibraryBooksReturnsSampleWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(java.util.Optional.empty());
+        given(bookService.getMyLibraryBooks(isNull(), any(Pageable.class), eq(OpinionCountScope.ALL))).willReturn(
+                new PageImpl<>(List.of(new BookActivityProjection(18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
+                        "cover", 13, 17)), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/books/my-library"))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].bookId").value(18));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -285,6 +285,17 @@ class OpinionServiceTest {
     }
 
     @Test
+    @DisplayName("비로그인 사용자가 내가 남긴 흔적 목록을 조회하면 QueryRepository 대신 고정 샘플 3건을 반환한다")
+    void getMyOpinionsReturnsSampleWhenGuest() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, pageable);
+
+        assertThat(results.getTotalElements()).isEqualTo(3);
+        assertThat(results.getContent()).allMatch(o -> o.bookId().equals(18L) && o.pageNumber() == 33);
+    }
+
+    @Test
     @DisplayName("좋아요 누른 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
     void getLikedOpinionsReturnsPageFromQueryRepository() {
         Pageable pageable = PageRequest.of(0, 20);

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -28,6 +28,7 @@ import com.nexters.palang.global.security.CurrentUserProvider;
 import com.nexters.palang.global.security.LoginRequiredException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -267,7 +268,7 @@ class UserControllerTest {
     @Test
     @DisplayName("내가 남긴 흔적 목록을 조회한다")
     void getMyOpinions() throws Exception {
-        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.of(1L));
         MyOpinionProjection projection = new MyOpinionProjection(
                 1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
         given(opinionService.getMyOpinions(eq(1L), any())).willReturn(
@@ -278,6 +279,21 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1))
                 .andExpect(jsonPath("$.data.opinions[0].bookTitle").value("책 제목"))
                 .andExpect(jsonPath("$.data.opinions[0].author").value("작가"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 내가 남긴 흔적 목록을 요청하면 샘플 흔적 목록을 반환한다")
+    void getMyOpinionsReturnsSampleWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.empty());
+        MyOpinionProjection projection = new MyOpinionProjection(
+                1L, 18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "cover", 1L, "인용문", 33, "애증의 관계", 5,
+                LocalDateTime.now());
+        given(opinionService.getMyOpinions(eq((Long) null), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/opinions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].bookId").value(18));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #119
- Close #120

## 🚀 개요
홈/마이페이지에서 실제로 쓰이는 `GET /api/books/my-library`와 `GET /api/users/me/opinions`가 비로그인 사용자를 401로 막고 있어, 로그인 없이도 미리보기가 가능하도록 두 API에 비로그인 샘플 응답 분기를 추가했다. 더 이상 사용하지 않는 `GET /api/home/books`(홈 캐러셀)는 로직 변경 없이 Swagger 문서에만 사용 중단 안내를 추가했다.

## 📄 작업 내용
- `GET /api/home/books`: Swagger `deprecated=true` + "더 이상 사용하지 않음" 설명 추가 (로직 변경 없음)
- `GET /api/books/my-library`: 로그인 필수(401) → 비로그인 허용
  - 로그인: 기존 로직 그대로 (내가 흔적을 남긴 도서 목록)
  - 비로그인: 실존 도서(bookId=18, 빵충 사육 준수 사항, 실제 메타데이터) 1건을 고정 샘플로 반환
- `GET /api/users/me/opinions`: 로그인 필수(401) → 비로그인 허용
  - 로그인: 기존 로직 그대로
  - 비로그인: 기획 확정 샘플 흔적 3건("애증의 관계"/"정말… 사람 구했다"/"지피티야 나랑 영원히 함께하자", 33p 인용문) 고정 반환
- 두 컨트롤러 모두 `CurrentUserProvider.getCurrentUserId()` → `findCurrentUserId().orElse(null)`로 교체 (도서 상세 API #114에서 쓰인 Soft Authentication 패턴 재사용)
- 관련 Controller/Service 테스트에 비로그인 케이스 추가, 기존 401 단위 테스트는 샘플 응답 검증으로 교체

## 📸 스크린샷 / 테스트 결과 (선택)
`./gradlew test --tests BookControllerTest --tests BookServiceTest --tests UserControllerTest --tests OpinionServiceTest` 통과 (20/20, 19/19, 18/18, 19/19). 전체 `./gradlew test`는 로컬 Redis 미기동으로 인한 기존 `AladinBookApiClientCacheTest` 3건만 실패(본 PR과 무관, 미수정 파일).

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 비로그인 샘플 도서/의견 내용을 서비스 코드에 상수로 하드코딩했는데, 이 방식이 맞는지 (추후 샘플 내용이 자주 바뀔 가능성이 있다면 설정값이나 DB로 빼는 게 나을 수도 있음)
- `/api/home/books`를 코드에서 완전히 제거하지 않고 deprecated 표시만 남겨둔 것이 맞는 방향인지
