### PR TITLE
Feat/#125 모임 CRUD 및 멤버 관리

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/application/GroupDetail.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupDetail.java
@@ -1,0 +1,8 @@
+package com.nexters.palang.domain.group.application;
+
+import com.nexters.palang.domain.group.domain.Group;
+
+// 모임 상세 조회용 뷰. memberCount는 Group 엔티티가 스스로 알 수 없어(다른 애그리거트인 GroupMember의
+// 집계값) 서비스가 조회해서 함께 묶어 내려준다.
+public record GroupDetail(Group group, long memberCount) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
@@ -1,0 +1,52 @@
+package com.nexters.palang.domain.group.application;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupMemberResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupSummaryResponse;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.response.PageInfo;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+
+public final class GroupMapper {
+
+    private GroupMapper() {
+    }
+
+    public static GroupDetailResponse toDetailResponse(GroupDetail detail) {
+        Group group = detail.group();
+        Book book = group.getBook();
+        User host = group.getHost();
+        return new GroupDetailResponse(
+                group.getId(), group.getName(), book.getId(), book.getTitle(), book.getAuthor(), book.getCoverImageUrl(),
+                host.getId(), host.getNickname(), group.getCapacity(), detail.memberCount(),
+                group.getStartDate(), group.getEndDate(), group.isEnded());
+    }
+
+    public static GroupSummaryResponse toSummaryResponse(GroupSummaryProjection projection) {
+        boolean ended = LocalDate.now().isAfter(projection.endDate());
+        return new GroupSummaryResponse(
+                projection.groupId(), projection.name(), projection.bookId(), projection.bookTitle(),
+                projection.bookCoverImageUrl(), projection.memberCount(), projection.capacity(),
+                projection.startDate(), projection.endDate(), ended);
+    }
+
+    public static GroupListResponse toListResponse(Page<GroupSummaryProjection> page) {
+        return new GroupListResponse(page.map(GroupMapper::toSummaryResponse).getContent(), PageInfo.from(page));
+    }
+
+    public static GroupMemberResponse toMemberResponse(GroupMember member) {
+        User user = member.getUser();
+        return new GroupMemberResponse(
+                user.getId(), user.getNickname(), user.getProfileImageUrl(), member.getRole(), member.getCreatedAt());
+    }
+
+    public static GroupMemberListResponse toMemberListResponse(Page<GroupMember> page) {
+        return new GroupMemberListResponse(page.map(GroupMapper::toMemberResponse).getContent(), PageInfo.from(page));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
@@ -1,0 +1,102 @@
+package com.nexters.palang.domain.group.application;
+
+import com.nexters.palang.domain.book.common.error.BookErrorCode;
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.domain.GroupMemberRole;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupQueryRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupService {
+
+    // 모임 생성 직후에는 host 1명만 참여 중임이 보장된다.
+    private static final long INITIAL_MEMBER_COUNT = 1L;
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupQueryRepository groupQueryRepository;
+    private final BookRepository bookRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public GroupDetail createGroup(Long hostUserId, CreateGroupRequest request) {
+        Book book = bookRepository.findById(request.bookId())
+                .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
+        User host = userRepository.getReferenceById(hostUserId);
+
+        Group group = Group.create(
+                request.name(), book, host, request.capacity(), request.startDate(), request.endDate());
+        groupRepository.save(group);
+        groupMemberRepository.save(GroupMember.of(group, host, GroupMemberRole.HOST));
+
+        return new GroupDetail(group, INITIAL_MEMBER_COUNT);
+    }
+
+    public Page<GroupSummaryProjection> getMyGroups(Long userId, Pageable pageable) {
+        return groupQueryRepository.findMyGroups(userId, pageable);
+    }
+
+    public GroupDetail getGroupDetail(Long groupId, Long userId) {
+        Group group = getExistingGroup(groupId);
+        validateMember(groupId, userId);
+        return new GroupDetail(group, groupMemberRepository.countByGroupId(groupId));
+    }
+
+    @Transactional
+    public GroupDetail updateGroup(Long groupId, Long userId, UpdateGroupRequest request) {
+        Group group = getExistingGroup(groupId);
+        validateHost(group, userId);
+        long memberCount = groupMemberRepository.countByGroupId(groupId);
+        group.updateSettings(request.name(), request.capacity(), request.startDate(), request.endDate(), memberCount);
+        return new GroupDetail(group, memberCount);
+    }
+
+    @Transactional
+    public void deleteGroup(Long groupId, Long userId) {
+        Group group = getExistingGroup(groupId);
+        validateHost(group, userId);
+        groupMemberRepository.deleteAllByGroupId(groupId);
+        groupRepository.delete(group);
+    }
+
+    public Page<GroupMember> getGroupMembers(Long groupId, Long userId, Pageable pageable) {
+        getExistingGroup(groupId);
+        validateMember(groupId, userId);
+        return groupQueryRepository.findMembers(groupId, pageable);
+    }
+
+    private Group getExistingGroup(Long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private void validateHost(Group group, Long userId) {
+        if (!group.getHost().getId().equals(userId)) {
+            throw new GroupException(GroupErrorCode.NOT_HOST);
+        }
+    }
+
+    private void validateMember(Long groupId, Long userId) {
+        if (!groupMemberRepository.existsByGroupIdAndUserId(groupId, userId)) {
+            throw new GroupException(GroupErrorCode.NOT_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupSummaryProjection.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupSummaryProjection.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.group.application;
+
+import java.time.LocalDate;
+
+// 내 모임 목록(홈 "모임" 탭)에서 카드 하나를 그리는 데 필요한 값만 모은 조회 전용 뷰.
+public record GroupSummaryProjection(
+        Long groupId,
+        String name,
+        Long bookId,
+        String bookTitle,
+        String bookCoverImageUrl,
+        long memberCount,
+        int capacity,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
@@ -1,0 +1,23 @@
+package com.nexters.palang.domain.group.common.error;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GroupErrorCode implements BaseErrorCode {
+
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_404_1", "해당 모임을 찾을 수 없습니다."),
+    INVALID_GROUP_PERIOD(HttpStatus.BAD_REQUEST, "GROUP_400_1", "시작일은 종료일보다 늦을 수 없습니다."),
+    INVALID_GROUP_CAPACITY(HttpStatus.BAD_REQUEST, "GROUP_400_2", "인원은 2명 이상 10명 이하여야 합니다."),
+    NOT_HOST(HttpStatus.FORBIDDEN, "GROUP_403_1", "모임장만 가능한 작업입니다."),
+    NOT_MEMBER(HttpStatus.FORBIDDEN, "GROUP_403_2", "모임원만 조회할 수 있습니다."),
+    CAPACITY_BELOW_MEMBER_COUNT(HttpStatus.CONFLICT, "GROUP_409_1", "인원을 현재 참여 인원보다 적게 설정할 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/domain/group/common/error/GroupException.java
+++ b/src/main/java/com/nexters/palang/domain/group/common/error/GroupException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.group.common.error;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class GroupException extends AppException {
+
+    public GroupException(GroupErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/domain/Group.java
+++ b/src/main/java/com/nexters/palang/domain/group/domain/Group.java
@@ -98,6 +98,9 @@ public class Group extends BaseEntity {
         this.endDate = endDate;
     }
 
+    // 기간은 모임원끼리 정하는 안내용 값일 뿐 강제되지 않는다(PM 확인: 기간이 지나도 모임 목록 노출,
+    // 흔적/의견 작성 모두 계속 가능). isEnded()는 FE가 "종료됨" 배지를 보여주는 용도로만 쓰이며,
+    // 어떤 조회/쓰기 API도 이 값으로 접근을 막지 않는다.
     public boolean isEnded() {
         return LocalDate.now().isAfter(endDate);
     }

--- a/src/main/java/com/nexters/palang/domain/group/domain/Group.java
+++ b/src/main/java/com/nexters/palang/domain/group/domain/Group.java
@@ -1,0 +1,120 @@
+package com.nexters.palang.domain.group.domain;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Check;
+
+@Getter
+@Entity
+// 테이블명을 "groups"로 두면 MySQL 8(GROUPS가 예약어, GROUPS BETWEEN 윈도우 프레임 구문 도입 이후)에서
+// DDL/쿼리가 깨질 수 있어 "reading_groups"로 둔다.
+@Table(
+        name = "reading_groups",
+        uniqueConstraints = @UniqueConstraint(name = "uq_reading_groups_invite_code", columnNames = "invite_code")
+)
+@Check(constraints = "capacity BETWEEN 2 AND 10 AND end_date >= start_date")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Group extends BaseEntity {
+
+    public static final int NAME_MAX_LENGTH = 15;
+    public static final int MIN_CAPACITY = 2;
+    public static final int MAX_CAPACITY = 10;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "name", length = NAME_MAX_LENGTH, nullable = false)
+    private String name;
+
+    // 모임을 만들 때 함께 고른 책. 흔적/의견이 이 책을 기준으로 쌓이므로 생성 후에는 바꿀 수 없다(setter 없음).
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false, updatable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false, updatable = false)
+    private User host;
+
+    @Column(name = "capacity", nullable = false)
+    private int capacity;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    // 카카오톡 등으로 공유하는 초대 링크의 식별자. 별도 만료 시각을 두지 않고 endDate가 지나면 자연히
+    // 무효화되는 것으로 취급한다(초대/가입 API는 후속 이슈에서 구현).
+    @Column(name = "invite_code", length = 32, nullable = false, updatable = false)
+    private String inviteCode;
+
+    private Group(String name, Book book, User host, int capacity, LocalDate startDate, LocalDate endDate, String inviteCode) {
+        this.name = name;
+        this.book = book;
+        this.host = host;
+        this.capacity = capacity;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.inviteCode = inviteCode;
+    }
+
+    public static Group create(String name, Book book, User host, int capacity, LocalDate startDate, LocalDate endDate) {
+        validateCapacity(capacity);
+        validatePeriod(startDate, endDate);
+        return new Group(name, book, host, capacity, startDate, endDate, generateInviteCode());
+    }
+
+    // 방 설정 변경(host 전용): 책은 대상이 아니다. 정원을 현재 참여 인원보다 적게 줄이는 것은 막는다.
+    public void updateSettings(String name, int capacity, LocalDate startDate, LocalDate endDate, long currentMemberCount) {
+        validateCapacity(capacity);
+        validatePeriod(startDate, endDate);
+        if (capacity < currentMemberCount) {
+            throw new GroupException(GroupErrorCode.CAPACITY_BELOW_MEMBER_COUNT);
+        }
+        this.name = name;
+        this.capacity = capacity;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public boolean isEnded() {
+        return LocalDate.now().isAfter(endDate);
+    }
+
+    private static void validateCapacity(int capacity) {
+        if (capacity < MIN_CAPACITY || capacity > MAX_CAPACITY) {
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_CAPACITY);
+        }
+    }
+
+    private static void validatePeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_PERIOD);
+        }
+    }
+
+    private static String generateInviteCode() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/domain/GroupMember.java
+++ b/src/main/java/com/nexters/palang/domain/group/domain/GroupMember.java
@@ -1,0 +1,61 @@
+package com.nexters.palang.domain.group.domain;
+
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "group_members",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_group_members_group_user", columnNames = {"group_id", "user_id"}),
+        indexes = @Index(name = "idx_group_members_user", columnList = "user_id")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false, updatable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, updatable = false)
+    private GroupMemberRole role;
+
+    private GroupMember(Group group, User user, GroupMemberRole role) {
+        this.group = group;
+        this.user = user;
+        this.role = role;
+    }
+
+    // 나가기/강퇴는 이번 스코프에 없어 정원 검증 등은 가입 플로우(후속 이슈)에서 다룬다. 여기서는
+    // 이미 확정된 (group, user, role) 조합으로 멤버 레코드를 만드는 역할만 한다.
+    public static GroupMember of(Group group, User user, GroupMemberRole role) {
+        return new GroupMember(group, user, role);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/domain/GroupMemberRole.java
+++ b/src/main/java/com/nexters/palang/domain/group/domain/GroupMemberRole.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.group.domain;
+
+public enum GroupMemberRole {
+    HOST,
+    MEMBER,
+}

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.group.infrastructure;
+
+import com.nexters.palang.domain.group.domain.GroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    boolean existsByGroupIdAndUserId(Long groupId, Long userId);
+
+    long countByGroupId(Long groupId);
+
+    void deleteAllByGroupId(Long groupId);
+}

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
@@ -39,8 +39,10 @@ public class GroupQueryRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        // 마지막 페이지를 넘어가는 page를 요청하면 groupIds는 비지만, totalElements는 여전히 실제
+        // 전체 건수를 내려줘야 pageInfo(totalPages/hasNext)가 올바르다.
         if (groupIds.isEmpty()) {
-            return new PageImpl<>(List.of(), pageable, 0);
+            return new PageImpl<>(List.of(), pageable, countMyGroups(userId));
         }
 
         Map<Long, Long> memberCountsByGroupId = queryFactory

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
@@ -1,0 +1,110 @@
+package com.nexters.palang.domain.group.infrastructure;
+
+import com.nexters.palang.domain.group.application.GroupSummaryProjection;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.domain.QGroup;
+import com.nexters.palang.domain.group.domain.QGroupMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 내가 속한 모임 목록(최근 생성 순). Group당 memberCount를 fetch join 한 번으로 같이 뽑을 수 없어
+    // (group by가 페이지 대상 group들을 벗어난 집계를 왜곡시킴) id 목록을 먼저 페이지네이션한 뒤
+    // 그 id들에 대해서만 멤버 수를 별도로 집계한다.
+    public Page<GroupSummaryProjection> findMyGroups(Long userId, Pageable pageable) {
+        QGroup group = QGroup.group;
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        List<Long> groupIds = queryFactory
+                .select(group.id)
+                .from(group)
+                .join(groupMember).on(groupMember.group.eq(group))
+                .where(groupMember.user.id.eq(userId))
+                .orderBy(group.createdAt.desc(), group.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (groupIds.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        Map<Long, Long> memberCountsByGroupId = queryFactory
+                .select(groupMember.group.id, groupMember.count())
+                .from(groupMember)
+                .where(groupMember.group.id.in(groupIds))
+                .groupBy(groupMember.group.id)
+                .fetch().stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(groupMember.group.id),
+                        tuple -> tuple.get(groupMember.count())));
+
+        List<Group> groups = queryFactory
+                .selectFrom(group)
+                .join(group.book).fetchJoin()
+                .where(group.id.in(groupIds))
+                .fetch();
+        Map<Long, Group> groupsById = groups.stream().collect(Collectors.toMap(Group::getId, g -> g));
+
+        List<GroupSummaryProjection> content = groupIds.stream()
+                .map(groupsById::get)
+                .filter(Objects::nonNull)
+                .map(g -> new GroupSummaryProjection(
+                        g.getId(), g.getName(), g.getBook().getId(), g.getBook().getTitle(),
+                        g.getBook().getCoverImageUrl(), memberCountsByGroupId.getOrDefault(g.getId(), 0L),
+                        g.getCapacity(), g.getStartDate(), g.getEndDate()))
+                .toList();
+
+        long total = countMyGroups(userId);
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private long countMyGroups(Long userId) {
+        QGroup group = QGroup.group;
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        Long total = queryFactory
+                .select(group.count())
+                .from(group)
+                .join(groupMember).on(groupMember.group.eq(group))
+                .where(groupMember.user.id.eq(userId))
+                .fetchOne();
+        return total != null ? total : 0L;
+    }
+
+    // 모임 멤버 목록: 모임장(HOST)이 먼저, 그다음 가입 순.
+    public Page<GroupMember> findMembers(Long groupId, Pageable pageable) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        List<GroupMember> content = queryFactory
+                .selectFrom(groupMember)
+                .join(groupMember.user).fetchJoin()
+                .where(groupMember.group.id.eq(groupId))
+                .orderBy(groupMember.role.asc(), groupMember.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(groupMember.count())
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.group.infrastructure;
+
+import com.nexters.palang.domain.group.domain.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
@@ -1,0 +1,119 @@
+package com.nexters.palang.domain.group.presentation;
+
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Group", description = "모임 API")
+public interface GroupApi {
+
+    @Operation(summary = "모임 생성", description = "책 1권을 고정해 모임을 만듭니다. 생성한 사용자는 모임장(HOST)으로 자동 가입됩니다. "
+            + "책은 생성 이후 변경할 수 없습니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "필수값 누락, 인원이 2~10명 범위를 벗어남(COMMON_400_1) "
+                    + "또는 시작일이 종료일보다 늦음 (GROUP_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 도서를 찾을 수 없음 (BOOK_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupDetailResponse>> createGroup(@Valid CreateGroupRequest request);
+
+    @Operation(summary = "내 모임 목록", description = "현재 로그인한 사용자가 속한 모임을 최근 생성 순으로 조회합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupListResponse>> getMyGroups(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "모임 상세 조회", description = "모임원만 조회할 수 있습니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임원이 아님 (GROUP_403_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<GroupDetailResponse>> getGroupDetail(
+            @Parameter(description = "모임 ID", required = true) Long groupId
+    );
+
+    @Operation(summary = "방 설정 변경", description = "모임장만 이름/인원/기간을 수정할 수 있습니다. 책은 대상이 아닙니다. "
+            + "인원은 현재 참여 인원보다 적게 줄일 수 없습니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "필수값 누락, 인원이 2~10명 범위를 벗어남(COMMON_400_1) "
+                    + "또는 시작일이 종료일보다 늦음 (GROUP_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "인원을 현재 참여 인원보다 적게 설정 (GROUP_409_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupDetailResponse>> updateGroup(
+            @Parameter(description = "모임 ID", required = true) Long groupId,
+            @Valid UpdateGroupRequest request
+    );
+
+    @Operation(summary = "모임 삭제", description = "모임장만 모임을 삭제할 수 있습니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<Void>> deleteGroup(
+            @Parameter(description = "모임 ID", required = true) Long groupId
+    );
+
+    @Operation(summary = "모임 멤버 목록", description = "모임원만 조회할 수 있습니다. 모임장이 먼저, 그다음 가입 순으로 정렬됩니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임원이 아님 (GROUP_403_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupMemberListResponse>> getGroupMembers(
+            @Parameter(description = "모임 ID", required = true) Long groupId,
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
@@ -1,0 +1,95 @@
+package com.nexters.palang.domain.group.presentation;
+
+import com.nexters.palang.domain.group.application.GroupDetail;
+import com.nexters.palang.domain.group.application.GroupMapper;
+import com.nexters.palang.domain.group.application.GroupService;
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GroupController implements GroupApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final GroupService groupService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @PostMapping("/api/groups")
+    public ResponseEntity<DataResponse<GroupDetailResponse>> createGroup(@Valid @RequestBody CreateGroupRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        GroupDetail detail = groupService.createGroup(currentUserId, request);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+    }
+
+    @Override
+    @GetMapping("/api/groups")
+    public ResponseEntity<DataResponse<GroupListResponse>> getMyGroups(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(
+                GroupMapper.toListResponse(groupService.getMyGroups(currentUserId, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/groups/{groupId}")
+    public ResponseEntity<DataResponse<GroupDetailResponse>> getGroupDetail(@PathVariable Long groupId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        GroupDetail detail = groupService.getGroupDetail(groupId, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+    }
+
+    @Override
+    @PatchMapping("/api/groups/{groupId}")
+    public ResponseEntity<DataResponse<GroupDetailResponse>> updateGroup(
+            @PathVariable Long groupId, @RequestBody @Valid UpdateGroupRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        GroupDetail detail = groupService.updateGroup(groupId, currentUserId, request);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+    }
+
+    @Override
+    @DeleteMapping("/api/groups/{groupId}")
+    public ResponseEntity<DataResponse<Void>> deleteGroup(@PathVariable Long groupId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        groupService.deleteGroup(groupId, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @GetMapping("/api/groups/{groupId}/members")
+    public ResponseEntity<DataResponse<GroupMemberListResponse>> getGroupMembers(
+            @PathVariable Long groupId,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toMemberListResponse(
+                groupService.getGroupMembers(groupId, currentUserId, pageable(page, size)))));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/CreateGroupRequest.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/CreateGroupRequest.java
@@ -1,0 +1,30 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import com.nexters.palang.domain.group.domain.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record CreateGroupRequest(
+        @NotBlank(message = "모임명은 필수입니다.")
+        @Size(max = Group.NAME_MAX_LENGTH, message = "모임명은 최대 15자까지 가능합니다.")
+        @Schema(example = "고전 뽀개기") String name,
+
+        @NotNull(message = "책 선택은 필수입니다.")
+        @Schema(example = "1") Long bookId,
+
+        @Min(value = Group.MIN_CAPACITY, message = "인원은 최소 2명 이상이어야 합니다.")
+        @Max(value = Group.MAX_CAPACITY, message = "인원은 최대 10명까지 가능합니다.")
+        @Schema(example = "4") int capacity,
+
+        @NotNull(message = "시작일은 필수입니다.")
+        @Schema(example = "2026-08-20") LocalDate startDate,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        @Schema(example = "2026-09-20") LocalDate endDate
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
@@ -1,0 +1,21 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record GroupDetailResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long groupId,
+        @Schema(example = "고전 뽀개기", requiredMode = Schema.RequiredMode.REQUIRED) String name,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String bookAuthor,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long hostUserId,
+        @Schema(example = "여백이", requiredMode = Schema.RequiredMode.REQUIRED) String hostNickname,
+        @Schema(example = "4", requiredMode = Schema.RequiredMode.REQUIRED) int capacity,
+        @Schema(example = "2", requiredMode = Schema.RequiredMode.REQUIRED) long memberCount,
+        @Schema(example = "2026-08-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate startDate,
+        @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
@@ -16,6 +16,8 @@ public record GroupDetailResponse(
         @Schema(example = "2", requiredMode = Schema.RequiredMode.REQUIRED) long memberCount,
         @Schema(example = "2026-08-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate startDate,
         @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
-        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+        @Schema(example = "false", description = "종료일이 지났는지 여부. 안내용 배지 표시에만 쓰이며, "
+                + "이 값이 true여도 모임 목록 노출/흔적·의견 작성 등은 계속 가능합니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record GroupListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<GroupSummaryResponse> groups,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupMemberListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupMemberListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record GroupMemberListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<GroupMemberResponse> members,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupMemberResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupMemberResponse.java
@@ -1,0 +1,14 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import com.nexters.palang.domain.group.domain.GroupMemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record GroupMemberResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(example = "여백이", requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(example = "https://...", nullable = true) String profileImageUrl,
+        @Schema(example = "HOST", requiredMode = Schema.RequiredMode.REQUIRED) GroupMemberRole role,
+        @Schema(example = "2026-08-19T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime joinedAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record GroupSummaryResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long groupId,
+        @Schema(example = "고전 뽀개기", requiredMode = Schema.RequiredMode.REQUIRED) String name,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
+        @Schema(example = "2", requiredMode = Schema.RequiredMode.REQUIRED) long memberCount,
+        @Schema(example = "4", requiredMode = Schema.RequiredMode.REQUIRED) int capacity,
+        @Schema(example = "2026-08-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate startDate,
+        @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
@@ -13,6 +13,8 @@ public record GroupSummaryResponse(
         @Schema(example = "4", requiredMode = Schema.RequiredMode.REQUIRED) int capacity,
         @Schema(example = "2026-08-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate startDate,
         @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
-        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+        @Schema(example = "false", description = "종료일이 지났는지 여부. 안내용 배지 표시에만 쓰이며, "
+                + "이 값이 true여도 모임 목록 노출/흔적·의견 작성 등은 계속 가능합니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/UpdateGroupRequest.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/UpdateGroupRequest.java
@@ -1,0 +1,28 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import com.nexters.palang.domain.group.domain.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+// 방 설정 변경: 책은 대상이 아니다(생성 후 불변).
+public record UpdateGroupRequest(
+        @NotBlank(message = "모임명은 필수입니다.")
+        @Size(max = Group.NAME_MAX_LENGTH, message = "모임명은 최대 15자까지 가능합니다.")
+        @Schema(example = "주말 독서 모임") String name,
+
+        @Min(value = Group.MIN_CAPACITY, message = "인원은 최소 2명 이상이어야 합니다.")
+        @Max(value = Group.MAX_CAPACITY, message = "인원은 최대 10명까지 가능합니다.")
+        @Schema(example = "6") int capacity,
+
+        @NotNull(message = "시작일은 필수입니다.")
+        @Schema(example = "2026-08-20") LocalDate startDate,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        @Schema(example = "2026-09-27") LocalDate endDate
+) {
+}

--- a/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
@@ -1,0 +1,215 @@
+package com.nexters.palang.domain.group.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupQueryRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private GroupQueryRepository groupQueryRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private GroupService groupService;
+
+    private Book book;
+    private User host;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        groupService = new GroupService(groupRepository, groupMemberRepository, groupQueryRepository, bookRepository, userRepository);
+        book = book(1L);
+        host = user(1L);
+        other = user(2L);
+    }
+
+    private Book book(Long id) {
+        Book built = Book.builder()
+                .title("채식주의자").author("한강").publisher("창비").pageCount(268).source(BookSource.API).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private CreateGroupRequest createRequest() {
+        return new CreateGroupRequest("고전 뽀개기", book.getId(), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+    }
+
+    private Group group(Long id, User host) {
+        Group built = Group.create(
+                "고전 뽀개기", book, host, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("모임을 생성하면 host가 모임원으로 함께 저장된다")
+    void createGroupSucceeds() {
+        given(bookRepository.findById(book.getId())).willReturn(Optional.of(book));
+        given(userRepository.getReferenceById(host.getId())).willReturn(host);
+
+        GroupDetail detail = groupService.createGroup(host.getId(), createRequest());
+
+        assertThat(detail.group().getHost()).isEqualTo(host);
+        assertThat(detail.memberCount()).isEqualTo(1L);
+        verify(groupRepository).save(any(Group.class));
+        verify(groupMemberRepository).save(any(GroupMember.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 책으로 모임을 만들면 예외가 발생한다")
+    void createGroupFailsWhenBookNotFound() {
+        given(bookRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.createGroup(
+                host.getId(), new CreateGroupRequest("고전 뽀개기", 999L, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20))))
+                .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임을 조회하면 예외가 발생한다")
+    void getGroupDetailFailsWhenNotFound() {
+        given(groupRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.getGroupDetail(999L, host.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임원이 아니면 모임 상세를 조회할 수 없다")
+    void getGroupDetailFailsWhenNotMember() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, other.getId())).willReturn(false);
+
+        assertThatThrownBy(() -> groupService.getGroupDetail(1L, other.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임원이면 모임 상세와 참여 인원 수를 함께 조회한다")
+    void getGroupDetailSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, host.getId())).willReturn(true);
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
+
+        GroupDetail detail = groupService.getGroupDetail(1L, host.getId());
+
+        assertThat(detail.group()).isEqualTo(group);
+        assertThat(detail.memberCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 방 설정을 변경할 수 없다")
+    void updateGroupFailsWhenNotHost() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupService.updateGroup(
+                1L, other.getId(), new UpdateGroupRequest("주말 독서 모임", 6, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20))))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("현재 참여 인원보다 적은 인원으로 방 설정을 변경하면 예외가 발생한다")
+    void updateGroupFailsWhenCapacityBelowMemberCount() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
+
+        assertThatThrownBy(() -> groupService.updateGroup(
+                1L, host.getId(), new UpdateGroupRequest("고전 뽀개기", 2, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20))))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임장은 방 설정을 변경할 수 있다")
+    void updateGroupSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(1L);
+
+        GroupDetail detail = groupService.updateGroup(
+                1L, host.getId(), new UpdateGroupRequest("주말 독서 모임", 6, LocalDate.of(2026, 8, 21), LocalDate.of(2026, 9, 27)));
+
+        assertThat(detail.group().getName()).isEqualTo("주말 독서 모임");
+        assertThat(detail.group().getCapacity()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 모임을 삭제할 수 없다")
+    void deleteGroupFailsWhenNotHost() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupService.deleteGroup(1L, other.getId())).isInstanceOf(GroupException.class);
+        verify(groupRepository, never()).delete(any(Group.class));
+    }
+
+    @Test
+    @DisplayName("모임장은 모임을 삭제할 수 있고, 모임원 레코드도 함께 삭제된다")
+    void deleteGroupSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        groupService.deleteGroup(1L, host.getId());
+
+        verify(groupMemberRepository, times(1)).deleteAllByGroupId(1L);
+        verify(groupRepository).delete(group);
+    }
+
+    @Test
+    @DisplayName("모임원이 아니면 모임 멤버 목록을 조회할 수 없다")
+    void getGroupMembersFailsWhenNotMember() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, other.getId())).willReturn(false);
+
+        assertThatThrownBy(() -> groupService.getGroupMembers(1L, other.getId(), null)).isInstanceOf(GroupException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/group/domain/GroupTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/domain/GroupTest.java
@@ -1,0 +1,98 @@
+package com.nexters.palang.domain.group.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.user.domain.User;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GroupTest {
+
+    private Book book() {
+        Book built = Book.builder()
+                .title("채식주의자").author("한강").publisher("창비").pageCount(268).source(BookSource.API).build();
+        ReflectionTestUtils.setField(built, "id", 1L);
+        return built;
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("모임을 만들면 host가 지정된 채로 생성되고 초대 코드가 발급된다")
+    void createsGroup() {
+        Group group = Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+
+        assertThat(group.getHost().getId()).isEqualTo(1L);
+        assertThat(group.getInviteCode()).isNotBlank();
+        assertThat(group.isEnded()).isFalse();
+    }
+
+    @Test
+    @DisplayName("인원이 2명 미만이면 예외가 발생한다")
+    void createFailsWhenCapacityTooSmall() {
+        assertThatThrownBy(() -> Group.create(
+                "고전 뽀개기", book(), user(1L), 1, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("인원이 10명 초과면 예외가 발생한다")
+    void createFailsWhenCapacityTooLarge() {
+        assertThatThrownBy(() -> Group.create(
+                "고전 뽀개기", book(), user(1L), 11, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("시작일이 종료일보다 늦으면 예외가 발생한다")
+    void createFailsWhenPeriodInvalid() {
+        assertThatThrownBy(() -> Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.of(2026, 9, 20), LocalDate.of(2026, 8, 20)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("방 설정을 변경하면 이름/인원/기간이 바뀐다")
+    void updatesSettings() {
+        Group group = Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+
+        group.updateSettings("주말 독서 모임", 6, LocalDate.of(2026, 8, 21), LocalDate.of(2026, 9, 27), 2L);
+
+        assertThat(group.getName()).isEqualTo("주말 독서 모임");
+        assertThat(group.getCapacity()).isEqualTo(6);
+        assertThat(group.getStartDate()).isEqualTo(LocalDate.of(2026, 8, 21));
+        assertThat(group.getEndDate()).isEqualTo(LocalDate.of(2026, 9, 27));
+    }
+
+    @Test
+    @DisplayName("현재 참여 인원보다 적은 인원으로 변경하면 예외가 발생한다")
+    void updateFailsWhenCapacityBelowMemberCount() {
+        Group group = Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+
+        assertThatThrownBy(() -> group.updateSettings(
+                "고전 뽀개기", 2, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20), 3L))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("종료일이 지나면 종료된 모임으로 판단한다")
+    void isEndedReturnsTrueAfterEndDate() {
+        Group group = Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.now().minusDays(10), LocalDate.now().minusDays(1));
+
+        assertThat(group.isEnded()).isTrue();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.nexters.palang.domain.group.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.group.application.GroupSummaryProjection;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.domain.GroupMemberRole;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class GroupQueryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private GroupQueryRepository groupQueryRepository;
+
+    @BeforeEach
+    void setUp() {
+        groupQueryRepository = new GroupQueryRepository(new JPAQueryFactory(entityManager.getEntityManager()));
+    }
+
+    private User user(String snsId) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname("닉네임" + snsId)
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId(snsId)
+                .build());
+    }
+
+    private Book book(String title) {
+        return entityManager.persistAndFlush(Book.builder()
+                .title(title).author("한강").publisher("창비").pageCount(268).source(BookSource.API).build());
+    }
+
+    private Group group(String name, Book book, User host) {
+        Group built = Group.create(name, book, host, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        return entityManager.persistAndFlush(built);
+    }
+
+    private void join(Group group, User user, GroupMemberRole role) {
+        entityManager.persistAndFlush(GroupMember.of(group, user, role));
+    }
+
+    @Test
+    @DisplayName("내가 속한 모임만 최근 생성 순으로, 참여 인원 수와 함께 조회한다")
+    void findMyGroups() {
+        User me = user("me");
+        User other = user("other");
+        Book book1 = book("채식주의자");
+        Book book2 = book("소년이 온다");
+
+        Group myGroup1 = group("고전 뽀개기", book1, me);
+        join(myGroup1, me, GroupMemberRole.HOST);
+
+        Group myGroup2 = group("주말 독서 모임", book2, other);
+        join(myGroup2, other, GroupMemberRole.HOST);
+        join(myGroup2, me, GroupMemberRole.MEMBER);
+
+        Group notMyGroup = group("남의 모임", book1, other);
+        join(notMyGroup, other, GroupMemberRole.HOST);
+
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<GroupSummaryProjection> result = groupQueryRepository.findMyGroups(me.getId(), pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(GroupSummaryProjection::groupId)
+                .containsExactly(myGroup2.getId(), myGroup1.getId());
+        assertThat(result.getContent().get(0).memberCount()).isEqualTo(2L);
+        assertThat(result.getContent().get(1).memberCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("모임 멤버 목록은 모임장이 먼저, 그다음 가입 순으로 조회한다")
+    void findMembers() {
+        User host = user("host");
+        User member = user("member");
+        Group group = group("고전 뽀개기", book("채식주의자"), host);
+        join(group, host, GroupMemberRole.HOST);
+        join(group, member, GroupMemberRole.MEMBER);
+
+        Page<GroupMember> result = groupQueryRepository.findMembers(group.getId(), PageRequest.of(0, 20));
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(m -> m.getUser().getId())
+                .containsExactly(host.getId(), member.getId());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
@@ -90,6 +90,20 @@ class GroupQueryRepositoryTest {
     }
 
     @Test
+    @DisplayName("마지막 페이지를 넘어가는 페이지를 요청해도 전체 건수는 정확히 반환한다")
+    void findMyGroupsReturnsTotalElementsEvenWhenPageIsEmpty() {
+        User me = user("me");
+        join(group("고전 뽀개기", book("채식주의자"), me), me, GroupMemberRole.HOST);
+        join(group("주말 독서 모임", book("소년이 온다"), me), me, GroupMemberRole.HOST);
+
+        // 전체 2건인데 첫 페이지(size=20)를 넘어가는 두 번째 페이지를 요청 -> content는 비지만 total은 2여야 한다.
+        Page<GroupSummaryProjection> result = groupQueryRepository.findMyGroups(me.getId(), PageRequest.of(1, 20));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("모임 멤버 목록은 모임장이 먼저, 그다음 가입 순으로 조회한다")
     void findMembers() {
         User host = user("host");

--- a/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
@@ -1,0 +1,245 @@
+package com.nexters.palang.domain.group.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.group.application.GroupDetail;
+import com.nexters.palang.domain.group.application.GroupService;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.domain.GroupMemberRole;
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GroupController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GroupControllerTest {
+
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 20);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @MockitoBean
+    private GroupService groupService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private Book book() {
+        Book built = Book.builder()
+                .title("채식주의자").author("한강").publisher("창비").pageCount(268).source(BookSource.API).build();
+        ReflectionTestUtils.setField(built, "id", 1L);
+        return built;
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Group group(Long id, User host) {
+        Group built = Group.create("고전 뽀개기", book(), host, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private CreateGroupRequest createRequest() {
+        return new CreateGroupRequest("고전 뽀개기", 1L, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+    }
+
+    private UpdateGroupRequest updateRequest() {
+        return new UpdateGroupRequest("주말 독서 모임", 6, LocalDate.of(2026, 8, 21), LocalDate.of(2026, 9, 27));
+    }
+
+    @Test
+    @DisplayName("모임을 생성하면 생성된 모임 정보를 반환한다")
+    void createGroup() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        Group group = group(1L, user(1L));
+        given(groupService.createGroup(eq(1L), any(CreateGroupRequest.class))).willReturn(new GroupDetail(group, 1L));
+
+        mockMvc.perform(post("/api/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.groupId").value(1))
+                .andExpect(jsonPath("$.data.memberCount").value(1));
+    }
+
+    @Test
+    @DisplayName("인증 없이 모임을 생성하면 401 에러가 발생한다")
+    void createGroupFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("모임명 없이 모임을 생성하면 400 에러가 발생한다")
+    void createGroupFailsWhenNameMissing() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(post("/api/groups")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"bookId\":1,\"capacity\":4,\"startDate\":\"2026-08-20\",\"endDate\":\"2026-09-20\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("내 모임 목록을 조회한다")
+    void getMyGroups() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.getMyGroups(eq(1L), any())).willReturn(new PageImpl<>(List.of(), DEFAULT_PAGEABLE, 0));
+
+        mockMvc.perform(get("/api/groups")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("모임 상세를 조회한다")
+    void getGroupDetail() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        Group group = group(1L, user(1L));
+        given(groupService.getGroupDetail(1L, 1L)).willReturn(new GroupDetail(group, 2L));
+
+        mockMvc.perform(get("/api/groups/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberCount").value(2));
+    }
+
+    @Test
+    @DisplayName("모임원이 아니면 모임 상세 조회 시 403 에러가 발생한다")
+    void getGroupDetailFailsWhenNotMember() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.getGroupDetail(1L, 1L)).willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(get("/api/groups/1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임을 조회하면 404 에러가 발생한다")
+    void getGroupDetailFailsWhenNotFound() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.getGroupDetail(1L, 1L)).willThrow(new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        mockMvc.perform(get("/api/groups/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("GROUP_404_1"));
+    }
+
+    @Test
+    @DisplayName("방 설정을 변경하면 변경된 모임 정보를 반환한다")
+    void updateGroup() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        Group group = group(1L, user(1L));
+        group.updateSettings("주말 독서 모임", 6, LocalDate.of(2026, 8, 21), LocalDate.of(2026, 9, 27), 1L);
+        given(groupService.updateGroup(eq(1L), eq(1L), any(UpdateGroupRequest.class))).willReturn(new GroupDetail(group, 1L));
+
+        mockMvc.perform(patch("/api/groups/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("주말 독서 모임"));
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 방 설정 변경 시 403 에러가 발생한다")
+    void updateGroupFailsWhenNotHost() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        given(groupService.updateGroup(eq(1L), eq(2L), any(UpdateGroupRequest.class)))
+                .willThrow(new GroupException(GroupErrorCode.NOT_HOST));
+
+        mockMvc.perform(patch("/api/groups/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest())))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_1"));
+    }
+
+    @Test
+    @DisplayName("현재 참여 인원보다 적은 인원으로 변경하면 409 에러가 발생한다")
+    void updateGroupFailsWhenCapacityBelowMemberCount() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.updateGroup(eq(1L), eq(1L), any(UpdateGroupRequest.class)))
+                .willThrow(new GroupException(GroupErrorCode.CAPACITY_BELOW_MEMBER_COUNT));
+
+        mockMvc.perform(patch("/api/groups/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("GROUP_409_1"));
+    }
+
+    @Test
+    @DisplayName("모임을 삭제한다")
+    void deleteGroup() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/groups/1")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 모임 삭제 시 403 에러가 발생한다")
+    void deleteGroupFailsWhenNotHost() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        org.mockito.Mockito.doThrow(new GroupException(GroupErrorCode.NOT_HOST))
+                .when(groupService).deleteGroup(1L, 2L);
+
+        mockMvc.perform(delete("/api/groups/1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_1"));
+    }
+
+    @Test
+    @DisplayName("모임 멤버 목록을 조회한다")
+    void getGroupMembers() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        Group group = group(1L, user(1L));
+        GroupMember member = GroupMember.of(group, user(1L), GroupMemberRole.HOST);
+        given(groupService.getGroupMembers(eq(1L), eq(1L), any()))
+                .willReturn(new PageImpl<>(List.of(member), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/groups/1/members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.members[0].role").value("HOST"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #125

## 🚀 개요
모임 도메인(Group)을 신설하고, 모임 생성/조회/수정/삭제와 멤버 목록 조회 API를 추가합니다.

## 📄 작업 내용
- `group` 도메인 5-레이어 스캐폴딩 (presentation/application/domain/infrastructure/common)
- `Group`(name/book/host/capacity 2~10/기간/inviteCode) · `GroupMember`(group+user 유니크, HOST/MEMBER) 엔티티 추가
  - 책은 생성 후 변경 불가 (host/book 컬럼 `updatable = false`)
  - 인원 2~10명, 시작일 ≤ 종료일을 정적 팩토리 + `@Check` DB 제약으로 이중 검증
  - 테이블명은 `groups`가 아니라 `reading_groups`로 지음 — MySQL 8부터 `GROUPS`가 예약어(`GROUPS BETWEEN` 윈도우 프레임 구문)라 DDL이 깨질 수 있어서
- `GroupErrorCode`/`GroupException` 추가 (GROUP_404_1, GROUP_400_1/2, GROUP_403_1/2, GROUP_409_1)
- `GroupRepository`, `GroupMemberRepository`, `GroupQueryRepository`(QueryDSL — 내 모임 목록 + 참여 인원 집계, 모임원 목록 host 우선 정렬) 추가
- `GroupService`, `GroupMapper` 추가
- `GroupController`/`GroupApi`(Swagger) 및 요청/응답 DTO 추가

| Method | Path | 설명 |
|---|---|---|
| POST | `/api/groups` | 모임 생성 (host 자동 가입) |
| GET | `/api/groups` | 내 모임 목록 |
| GET | `/api/groups/{groupId}` | 모임 상세 (모임원만) |
| PATCH | `/api/groups/{groupId}` | 방 설정 변경 (host만, 책 제외) |
| DELETE | `/api/groups/{groupId}` | 모임 삭제 (host만) |
| GET | `/api/groups/{groupId}/members` | 모임 멤버 목록 (모임원만) |

**설계 결정**
- 나가기/강퇴 기능은 이번 스코프에서 제외 (정원 찰 때까지 멤버 고정, host 위임 로직 불필요)
- 모임 기간(시작일~종료일)은 강제되지 않는 안내용 값 — 종료일이 지나도 모임 목록 노출, 흔적/의견 작성 모두 계속 가능. `ended` 필드는 FE 배지 표시용 정보성 값일 뿐 어떤 API도 이 값으로 접근을 막지 않음 (PM 확인 반영)

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava compileTestJava` 통과
- `GroupTest`(7) / `GroupServiceTest`(11) / `GroupControllerTest`(13) 전부 통과

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인 (`GroupQueryRepositoryTest` 제외 — 위 테스트 결과 참고)
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 참고) 나가기 기능은 따로 언급된 바가 없어 기능에서 완전히 제외함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 독서 모임을 생성하고 이름, 정원, 기간을 관리할 수 있습니다.
  - 내가 참여한 모임을 페이지 단위로 조회할 수 있습니다.
  - 모임 상세 정보와 도서, 호스트, 현재 멤버 수를 확인할 수 있습니다.
  - 모임 멤버 목록과 역할, 가입 일시를 조회할 수 있습니다.
  - 호스트가 모임 설정을 수정하거나 모임을 삭제할 수 있습니다.
  - 초대 코드가 자동으로 발급됩니다.

- **오류 처리**
  - 잘못된 기간·정원, 비회원 접근, 호스트 권한 부족 등의 상황을 명확한 오류로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->