### PR TITLE
Feat/#123 내 흔적/좋아요 목록 도서 필터 및 좋아요 작성자 닉네임 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookOptionProjection.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookOptionProjection.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.book.application;
+
+public record BookOptionProjection(
+        Long bookId,
+        String title
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/application/LikedOpinionProjection.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/LikedOpinionProjection.java
@@ -6,11 +6,13 @@ public record LikedOpinionProjection(
         Long opinionId,
         Long bookId,
         String bookTitle,
+        String author,
         String bookCoverImageUrl,
         Long passageId,
         String quotedText,
         int pageNumber,
         String content,
+        String nickname,
         int likeCount,
         LocalDateTime createdAt,
         LocalDateTime likedAt

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.opinion.application;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.common.error.BookErrorCode;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
@@ -148,15 +149,23 @@ public class OpinionService {
                     "지피티야 나랑 영원히 함께하자", 8, GUEST_SAMPLE_CREATED_AT)
     );
 
-    public Page<MyOpinionProjection> getMyOpinions(Long userId, Pageable pageable) {
+    public Page<MyOpinionProjection> getMyOpinions(Long userId, Long bookId, Pageable pageable) {
         if (userId == null) {
-            return new PageImpl<>(GUEST_SAMPLE_OPINIONS, pageable, GUEST_SAMPLE_OPINIONS.size());
+            List<MyOpinionProjection> guestSample = bookId == null || bookId.equals(18L)
+                    ? GUEST_SAMPLE_OPINIONS
+                    : List.of();
+            return new PageImpl<>(guestSample, pageable, guestSample.size());
         }
-        return opinionQueryRepository.findMyOpinions(userId, pageable);
+        return opinionQueryRepository.findMyOpinions(userId, bookId, pageable);
     }
 
-    public Page<LikedOpinionProjection> getLikedOpinions(Long userId, Pageable pageable) {
-        return opinionQueryRepository.findLikedOpinions(userId, pageable);
+    public Page<LikedOpinionProjection> getLikedOpinions(Long userId, Long bookId, Pageable pageable) {
+        return opinionQueryRepository.findLikedOpinions(userId, bookId, pageable);
+    }
+
+    // 좋아요 관리 화면의 "전체 책 보기" 드롭다운: 내가 좋아요를 누른 흔적이 있는 도서 목록.
+    public List<BookOptionProjection> getLikedBookOptions(Long userId) {
+        return opinionQueryRepository.findLikedBookOptions(userId);
     }
 
     public long getMyOpinionCount(Long userId) {

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.block.domain.QUserBlock;
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.comment.domain.QComment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
@@ -89,10 +90,12 @@ public class OpinionQueryRepository {
         return new OrderSpecifier<?>[]{opinion.createdAt.desc(), opinion.id.desc()};
     }
 
-    public Page<MyOpinionProjection> findMyOpinions(Long userId, Pageable pageable) {
+    public Page<MyOpinionProjection> findMyOpinions(Long userId, Long bookId, Pageable pageable) {
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
         QBook book = QBook.book;
+
+        BooleanExpression bookFilter = bookId != null ? book.id.eq(bookId) : null;
 
         List<MyOpinionProjection> content = queryFactory
                 .select(Projections.constructor(MyOpinionProjection.class,
@@ -102,7 +105,7 @@ public class OpinionQueryRepository {
                 .from(opinion)
                 .join(opinion.passage, passage)
                 .join(passage.book, book)
-                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), bookFilter)
                 .orderBy(opinion.createdAt.desc(), opinion.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -111,29 +114,35 @@ public class OpinionQueryRepository {
         Long total = queryFactory
                 .select(opinion.count())
                 .from(opinion)
-                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull())
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), bookFilter)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     // liked_at(=OpinionLike.createdAt) 최신순. idx_likes_user_created(user_id, created_at) 인덱스와 정합.
-    public Page<LikedOpinionProjection> findLikedOpinions(Long userId, Pageable pageable) {
+    public Page<LikedOpinionProjection> findLikedOpinions(Long userId, Long bookId, Pageable pageable) {
         QOpinionLike opinionLike = QOpinionLike.opinionLike;
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
         QBook book = QBook.book;
+        QUser author = QUser.user;
+
+        BooleanExpression bookFilter = bookId != null ? book.id.eq(bookId) : null;
 
         List<LikedOpinionProjection> content = queryFactory
                 .select(Projections.constructor(LikedOpinionProjection.class,
-                        opinion.id, book.id, book.title, book.coverImageUrl,
+                        opinion.id, book.id, book.title, book.author, book.coverImageUrl,
                         passage.id, passage.quotedText, passage.pageNumber,
-                        opinion.content, opinion.likeCount, opinion.createdAt, opinionLike.createdAt))
+                        opinion.content, author.nickname, opinion.likeCount, opinion.createdAt, opinionLike.createdAt))
                 .from(opinionLike)
                 .join(opinionLike.opinion, opinion)
                 .join(opinion.passage, passage)
                 .join(passage.book, book)
-                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .join(opinion.user, author)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull(), bookFilter)
                 .orderBy(opinionLike.createdAt.desc(), opinionLike.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -143,9 +152,30 @@ public class OpinionQueryRepository {
                 .select(opinionLike.count())
                 .from(opinionLike)
                 .join(opinionLike.opinion, opinion)
-                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull(), bookFilter)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // 좋아요·스포일러 관리 화면 공용 "전체 책 보기" 드롭다운: 활동(좋아요/스포일러) 최신순으로 중복 없이 책만 나열.
+    public List<BookOptionProjection> findLikedBookOptions(Long userId) {
+        QOpinionLike opinionLike = QOpinionLike.opinionLike;
+        QOpinion opinion = QOpinion.opinion;
+        QPassage passage = QPassage.passage;
+        QBook book = QBook.book;
+
+        return queryFactory
+                .select(Projections.constructor(BookOptionProjection.class, book.id, book.title))
+                .from(opinionLike)
+                .join(opinionLike.opinion, opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .groupBy(book.id, book.title)
+                .orderBy(opinionLike.createdAt.max().desc())
+                .fetch();
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -1,5 +1,6 @@
 package com.nexters.palang.domain.passage.application;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.common.error.BookErrorCode;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
@@ -44,6 +45,11 @@ public class PassageService {
     // 내가 남긴 대목 목록: bookId 미지정 시 전체 도서, spoilerOnly=true 시 스포일러 대목만.
     public Page<MyPassageProjection> getMyPassages(Long userId, Long bookId, boolean spoilerOnly, Pageable pageable) {
         return passageQueryRepository.findMyPassages(userId, bookId, spoilerOnly, pageable);
+    }
+
+    // 스포일러 관리 화면의 "전체 책 보기" 드롭다운: 내가 스포일러로 남긴 대목이 있는 도서 목록.
+    public List<BookOptionProjection> getSpoilerBookOptions(Long userId) {
+        return passageQueryRepository.findSpoilerBookOptions(userId);
     }
 
     public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -1,5 +1,7 @@
 package com.nexters.palang.domain.passage.infrastructure;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
+import com.nexters.palang.domain.book.domain.QBook;
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
@@ -109,5 +111,24 @@ public class PassageQueryRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    // 좋아요·스포일러 관리 화면 공용 "전체 책 보기" 드롭다운: 내가 스포일러로 남긴 대목이 있는 도서 목록.
+    // 소유 기준은 findMyPassages와 동일하게 흔적을 남긴 사용자(opinion.user) 기준.
+    public List<BookOptionProjection> findSpoilerBookOptions(Long userId) {
+        QOpinion opinion = QOpinion.opinion;
+        QPassage passage = QPassage.passage;
+        QBook book = QBook.book;
+
+        return queryFactory
+                .select(Projections.constructor(BookOptionProjection.class, book.id, book.title))
+                .from(opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
+                        passage.isSpoiler.isTrue())
+                .groupBy(book.id, book.title)
+                .orderBy(opinion.createdAt.max().desc())
+                .fetch();
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -1,9 +1,12 @@
 package com.nexters.palang.domain.user.application;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.presentation.dto.BookOptionResponse;
+import com.nexters.palang.domain.user.presentation.dto.FilterBooksResponse;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
@@ -12,6 +15,7 @@ import com.nexters.palang.domain.user.presentation.dto.MyOpinionResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyPassageListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyPassageResponse;
 import com.nexters.palang.global.common.response.PageInfo;
+import java.util.List;
 import org.springframework.data.domain.Page;
 
 public final class UserMapper {
@@ -39,14 +43,23 @@ public final class UserMapper {
 
     public static LikedOpinionResponse toLikedOpinionResponse(LikedOpinionProjection projection) {
         return new LikedOpinionResponse(
-                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.bookCoverImageUrl(),
-                projection.passageId(), projection.quotedText(), projection.pageNumber(),
-                projection.content(), projection.likeCount(), projection.createdAt(), projection.likedAt());
+                projection.opinionId(), projection.bookId(), projection.bookTitle(), projection.author(),
+                projection.bookCoverImageUrl(), projection.passageId(), projection.quotedText(), projection.pageNumber(),
+                projection.content(), projection.nickname(), projection.likeCount(), projection.createdAt(),
+                projection.likedAt());
     }
 
     public static LikedOpinionListResponse toLikedOpinionListResponse(Page<LikedOpinionProjection> projections) {
         return new LikedOpinionListResponse(
                 projections.map(UserMapper::toLikedOpinionResponse).getContent(), PageInfo.from(projections));
+    }
+
+    public static BookOptionResponse toBookOptionResponse(BookOptionProjection projection) {
+        return new BookOptionResponse(projection.bookId(), projection.title());
+    }
+
+    public static FilterBooksResponse toFilterBooksResponse(List<BookOptionProjection> projections) {
+        return new FilterBooksResponse(projections.stream().map(UserMapper::toBookOptionResponse).toList());
     }
 
     public static MyPassageResponse toMyPassageResponse(MyPassageProjection projection) {

--- a/src/main/java/com/nexters/palang/domain/user/domain/BookFilterType.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/BookFilterType.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.user.domain;
+
+// 마이페이지 도서 필터 목록(#123): LIKE - 좋아요 관리, SPOILER - 스포일러 대목 관리 화면 공용 드롭다운.
+public enum BookFilterType {
+    LIKE,
+    SPOILER
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -1,5 +1,7 @@
 package com.nexters.palang.domain.user.presentation;
 
+import com.nexters.palang.domain.user.domain.BookFilterType;
+import com.nexters.palang.domain.user.presentation.dto.FilterBooksResponse;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
@@ -143,6 +145,7 @@ public interface UserApi {
     ResponseEntity<DataResponse<OnboardingCompleteResponse>> completeOnboarding();
 
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
+            + "bookId를 지정하면 해당 책의 흔적만 조회합니다(내 서재 책 상세 - 의견 탭). 생략하면 전체 책을 대상으로 합니다. "
             + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없으면(비로그인) 샘플 흔적 목록을 "
             + "고정 응답으로 반환합니다.")
     @ApiResponses({
@@ -153,11 +156,14 @@ public interface UserApi {
                                     + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}")))
     })
     ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
+            @Parameter(description = "책 ID (생략 시 전체 책 대상)") Long bookId,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
     @Operation(summary = "좋아요 누른 흔적 목록", description = "내가 좋아요를 누른 흔적을 좋아요 누른 순서대로(최신순) 조회합니다. "
+            + "bookId를 지정하면 해당 책의 좋아요만 조회합니다(내 서재 책 상세 - 좋아요 탭). "
+            + "생략하면 전체 책을 대상으로 합니다(마이페이지 좋아요 관리 - 전체 책 보기). "
             + "좋아요 취소는 이 API가 아니라 흔적 좋아요 토글 API가 담당합니다. "
             + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
@@ -172,8 +178,28 @@ public interface UserApi {
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
     })
     ResponseEntity<DataResponse<LikedOpinionListResponse>> getLikedOpinions(
+            @Parameter(description = "책 ID (생략 시 전체 책 대상)") Long bookId,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "도서 필터 목록", description = "좋아요 관리·스포일러 관리 화면의 \"전체 책 보기\" 드롭다운에 쓸 도서 목록입니다. "
+            + "type=LIKE면 내가 좋아요를 누른 흔적이 있는 도서를, type=SPOILER면 내가 스포일러로 남긴 대목이 있는 도서를 "
+            + "최근 활동순으로 중복 없이 반환합니다. 여기서 고른 bookId를 흔적/좋아요/대목 목록 API의 bookId 파라미터로 전달합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "type 누락/형식 오류 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/filter-books\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"'type' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/users/me/filter-books\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<FilterBooksResponse>> getFilterBooks(
+            @Parameter(description = "필터 종류 (LIKE: 좋아요 관리, SPOILER: 스포일러 대목 관리)", required = true) BookFilterType type
     );
 
     @Operation(summary = "내 대목 목록", description = "내가 흔적을 남긴 대목을 최신순으로 조회합니다. "

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -1,11 +1,14 @@
 package com.nexters.palang.domain.user.presentation;
 
 import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionService;
 import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.user.application.UserMapper;
 import com.nexters.palang.domain.user.application.UserService;
+import com.nexters.palang.domain.user.domain.BookFilterType;
 import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.presentation.dto.FilterBooksResponse;
 import com.nexters.palang.domain.user.presentation.dto.LikedOpinionListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MeResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyOpinionListResponse;
@@ -16,6 +19,7 @@ import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
 import com.nexters.palang.global.common.response.DataResponse;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -97,21 +101,33 @@ public class UserController implements UserApi {
     @Override
     @GetMapping("/api/users/me/opinions")
     public ResponseEntity<DataResponse<MyOpinionListResponse>> getMyOpinions(
+            @RequestParam(required = false) Long bookId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
         Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
         return ResponseEntity.ok(DataResponse.from(UserMapper.toMyOpinionListResponse(
-                opinionService.getMyOpinions(currentUserId, pageable(page, size)))));
+                opinionService.getMyOpinions(currentUserId, bookId, pageable(page, size)))));
     }
 
     @Override
     @GetMapping("/api/users/me/likes")
     public ResponseEntity<DataResponse<LikedOpinionListResponse>> getLikedOpinions(
+            @RequestParam(required = false) Long bookId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         return ResponseEntity.ok(DataResponse.from(UserMapper.toLikedOpinionListResponse(
-                opinionService.getLikedOpinions(currentUserId, pageable(page, size)))));
+                opinionService.getLikedOpinions(currentUserId, bookId, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/users/me/filter-books")
+    public ResponseEntity<DataResponse<FilterBooksResponse>> getFilterBooks(@RequestParam BookFilterType type) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        List<BookOptionProjection> books = type == BookFilterType.SPOILER
+                ? passageService.getSpoilerBookOptions(currentUserId)
+                : opinionService.getLikedBookOptions(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(UserMapper.toFilterBooksResponse(books)));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/BookOptionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/BookOptionResponse.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BookOptionResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String title
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/FilterBooksResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/FilterBooksResponse.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.domain.user.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record FilterBooksResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookOptionResponse> books
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/LikedOpinionResponse.java
@@ -7,11 +7,13 @@ public record LikedOpinionResponse(
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
         @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String author,
         @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
         @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.", requiredMode = Schema.RequiredMode.REQUIRED) String content,
+        @Schema(example = "책벌레", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
         @Schema(example = "5", requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
         @Schema(example = "2026-07-20T14:32:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
         @Schema(example = "2026-07-25T09:10:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime likedAt

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
@@ -277,9 +278,9 @@ class OpinionServiceTest {
         Page<MyOpinionProjection> expected = new PageImpl<>(
                 List.of(new MyOpinionProjection(1L, 10L, "제목", "작가", "cover", 100L, "발췌", 5, "흔적", 0, LocalDateTime.now())),
                 pageable, 1);
-        given(opinionQueryRepository.findMyOpinions(1L, pageable)).willReturn(expected);
+        given(opinionQueryRepository.findMyOpinions(1L, null, pageable)).willReturn(expected);
 
-        Page<MyOpinionProjection> results = opinionService.getMyOpinions(1L, pageable);
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(1L, null, pageable);
 
         assertThat(results).isEqualTo(expected);
     }
@@ -289,10 +290,20 @@ class OpinionServiceTest {
     void getMyOpinionsReturnsSampleWhenGuest() {
         Pageable pageable = PageRequest.of(0, 20);
 
-        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, pageable);
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, null, pageable);
 
         assertThat(results.getTotalElements()).isEqualTo(3);
         assertThat(results.getContent()).allMatch(o -> o.bookId().equals(18L) && o.pageNumber() == 33);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 다른 책 bookId로 조회하면 샘플이 아닌 빈 목록을 반환한다")
+    void getMyOpinionsReturnsEmptyWhenGuestFiltersOtherBook() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, 999L, pageable);
+
+        assertThat(results.getTotalElements()).isZero();
     }
 
     @Test
@@ -300,12 +311,23 @@ class OpinionServiceTest {
     void getLikedOpinionsReturnsPageFromQueryRepository() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<LikedOpinionProjection> expected = new PageImpl<>(
-                List.of(new LikedOpinionProjection(1L, 10L, "제목", "cover", 100L, "발췌", 5, "흔적", 0,
+                List.of(new LikedOpinionProjection(1L, 10L, "제목", "작가", "cover", 100L, "발췌", 5, "흔적", "닉네임", 0,
                         LocalDateTime.now(), LocalDateTime.now())),
                 pageable, 1);
-        given(opinionQueryRepository.findLikedOpinions(1L, pageable)).willReturn(expected);
+        given(opinionQueryRepository.findLikedOpinions(1L, null, pageable)).willReturn(expected);
 
-        Page<LikedOpinionProjection> results = opinionService.getLikedOpinions(1L, pageable);
+        Page<LikedOpinionProjection> results = opinionService.getLikedOpinions(1L, null, pageable);
+
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("좋아요 도서 필터 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
+    void getLikedBookOptionsReturnsResultFromQueryRepository() {
+        List<BookOptionProjection> expected = List.of(new BookOptionProjection(10L, "제목"));
+        given(opinionQueryRepository.findLikedBookOptions(1L)).willReturn(expected);
+
+        List<BookOptionProjection> results = opinionService.getLikedBookOptions(1L);
 
         assertThat(results).isEqualTo(expected);
     }

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.opinion.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.block.domain.UserBlock;
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
@@ -17,6 +18,7 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.global.config.JpaAuditingConfig;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -211,7 +213,7 @@ class OpinionQueryRepositoryTest {
         deleted.delete();
         opinion(other, passage(4), "다른 사람 흔적");
 
-        Page<MyOpinionProjection> results = opinionQueryRepository.findMyOpinions(me.getId(), PageRequest.of(0, 20));
+        Page<MyOpinionProjection> results = opinionQueryRepository.findMyOpinions(me.getId(), null, PageRequest.of(0, 20));
 
         assertThat(results.getContent()).extracting(MyOpinionProjection::opinionId)
                 .containsExactly(newer.getId(), older.getId());
@@ -221,7 +223,20 @@ class OpinionQueryRepositoryTest {
     }
 
     @Test
-    @DisplayName("좋아요 누른 흔적을 좋아요 순서(최신순)로 조회하고 삭제된 흔적의 좋아요는 제외한다")
+    @DisplayName("bookId를 지정하면 해당 책의 흔적만 조회한다")
+    void findMyOpinionsFiltersByBookId() {
+        Opinion inOtherBook = opinion(me, passage(other), "다른 책 흔적");
+        Opinion inTargetBook = opinion(me, passage(1), "대상 책 흔적");
+
+        Page<MyOpinionProjection> results = opinionQueryRepository.findMyOpinions(me.getId(), book.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(MyOpinionProjection::opinionId)
+                .containsExactly(inTargetBook.getId());
+        assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 흔적을 좋아요 순서(최신순)로 조회하고 삭제된 흔적의 좋아요는 제외하며, 흔적 작성자 닉네임/책 저자를 함께 반환한다")
     void findLikedOpinionsOrdersByLikedAtDescendingAndExcludesDeleted() {
         Opinion opinion1 = opinion(other, passage(1), "흔적1");
         Opinion opinion2 = opinion(other, passage(2), "흔적2");
@@ -233,19 +248,56 @@ class OpinionQueryRepositoryTest {
         deletedOpinion.delete();
         entityManager.persistAndFlush(deletedOpinion);
 
-        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), PageRequest.of(0, 20));
+        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), null, PageRequest.of(0, 20));
 
         assertThat(results.getContent()).extracting(LikedOpinionProjection::opinionId)
                 .containsExactly(opinion2.getId(), opinion1.getId());
+        assertThat(results.getContent()).extracting(LikedOpinionProjection::nickname)
+                .containsOnly(other.getNickname());
+        assertThat(results.getContent()).extracting(LikedOpinionProjection::author)
+                .containsOnly(book.getAuthor());
         assertThat(results.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("bookId를 지정하면 해당 책의 좋아요만 조회한다")
+    void findLikedOpinionsFiltersByBookId() {
+        Opinion inOtherBook = opinion(other, passage(other), "다른 책 흔적");
+        Opinion inTargetBook = opinion(other, passage(1), "대상 책 흔적");
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inOtherBook).build());
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inTargetBook).build());
+
+        Page<LikedOpinionProjection> results =
+                opinionQueryRepository.findLikedOpinions(me.getId(), book.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(LikedOpinionProjection::opinionId)
+                .containsExactly(inTargetBook.getId());
+        assertThat(results.getTotalElements()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("좋아요가 없으면 빈 목록을 반환한다")
     void findLikedOpinionsReturnsEmptyWhenNoLikes() {
-        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), PageRequest.of(0, 20));
+        Page<LikedOpinionProjection> results = opinionQueryRepository.findLikedOpinions(me.getId(), null, PageRequest.of(0, 20));
 
         assertThat(results.getContent()).isEmpty();
         assertThat(results.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("좋아요를 누른 도서 목록을 최근 좋아요순으로 중복 없이 반환한다")
+    void findLikedBookOptionsReturnsDistinctBooksOrderedByLatestLike() {
+        Opinion inTargetBook1 = opinion(other, passage(1), "흔적1");
+        Opinion inTargetBook2 = opinion(other, passage(2), "흔적2");
+        Opinion inOtherBook = opinion(other, passage(other), "다른 책 흔적");
+
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inOtherBook).build());
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inTargetBook1).build());
+        entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inTargetBook2).build());
+
+        List<BookOptionProjection> results = opinionQueryRepository.findLikedBookOptions(me.getId());
+
+        assertThat(results).extracting(BookOptionProjection::bookId)
+                .containsExactly(book.getId(), inOtherBook.getPassage().getBook().getId());
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
@@ -101,5 +102,16 @@ class PassageServiceTest {
                 passageService.getMergedDecorationsByPassageId(List.of(passage));
 
         assertThat(result.get(1L)).containsExactly(candidate);
+    }
+
+    @Test
+    @DisplayName("스포일러 도서 필터 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
+    void getSpoilerBookOptionsReturnsResultFromQueryRepository() {
+        List<BookOptionProjection> expected = List.of(new BookOptionProjection(10L, "책 제목"));
+        given(passageQueryRepository.findSpoilerBookOptions(1L)).willReturn(expected);
+
+        List<BookOptionProjection> result = passageService.getSpoilerBookOptions(1L);
+
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.passage.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.application.MyPassageProjection;
@@ -282,5 +283,21 @@ class PassageQueryRepositoryTest {
 
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("스포일러로 흔적을 남긴 도서 목록을 최근 활동순으로 중복 없이 반환한다")
+    void findSpoilerBookOptionsReturnsDistinctBooksWithSpoilerOpinion() {
+        User writer = user("writer-12");
+        Book targetBook = book("대상 책");
+        Book noSpoilerBook = book("스포일러 없는 책");
+        Passage spoiler = passage(targetBook, writer, 1, true);
+        Passage notSpoiler = passage(noSpoilerBook, writer, 1, false);
+        entityManager.persistAndFlush(Opinion.builder().passage(spoiler).user(writer).content("흔적1").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(notSpoiler).user(writer).content("흔적2").build());
+
+        List<BookOptionProjection> results = passageQueryRepository.findSpoilerBookOptions(writer.getId());
+
+        assertThat(results).extracting(BookOptionProjection::bookId).containsExactly(targetBook.getId());
     }
 }

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.user.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.auth.application.AuthService;
+import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.opinion.application.LikedOpinionProjection;
 import com.nexters.palang.domain.opinion.application.MyOpinionProjection;
 import com.nexters.palang.domain.opinion.application.OpinionService;
@@ -276,7 +278,7 @@ class UserControllerTest {
         given(currentUserProvider.findCurrentUserId()).willReturn(Optional.of(1L));
         MyOpinionProjection projection = new MyOpinionProjection(
                 1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
-        given(opinionService.getMyOpinions(eq(1L), any())).willReturn(
+        given(opinionService.getMyOpinions(eq(1L), isNull(), any())).willReturn(
                 new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/opinions"))
@@ -287,13 +289,27 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("bookId를 지정해 내가 남긴 흔적 목록을 조회한다")
+    void getMyOpinionsFiltersByBookId() throws Exception {
+        given(currentUserProvider.findCurrentUserId()).willReturn(Optional.of(1L));
+        MyOpinionProjection projection = new MyOpinionProjection(
+                1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0, LocalDateTime.now());
+        given(opinionService.getMyOpinions(eq(1L), eq(10L), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/opinions").param("bookId", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].bookId").value(10));
+    }
+
+    @Test
     @DisplayName("인증 없이 내가 남긴 흔적 목록을 요청하면 샘플 흔적 목록을 반환한다")
     void getMyOpinionsReturnsSampleWhenUnauthenticated() throws Exception {
         given(currentUserProvider.findCurrentUserId()).willReturn(Optional.empty());
         MyOpinionProjection projection = new MyOpinionProjection(
                 1L, 18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "cover", 1L, "인용문", 33, "애증의 관계", 5,
                 LocalDateTime.now());
-        given(opinionService.getMyOpinions(eq((Long) null), any())).willReturn(
+        given(opinionService.getMyOpinions(eq((Long) null), isNull(), any())).willReturn(
                 new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/opinions"))
@@ -306,14 +322,65 @@ class UserControllerTest {
     void getLikedOpinions() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
         LikedOpinionProjection projection = new LikedOpinionProjection(
-                1L, 10L, "책 제목", "cover", 100L, "발췌 문장", 5, "흔적 내용", 0,
+                1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", "닉네임", 0,
                 LocalDateTime.now(), LocalDateTime.now());
-        given(opinionService.getLikedOpinions(eq(1L), any())).willReturn(
+        given(opinionService.getLikedOpinions(eq(1L), isNull(), any())).willReturn(
                 new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/likes"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1));
+                .andExpect(jsonPath("$.data.opinions[0].opinionId").value(1))
+                .andExpect(jsonPath("$.data.opinions[0].nickname").value("닉네임"))
+                .andExpect(jsonPath("$.data.opinions[0].author").value("작가"));
+    }
+
+    @Test
+    @DisplayName("bookId를 지정해 좋아요 누른 흔적 목록을 조회한다")
+    void getLikedOpinionsFiltersByBookId() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        LikedOpinionProjection projection = new LikedOpinionProjection(
+                1L, 10L, "책 제목", "작가", "cover", 100L, "발췌 문장", 5, "흔적 내용", "닉네임", 0,
+                LocalDateTime.now(), LocalDateTime.now());
+        given(opinionService.getLikedOpinions(eq(1L), eq(10L), any())).willReturn(
+                new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/users/me/likes").param("bookId", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.opinions[0].bookId").value(10));
+    }
+
+    @Test
+    @DisplayName("좋아요 도서 필터 목록을 조회한다")
+    void getFilterBooksForLike() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(opinionService.getLikedBookOptions(1L)).willReturn(
+                List.of(new BookOptionProjection(10L, "책 제목")));
+
+        mockMvc.perform(get("/api/users/me/filter-books").param("type", "LIKE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].bookId").value(10))
+                .andExpect(jsonPath("$.data.books[0].title").value("책 제목"));
+    }
+
+    @Test
+    @DisplayName("스포일러 도서 필터 목록을 조회한다")
+    void getFilterBooksForSpoiler() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(passageService.getSpoilerBookOptions(1L)).willReturn(
+                List.of(new BookOptionProjection(20L, "다른 책")));
+
+        mockMvc.perform(get("/api/users/me/filter-books").param("type", "SPOILER"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.books[0].bookId").value(20));
+    }
+
+    @Test
+    @DisplayName("type 파라미터가 없으면 400을 반환한다")
+    void getFilterBooksFailsWhenTypeMissing() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(get("/api/users/me/filter-books"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #123

## 🚀 개요
내 서재 책 상세(의견/좋아요/스포일러 탭)와 마이페이지 좋아요 관리 화면이 공유하는 흔적/좋아요 목록 API에 도서 필터를 추가하고, 좋아요 목록에서 흔적 작성자를 식별할 수 있도록 닉네임을 추가한다. 좋아요·스포일러 관리 화면 공용 "전체 책 보기" 드롭다운을 위한 신규 엔드포인트도 추가한다.

## 📄 작업 내용
- `GET /api/users/me/opinions`에 `bookId`(선택) 쿼리 파라미터 추가 — 지정 시 해당 도서의 흔적만 반환(비로그인 샘플 응답도 동일하게 필터링)
- `GET /api/users/me/likes`에 `bookId`(선택) 쿼리 파라미터 추가
- `LikedOpinionResponse`에 `author`(책 저자, `MyOpinionResponse`와 정합성 맞춤)와 `nickname`(흔적 작성자) 필드 추가
- `GET /api/users/me/filter-books?type={LIKE|SPOILER}` 신규 엔드포인트 추가
  - `LIKE`: 내가 좋아요를 누른 흔적이 있는 도서, `SPOILER`: 내가 스포일러로 남긴 대목이 있는 도서를 최근 활동순으로 중복 없이 반환
  - 좋아요 관리/스포일러 관리 화면이 공유하는 단일 엔드포인트로 처리(중복 구현 없음)
- `OpinionQueryRepository`, `PassageQueryRepository`에 위 조회를 위한 QueryDSL 메서드 추가

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/users/me/opinions?bookId=` | 내 흔적 목록(도서 필터 추가) |
| GET | `/api/users/me/likes?bookId=` | 내 좋아요 목록(도서 필터 + author/nickname 추가) |
| GET | `/api/users/me/filter-books?type=` | 도서 필터 드롭다운용 목록(신규) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 확인(신규/기존 456개 테스트 중 3개 실패는 로컬 Redis 미기동으로 인한 `AladinBookApiClientCacheTest`로, 이번 변경과 무관)
- `bootRun --spring.profiles.active=local` 기동 후 `/v3/api-docs`로 신규/변경 스키마(`LikedOpinionResponse`, `FilterBooksResponse`, `BookOptionResponse`) 및 쿼리 파라미터 required 여부 직접 확인
- `curl /api/users/me/opinions?bookId=18`(비로그인 샘플), `curl /api/users/me/filter-books`(type 누락 시 400) 동작 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `filter-books` 응답의 정렬 기준(활동 최신순)과 개수 상한(현재 미적용, 전체 반환)이 이슈에서 프론트와 확정되지 않은 상태로 남아있습니다. 시안 기준 4개까지만 노출한다면 서버에서 상한을 둘지, 프론트에서 자를지 확인 부탁드립니다.
- `SPOILER` 타입의 도서 소유 기준을 `findMyPassages`와 동일하게 "흔적을 남긴 사용자(opinion.user)" 기준으로 잡았습니다(최초 대목 생성자 기준이 아님). 기존 스포일러 대목 API(#118)와의 일관성 관점에서 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 내 흔적 및 좋아요 흔적을 특정 책 기준으로 필터링할 수 있습니다.
  * 좋아요 또는 스포일러 활동이 있는 책 목록을 활동 유형별로 조회할 수 있습니다.
  * 좋아요 흔적에 책 저자와 작성자 닉네임 정보가 표시됩니다.
* **개선**
  * 비로그인 사용자의 책별 흔적 조회 결과가 올바르게 제공됩니다.
  * 책 목록과 활동 결과가 중복 없이 최신 활동 순으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->