### PR TITLE
Feat/#128 대목 스포일러 설정 변경 API 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -13,6 +13,9 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
     // 흔적 삭제 시 그 대목에 남은 다른 살아있는 흔적이 있는지 확인하기 위함 (없으면 대목도 함께 삭제).
     boolean existsByPassageIdAndDeletedAtIsNullAndIdNot(Long passageId, Long id);
 
+    // 대목 소유자 판정(findMyPassages와 동일 기준): 이 대목에 흔적을 남긴 사용자인지 확인.
+    boolean existsByPassageIdAndUserIdAndDeletedAtIsNull(Long passageId, Long userId);
+
     // open-in-view: false 환경에서 컨트롤러 단 응답 매핑이 opinion.getUser()/getDecorations()를
     // 참조하므로 트랜잭션 안에서 미리 로딩해야 LazyInitializationException을 피할 수 있다.
     @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations where o.id = :id")

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -8,8 +8,12 @@ import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.decoration.application.DecorationMergeSelector;
 import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.common.error.PassageErrorCode;
+import com.nexters.palang.domain.passage.common.error.PassageException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +31,8 @@ public class PassageService {
     private final PassageQueryRepository passageQueryRepository;
     private final DecorationQueryRepository decorationQueryRepository;
     private final BookRepository bookRepository;
+    private final PassageRepository passageRepository;
+    private final OpinionRepository opinionRepository;
 
     // 대목/흔적 보기 페이지 네비게이션: 발췌된 페이지 번호 목록 (스포일러 포함) + 헤더용 책 정보.
     public PageNumbersResult getPageNumbers(Long bookId, Pageable pageable) {
@@ -50,6 +56,22 @@ public class PassageService {
     // 스포일러 관리 화면의 "전체 책 보기" 드롭다운: 내가 스포일러로 남긴 대목이 있는 도서 목록.
     public List<BookOptionProjection> getSpoilerBookOptions(Long userId) {
         return passageQueryRepository.findSpoilerBookOptions(userId);
+    }
+
+    // 대목 스포일러 설정 변경: 소유 기준은 findMyPassages와 동일하게 이 대목에 흔적을 남긴 사용자.
+    // false→true 재설정도 허용한다(양방향 전환).
+    @Transactional
+    public Passage updateSpoiler(Long passageId, Long userId, boolean isSpoiler) {
+        Passage passage = passageRepository.findById(passageId)
+                .orElseThrow(() -> new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
+        if (passage.isDeleted()) {
+            throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
+        }
+        if (!opinionRepository.existsByPassageIdAndUserIdAndDeletedAtIsNull(passageId, userId)) {
+            throw new PassageException(PassageErrorCode.PASSAGE_FORBIDDEN);
+        }
+        passage.changeSpoiler(isSpoiler);
+        return passage;
     }
 
     public Map<Long, List<DecorationMergeCandidate>> getMergedDecorationsByPassageId(List<Passage> passages) {

--- a/src/main/java/com/nexters/palang/domain/passage/common/error/PassageErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/passage/common/error/PassageErrorCode.java
@@ -12,6 +12,7 @@ public enum PassageErrorCode implements BaseErrorCode {
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "PASSAGE_400_1", "이미지 파일만 업로드할 수 있습니다."),
     PASSAGE_BOOK_MISMATCH(HttpStatus.BAD_REQUEST, "PASSAGE_400_2", "선택한 대목이 지정한 도서와 일치하지 않습니다."),
     PASSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "PASSAGE_404_1", "해당 대목을 찾을 수 없습니다."),
+    PASSAGE_FORBIDDEN(HttpStatus.FORBIDDEN, "PASSAGE_403_1", "본인이 흔적을 남긴 대목만 스포일러 설정을 변경할 수 있습니다."),
     OCR_TEXT_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "PASSAGE_422_1", "이미지에서 텍스트를 인식하지 못했습니다."),
     OCR_REQUEST_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "PASSAGE_503_1", "OCR 처리 중 오류가 발생했습니다."),
     ;

--- a/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
+++ b/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
@@ -79,6 +79,10 @@ public class Passage extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void changeSpoiler(boolean isSpoiler) {
+        this.isSpoiler = isSpoiler;
+    }
+
     public boolean isDeleted() {
         return this.deletedAt != null;
     }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -68,6 +69,16 @@ public class PassageController implements PassageControllerDocs {
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
         PageNumbersResult result = passageService.getPageNumbers(bookId, pageable(page, size));
         return DataResponse.from(PassageResponse.PageNumbers.from(result));
+    }
+
+    @Override
+    @PatchMapping("/api/passages/{passageId}/spoiler")
+    public DataResponse<PassageResponse.SpoilerUpdate> updateSpoiler(
+            @PathVariable Long passageId,
+            @Valid @RequestBody PassageRequest.UpdateSpoiler request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Passage passage = passageService.updateSpoiler(passageId, currentUserId, request.isSpoiler());
+        return DataResponse.from(PassageResponse.SpoilerUpdate.from(passage));
     }
 
     @Override

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -45,6 +45,33 @@ public interface PassageControllerDocs {
             @RequestPart("image") MultipartFile image
     );
 
+    @Operation(summary = "대목 스포일러 설정 변경", description = "대목의 스포일러 표기를 변경합니다(해제 뿐 아니라 재설정도 허용). "
+            + "권한은 이 대목에 흔적을 남긴 사용자만 가집니다(최초 생성자가 아니어도 병합된 대목에 흔적을 남겼으면 가능). "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "isSpoiler 누락 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/spoiler\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"isSpoiler는 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "AUTH_401_1: 로그인이 필요합니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/spoiler\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "PASSAGE_403_1: 본인이 흔적을 남긴 대목만 스포일러 설정을 변경할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/spoiler\",\"title\":\"PASSAGE_403_1\","
+                                    + "\"status\":403,\"detail\":\"본인이 흔적을 남긴 대목만 스포일러 설정을 변경할 수 있습니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "PASSAGE_404_1: 해당 대목을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/spoiler\",\"title\":\"PASSAGE_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}")))
+    })
+    DataResponse<PassageResponse.SpoilerUpdate> updateSpoiler(
+            @Parameter(description = "대목 ID", required = true) Long passageId,
+            @Valid @RequestBody PassageRequest.UpdateSpoiler request
+    );
+
     @Operation(summary = "유사 문장 후보 조회", description = "저장 전 같은 도서의 인접 페이지(±1)에서 정규화 해시가 같은 대목 후보를 조회합니다. "
             + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
@@ -9,6 +9,13 @@ import jakarta.validation.constraints.Size;
 
 public class PassageRequest {
 
+    public record UpdateSpoiler(
+            @NotNull(message = "isSpoiler는 필수입니다.")
+            @Schema(example = "false")
+            Boolean isSpoiler
+    ) {
+    }
+
     public record SimilarCheck(
             @NotNull(message = "도서 ID는 필수입니다.")
             @Schema(example = "1")

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/response/PassageResponse.java
@@ -15,6 +15,15 @@ import org.springframework.data.domain.Page;
 
 public class PassageResponse {
 
+    public record SpoilerUpdate(
+            @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+            @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isSpoiler
+    ) {
+        public static SpoilerUpdate from(Passage passage) {
+            return new SpoilerUpdate(passage.getId(), passage.isSpoiler());
+        }
+    }
+
     public record SimilarCandidates(
             @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<SimilarCandidate> passages
     ) {

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -10,8 +10,11 @@ import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.common.error.PassageException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -37,11 +40,18 @@ class PassageServiceTest {
     @Mock
     private BookRepository bookRepository;
 
+    @Mock
+    private PassageRepository passageRepository;
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
     private PassageService passageService;
 
     @BeforeEach
     void setUp() {
-        passageService = new PassageService(passageQueryRepository, decorationQueryRepository, bookRepository);
+        passageService = new PassageService(
+                passageQueryRepository, decorationQueryRepository, bookRepository, passageRepository, opinionRepository);
     }
 
     private Passage passage(Long id) {
@@ -113,5 +123,61 @@ class PassageServiceTest {
         List<BookOptionProjection> result = passageService.getSpoilerBookOptions(1L);
 
         assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("이 대목에 흔적을 남긴 사용자는 스포일러 설정을 변경할 수 있다")
+    void updateSpoilerChangesFlagWhenUserHasOpinionOnPassage() {
+        Passage passage = passage(1L);
+        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+        given(opinionRepository.existsByPassageIdAndUserIdAndDeletedAtIsNull(1L, 10L)).willReturn(true);
+
+        Passage result = passageService.updateSpoiler(1L, 10L, true);
+
+        assertThat(result.isSpoiler()).isTrue();
+    }
+
+    @Test
+    @DisplayName("스포일러 해제 후 다시 켜는 재설정도 허용한다")
+    void updateSpoilerAllowsResettingFalseToTrue() {
+        Passage passage = passage(1L);
+        ReflectionTestUtils.setField(passage, "isSpoiler", false);
+        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+        given(opinionRepository.existsByPassageIdAndUserIdAndDeletedAtIsNull(1L, 10L)).willReturn(true);
+
+        Passage result = passageService.updateSpoiler(1L, 10L, true);
+
+        assertThat(result.isSpoiler()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이 대목에 흔적을 남긴 적 없는 사용자가 변경을 시도하면 예외가 발생한다")
+    void updateSpoilerThrowsExceptionWhenUserHasNoOpinionOnPassage() {
+        Passage passage = passage(1L);
+        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+        given(opinionRepository.existsByPassageIdAndUserIdAndDeletedAtIsNull(1L, 999L)).willReturn(false);
+
+        assertThatThrownBy(() -> passageService.updateSpoiler(1L, 999L, true))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대목의 스포일러 설정을 변경하면 예외가 발생한다")
+    void updateSpoilerThrowsExceptionWhenPassageDoesNotExist() {
+        given(passageRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> passageService.updateSpoiler(1L, 10L, true))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("삭제된 대목의 스포일러 설정을 변경하면 예외가 발생한다")
+    void updateSpoilerThrowsExceptionWhenPassageDeleted() {
+        Passage passage = passage(1L);
+        passage.delete();
+        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+
+        assertThatThrownBy(() -> passageService.updateSpoiler(1L, 10L, true))
+                .isInstanceOf(PassageException.class);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
@@ -3,8 +3,10 @@ package com.nexters.palang.domain.passage.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,6 +18,8 @@ import com.nexters.palang.domain.passage.application.PassageOcrService;
 import com.nexters.palang.domain.passage.application.PassageService;
 import com.nexters.palang.domain.passage.application.SimilarPassageFinder;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
+import com.nexters.palang.domain.passage.common.error.PassageErrorCode;
+import com.nexters.palang.domain.passage.common.error.PassageException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.presentation.request.PassageRequest;
 import com.nexters.palang.global.security.CurrentUserProvider;
@@ -172,5 +176,73 @@ class PassageControllerTest {
         mockMvc.perform(get("/api/books/1/pages/5/passages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].passageId").value(10));
+    }
+
+    @Test
+    @DisplayName("대목 소유자가 스포일러 설정을 변경한다")
+    void updateSpoiler() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        Passage passage = passage(10L, 5);
+        ReflectionTestUtils.setField(passage, "isSpoiler", true);
+        given(passageService.updateSpoiler(eq(10L), eq(1L), eq(true))).willReturn(passage);
+
+        mockMvc.perform(patch("/api/passages/10/spoiler")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PassageRequest.UpdateSpoiler(true))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.passageId").value(10))
+                .andExpect(jsonPath("$.data.isSpoiler").value(true));
+    }
+
+    @Test
+    @DisplayName("isSpoiler 없이 스포일러 설정을 변경하면 400 에러가 발생한다")
+    void updateSpoilerFailsWhenIsSpoilerMissing() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/passages/10/spoiler")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 스포일러 설정을 변경하면 401 에러가 발생한다")
+    void updateSpoilerFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(patch("/api/passages/10/spoiler")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PassageRequest.UpdateSpoiler(false))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("이 대목에 흔적을 남긴 적 없는 사용자가 변경을 시도하면 403 에러가 발생한다")
+    void updateSpoilerFailsWhenNotOwner() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(passageService.updateSpoiler(eq(10L), eq(1L), eq(true)))
+                .willThrow(new PassageException(PassageErrorCode.PASSAGE_FORBIDDEN));
+
+        mockMvc.perform(patch("/api/passages/10/spoiler")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PassageRequest.UpdateSpoiler(true))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("PASSAGE_403_1"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대목의 스포일러 설정을 변경하면 404 에러가 발생한다")
+    void updateSpoilerFailsWhenPassageNotFound() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(passageService.updateSpoiler(eq(999L), eq(1L), eq(true)))
+                .willThrow(new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/passages/999/spoiler")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new PassageRequest.UpdateSpoiler(true))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("PASSAGE_404_1"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #128

## 🚀 개요
대목의 `isSpoiler`는 지금까지 흔적 생성 시점에만 정해지고 이후 바꿀 방법이 없었다. 스포일러 관리 화면에서 사용자가 스포일러 표시를 해제(또는 재설정)할 수 있도록 신규 엔드포인트를 추가한다.

## 📄 작업 내용
- `PATCH /api/passages/{passageId}/spoiler` 신규 엔드포인트 추가
  - 요청: `{ isSpoiler: boolean }` (false→true 재설정도 허용)
  - 응답: `{ passageId, isSpoiler }`
  - 권한: 이 대목에 흔적을 남긴 사용자만(`findMyPassages`/`filter-books?type=SPOILER`와 동일 기준, `passage.creator` 아님)
- `Passage` 엔티티에 `changeSpoiler(boolean)` 도메인 메서드 추가 (기존에는 생성 시점 세팅 외 변경 수단 없었음)
- `OpinionRepository`에 `existsByPassageIdAndUserIdAndDeletedAtIsNull` 추가 — 대목 소유권(흔적 작성 여부) 판정용
- `PassageErrorCode`에 `PASSAGE_FORBIDDEN`(`PASSAGE_403_1`) 신규 추가 — `OpinionErrorCode.OPINION_FORBIDDEN`과 동일한 관례
- 삭제된/존재하지 않는 대목은 기존 `PASSAGE_NOT_FOUND`(404)로 처리

| Method | Path | 설명 |
|---|---|---|
| PATCH | `/api/passages/{passageId}/spoiler` | 대목 스포일러 설정 변경(신규) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 확인(신규 포함 466개 테스트 중 3개 실패는 로컬 Redis 미기동으로 인한 `AladinBookApiClientCacheTest`로, 이번 변경과 무관)
- `bootRun --spring.profiles.active=local` 기동 후 `/v3/api-docs`로 `UpdateSpoiler`/`SpoilerUpdate` 스키마 및 400/401/403/404 응답 예시 직접 확인
- `curl -X PATCH /api/passages/1/spoiler`로 body 누락 시 400, 미인증 시 401 동작 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 소유권 판정을 "이 대목에 흔적을 남긴 모든 사용자(opinion.user)" 기준으로 잡아, 병합된 대목이면 여러 사용자가 동시에 스포일러 설정을 바꿀 수 있습니다. 기존 `findMyPassages`/`filter-books?type=SPOILER`와 일관된 선택이지만, "본인이 스포일러로 남긴 흔적이 있는 경우만"처럼 더 좁은 기준이 맞다면 알려주세요.
- false→true 재설정을 허용하는 것으로 결정해 PATCH + body 방식을 그대로 유지했습니다(DELETE 방식 대신).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 대목의 스포일러 표시 상태를 변경할 수 있는 기능을 추가했습니다.
  * 해당 대목에 흔적을 남긴 사용자만 스포일러 상태를 변경할 수 있습니다.
  * 변경 결과로 대목 ID와 스포일러 상태를 제공합니다.

* **문서**
  * 스포일러 상태 변경 API와 성공·오류 응답 조건을 문서화했습니다.

* **버그 수정**
  * 존재하지 않거나 삭제된 대목, 권한이 없는 사용자의 요청을 적절한 오류로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->