### PR TITLE
Feat/#126 모임 초대 링크 및 가입

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/application/GroupInvitationPreview.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupInvitationPreview.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.group.application;
+
+import com.nexters.palang.domain.group.domain.Group;
+
+// 초대 링크 미리보기 조회용 뷰. alreadyJoined는 비로그인 요청이면 항상 false다.
+public record GroupInvitationPreview(Group group, long memberCount, boolean alreadyJoined) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
@@ -4,6 +4,8 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.domain.group.domain.GroupMember;
 import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInvitationPreviewResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInviteLinkResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupMemberResponse;
@@ -48,5 +50,18 @@ public final class GroupMapper {
 
     public static GroupMemberListResponse toMemberListResponse(Page<GroupMember> page) {
         return new GroupMemberListResponse(page.map(GroupMapper::toMemberResponse).getContent(), PageInfo.from(page));
+    }
+
+    public static GroupInviteLinkResponse toInviteLinkResponse(Long groupId, String inviteCode) {
+        return new GroupInviteLinkResponse(groupId, inviteCode);
+    }
+
+    public static GroupInvitationPreviewResponse toInvitationPreviewResponse(GroupInvitationPreview preview) {
+        Group group = preview.group();
+        Book book = group.getBook();
+        boolean full = preview.memberCount() >= group.getCapacity();
+        return new GroupInvitationPreviewResponse(
+                group.getId(), group.getName(), book.getTitle(), book.getAuthor(), book.getCoverImageUrl(),
+                group.getCapacity(), preview.memberCount(), full, preview.alreadyJoined());
     }
 }

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
@@ -60,9 +60,12 @@ public class GroupService {
         return new GroupDetail(group, groupMemberRepository.countByGroupId(groupId));
     }
 
+    // joinGroup(초대 가입)과 같은 Group row 잠금을 사용한다 — 정원을 줄이는 것과 동시 가입이 겹치면
+    // "참여 인원 > 정원"이 될 수 있어(TOCTOU), 두 경로 모두 같은 락으로 직렬화해야 한다.
     @Transactional
     public GroupDetail updateGroup(Long groupId, Long userId, UpdateGroupRequest request) {
-        Group group = getExistingGroup(groupId);
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
         validateHost(group, userId);
         long memberCount = groupMemberRepository.countByGroupId(groupId);
         group.updateSettings(request.name(), request.capacity(), request.startDate(), request.endDate(), memberCount);

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
@@ -83,9 +83,56 @@ public class GroupService {
         return groupQueryRepository.findMembers(groupId, pageable);
     }
 
+    public String getInviteLink(Long groupId, Long userId) {
+        Group group = getExistingGroup(groupId);
+        validateHost(group, userId);
+        return group.getInviteCode();
+    }
+
+    @Transactional
+    public String regenerateInviteLink(Long groupId, Long userId) {
+        Group group = getExistingGroup(groupId);
+        validateHost(group, userId);
+        group.regenerateInviteCode();
+        return group.getInviteCode();
+    }
+
+    // 초대 링크 미리보기: 비로그인 요청도 허용해야 하므로 userId는 nullable이다(Soft Authentication).
+    public GroupInvitationPreview previewInvitation(String inviteCode, Long userId) {
+        Group group = getExistingGroupByInviteCode(inviteCode);
+        long memberCount = groupMemberRepository.countByGroupId(group.getId());
+        boolean alreadyJoined = userId != null && groupMemberRepository.existsByGroupIdAndUserId(group.getId(), userId);
+        return new GroupInvitationPreview(group, memberCount, alreadyJoined);
+    }
+
+    // 초대 링크로 가입. 정원 초과(TOCTOU)를 막기 위해 Group row에 비관적 락을 건 채로 인원 수를
+    // 확인하고 GroupMember를 추가한다 (GroupRepository#findByInviteCodeForUpdate 참고).
+    @Transactional
+    public GroupDetail joinGroup(String inviteCode, Long userId) {
+        Group group = groupRepository.findByInviteCodeForUpdate(inviteCode)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVALID_INVITE_CODE));
+
+        if (groupMemberRepository.existsByGroupIdAndUserId(group.getId(), userId)) {
+            throw new GroupException(GroupErrorCode.ALREADY_JOINED);
+        }
+        long memberCount = groupMemberRepository.countByGroupId(group.getId());
+        if (memberCount >= group.getCapacity()) {
+            throw new GroupException(GroupErrorCode.GROUP_FULL);
+        }
+
+        User user = userRepository.getReferenceById(userId);
+        groupMemberRepository.save(GroupMember.of(group, user, GroupMemberRole.MEMBER));
+        return new GroupDetail(group, memberCount + 1);
+    }
+
     private Group getExistingGroup(Long groupId) {
         return groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private Group getExistingGroupByInviteCode(String inviteCode) {
+        return groupRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.INVALID_INVITE_CODE));
     }
 
     private void validateHost(Group group, Long userId) {

--- a/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
@@ -10,11 +10,14 @@ import org.springframework.http.HttpStatus;
 public enum GroupErrorCode implements BaseErrorCode {
 
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP_404_1", "해당 모임을 찾을 수 없습니다."),
+    INVALID_INVITE_CODE(HttpStatus.NOT_FOUND, "GROUP_404_2", "유효하지 않은 초대 코드입니다."),
     INVALID_GROUP_PERIOD(HttpStatus.BAD_REQUEST, "GROUP_400_1", "시작일은 종료일보다 늦을 수 없습니다."),
     INVALID_GROUP_CAPACITY(HttpStatus.BAD_REQUEST, "GROUP_400_2", "인원은 2명 이상 10명 이하여야 합니다."),
     NOT_HOST(HttpStatus.FORBIDDEN, "GROUP_403_1", "모임장만 가능한 작업입니다."),
     NOT_MEMBER(HttpStatus.FORBIDDEN, "GROUP_403_2", "모임원만 조회할 수 있습니다."),
     CAPACITY_BELOW_MEMBER_COUNT(HttpStatus.CONFLICT, "GROUP_409_1", "인원을 현재 참여 인원보다 적게 설정할 수 없습니다."),
+    ALREADY_JOINED(HttpStatus.CONFLICT, "GROUP_409_2", "이미 가입된 모임입니다."),
+    GROUP_FULL(HttpStatus.CONFLICT, "GROUP_409_3", "모임 정원이 가득 찼습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/group/domain/Group.java
+++ b/src/main/java/com/nexters/palang/domain/group/domain/Group.java
@@ -64,9 +64,11 @@ public class Group extends BaseEntity {
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
-    // 카카오톡 등으로 공유하는 초대 링크의 식별자. 별도 만료 시각을 두지 않고 endDate가 지나면 자연히
-    // 무효화되는 것으로 취급한다(초대/가입 API는 후속 이슈에서 구현).
-    @Column(name = "invite_code", length = 32, nullable = false, updatable = false)
+    // 카카오톡 등으로 공유하는 초대 링크의 식별자. 별도 만료 시각을 두지 않으며, endDate가 지나도
+    // 무효화되지 않는다 — 기간은 강제되지 않는 안내용 값이라는 결정(isEnded() 주석 참고)과 일관되게,
+    // 종료된 모임에도 초대 링크로 새 멤버가 계속 가입할 수 있다. 유출 등으로 재발급이 필요하면
+    // regenerateInviteCode()로 기존 코드를 무효화한다.
+    @Column(name = "invite_code", length = 32, nullable = false)
     private String inviteCode;
 
     private Group(String name, Book book, User host, int capacity, LocalDate startDate, LocalDate endDate, String inviteCode) {
@@ -103,6 +105,12 @@ public class Group extends BaseEntity {
     // 어떤 조회/쓰기 API도 이 값으로 접근을 막지 않는다.
     public boolean isEnded() {
         return LocalDate.now().isAfter(endDate);
+    }
+
+    // 초대 링크 재발급(host 전용): 기존 코드는 즉시 무효화되고 이 코드로 들어온 이후 요청은 전부
+    // INVALID_INVITE_CODE로 거절된다.
+    public void regenerateInviteCode() {
+        this.inviteCode = generateInviteCode();
     }
 
     private static void validateCapacity(int capacity) {

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -1,7 +1,22 @@
 package com.nexters.palang.domain.group.infrastructure;
 
 import com.nexters.palang.domain.group.domain.Group;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다.
+    Optional<Group> findByInviteCode(String inviteCode);
+
+    // 가입(join) 전용. 정원 초과 여부를 확인하고 GroupMember를 추가하는 사이 다른 트랜잭션이 끼어들어
+    // 정원을 넘기는 것(TOCTOU)을 막기 위해 Group row에 비관적 락을 건다. 같은 모임에 대한 동시 가입
+    // 요청은 이 락으로 직렬화되고, 락을 먼저 잡은 트랜잭션이 커밋(또는 롤백)해야 다음 요청이 최신
+    // 참여 인원 수를 보고 진행한다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Group g where g.inviteCode = :inviteCode")
+    Optional<Group> findByInviteCodeForUpdate(String inviteCode);
 }

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -19,4 +19,12 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select g from Group g where g.inviteCode = :inviteCode")
     Optional<Group> findByInviteCodeForUpdate(String inviteCode);
+
+    // 방 설정 변경(정원 변경) 전용. findByInviteCodeForUpdate와 같은 Group row 잠금을 공유해야
+    // 두 경로가 서로를 배제한다 — 그렇지 않으면 host가 정원을 줄이는 사이 다른 사용자가 가입해
+    // "참여 인원 > 정원"인 모임이 만들어질 수 있다(TOCTOU). 다른 PK로 조회해도 잠그는 row가 같으면
+    // DB가 알아서 직렬화하므로, findByInviteCodeForUpdate와 조회 키가 달라도 안전하다.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Group g where g.id = :groupId")
+    Optional<Group> findByIdForUpdate(Long groupId);
 }

--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
@@ -2,6 +2,8 @@ package com.nexters.palang.domain.group.presentation;
 
 import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
 import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInvitationPreviewResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInviteLinkResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
 import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
@@ -115,5 +117,63 @@ public interface GroupApi {
             @Parameter(description = "모임 ID", required = true) Long groupId,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "초대 링크 조회", description = "모임장만 조회할 수 있습니다. 초대 코드는 별도 만료 시각이 없고 "
+            + "모임 기간과도 무관하게 계속 유효합니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupInviteLinkResponse>> getInviteLink(
+            @Parameter(description = "모임 ID", required = true) Long groupId
+    );
+
+    @Operation(summary = "초대 링크 재발급", description = "모임장만 재발급할 수 있습니다. 재발급하면 기존 초대 코드는 즉시 무효화됩니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupInviteLinkResponse>> regenerateInviteLink(
+            @Parameter(description = "모임 ID", required = true) Long groupId
+    );
+
+    @Operation(summary = "초대 링크 미리보기", description = "초대 링크를 열었을 때 가입 전 모임 정보를 보여줍니다. 인증 불필요. "
+            + "Authorization: Bearer {accessToken} 헤더를 보내면 alreadyJoined(이미 가입 여부)도 함께 내려줍니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 초대 코드 (GROUP_404_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/invitations/abc123\",\"title\":\"GROUP_404_2\","
+                                    + "\"status\":404,\"detail\":\"유효하지 않은 초대 코드입니다.\"}")))
+    })
+    ResponseEntity<DataResponse<GroupInvitationPreviewResponse>> previewInvitation(
+            @Parameter(description = "초대 코드", required = true) String inviteCode
+    );
+
+    @Operation(summary = "초대 링크로 모임 가입", description = "정원이 가득 찼거나 이미 가입한 모임이면 가입할 수 없습니다. "
+            + "모임 기간이 지났어도 가입할 수 있습니다. Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "가입 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 초대 코드 (GROUP_404_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 모임 (GROUP_409_2) 또는 정원이 가득 참 (GROUP_409_3)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<DataResponse<GroupDetailResponse>> joinGroup(
+            @Parameter(description = "초대 코드", required = true) String inviteCode
     );
 }

--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
@@ -1,10 +1,13 @@
 package com.nexters.palang.domain.group.presentation;
 
 import com.nexters.palang.domain.group.application.GroupDetail;
+import com.nexters.palang.domain.group.application.GroupInvitationPreview;
 import com.nexters.palang.domain.group.application.GroupMapper;
 import com.nexters.palang.domain.group.application.GroupService;
 import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
 import com.nexters.palang.domain.group.presentation.dto.GroupDetailResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInvitationPreviewResponse;
+import com.nexters.palang.domain.group.presentation.dto.GroupInviteLinkResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupListResponse;
 import com.nexters.palang.domain.group.presentation.dto.GroupMemberListResponse;
 import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
@@ -87,6 +90,38 @@ public class GroupController implements GroupApi {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         return ResponseEntity.ok(DataResponse.from(GroupMapper.toMemberListResponse(
                 groupService.getGroupMembers(groupId, currentUserId, pageable(page, size)))));
+    }
+
+    @Override
+    @GetMapping("/api/groups/{groupId}/invite-link")
+    public ResponseEntity<DataResponse<GroupInviteLinkResponse>> getInviteLink(@PathVariable Long groupId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        String inviteCode = groupService.getInviteLink(groupId, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toInviteLinkResponse(groupId, inviteCode)));
+    }
+
+    @Override
+    @PostMapping("/api/groups/{groupId}/invite-link/regenerate")
+    public ResponseEntity<DataResponse<GroupInviteLinkResponse>> regenerateInviteLink(@PathVariable Long groupId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        String inviteCode = groupService.regenerateInviteLink(groupId, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toInviteLinkResponse(groupId, inviteCode)));
+    }
+
+    @Override
+    @GetMapping("/api/groups/invitations/{inviteCode}")
+    public ResponseEntity<DataResponse<GroupInvitationPreviewResponse>> previewInvitation(@PathVariable String inviteCode) {
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        GroupInvitationPreview preview = groupService.previewInvitation(inviteCode, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toInvitationPreviewResponse(preview)));
+    }
+
+    @Override
+    @PostMapping("/api/groups/invitations/{inviteCode}/join")
+    public ResponseEntity<DataResponse<GroupDetailResponse>> joinGroup(@PathVariable String inviteCode) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        GroupDetail detail = groupService.joinGroup(inviteCode, currentUserId);
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
     }
 
     private Pageable pageable(int page, int size) {

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupInvitationPreviewResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupInvitationPreviewResponse.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 초대 링크로 들어온 사용자가 가입 전 미리 보는 정보. 비로그인 상태에서도 조회 가능해야 하므로
+// 모임 상세(GroupDetailResponse)보다 훨씬 적은 정보만 담는다(멤버 목록, host 정보 등은 노출하지 않음).
+public record GroupInvitationPreviewResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long groupId,
+        @Schema(example = "고전 뽀개기", requiredMode = Schema.RequiredMode.REQUIRED) String name,
+        @Schema(example = "채식주의자", requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(example = "한강", requiredMode = Schema.RequiredMode.REQUIRED) String bookAuthor,
+        @Schema(example = "https://image.aladin.co.kr/product/123/45/cover/8936434120_1.jpg", nullable = true) String bookCoverImageUrl,
+        @Schema(example = "4", requiredMode = Schema.RequiredMode.REQUIRED) int capacity,
+        @Schema(example = "3", requiredMode = Schema.RequiredMode.REQUIRED) long memberCount,
+        @Schema(example = "false", description = "정원이 가득 차 더 이상 가입할 수 없는지 여부",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean full,
+        @Schema(example = "false", description = "요청자가 이미 이 모임의 멤버인지 여부. 비로그인 요청이면 항상 false.",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean alreadyJoined
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupInviteLinkResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupInviteLinkResponse.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.group.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GroupInviteLinkResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long groupId,
+        @Schema(example = "a1b2c3d4e5f64789a0b1c2d3e4f5a6b7", description = "초대 코드. 클라이언트가 이 값으로 딥링크를 구성해 카카오톡 등으로 공유한다.",
+                requiredMode = Schema.RequiredMode.REQUIRED) String inviteCode
+) {
+}

--- a/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
@@ -148,7 +148,7 @@ class GroupServiceTest {
     @DisplayName("모임장이 아니면 방 설정을 변경할 수 없다")
     void updateGroupFailsWhenNotHost() {
         Group group = group(1L, host);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findByIdForUpdate(1L)).willReturn(Optional.of(group));
 
         assertThatThrownBy(() -> groupService.updateGroup(
                 1L, other.getId(), new UpdateGroupRequest("주말 독서 모임", 6, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20))))
@@ -159,7 +159,7 @@ class GroupServiceTest {
     @DisplayName("현재 참여 인원보다 적은 인원으로 방 설정을 변경하면 예외가 발생한다")
     void updateGroupFailsWhenCapacityBelowMemberCount() {
         Group group = group(1L, host);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findByIdForUpdate(1L)).willReturn(Optional.of(group));
         given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
 
         assertThatThrownBy(() -> groupService.updateGroup(
@@ -171,7 +171,7 @@ class GroupServiceTest {
     @DisplayName("모임장은 방 설정을 변경할 수 있다")
     void updateGroupSucceeds() {
         Group group = group(1L, host);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findByIdForUpdate(1L)).willReturn(Optional.of(group));
         given(groupMemberRepository.countByGroupId(1L)).willReturn(1L);
 
         GroupDetail detail = groupService.updateGroup(
@@ -179,6 +179,20 @@ class GroupServiceTest {
 
         assertThat(detail.group().getName()).isEqualTo("주말 독서 모임");
         assertThat(detail.group().getCapacity()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("방 설정을 변경할 때는 동시 가입과의 정원 race를 막기 위해 잠금 조회를 사용한다")
+    void updateGroupUsesLockedLookup() {
+        Group group = group(1L, host);
+        given(groupRepository.findByIdForUpdate(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(1L);
+
+        groupService.updateGroup(
+                1L, host.getId(), new UpdateGroupRequest("주말 독서 모임", 6, LocalDate.of(2026, 8, 21), LocalDate.of(2026, 9, 27)));
+
+        verify(groupRepository).findByIdForUpdate(1L);
+        verify(groupRepository, never()).findById(any());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
@@ -212,4 +212,124 @@ class GroupServiceTest {
 
         assertThatThrownBy(() -> groupService.getGroupMembers(1L, other.getId(), null)).isInstanceOf(GroupException.class);
     }
+
+    @Test
+    @DisplayName("모임장이 아니면 초대 링크를 조회할 수 없다")
+    void getInviteLinkFailsWhenNotHost() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupService.getInviteLink(1L, other.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임장은 초대 링크를 조회할 수 있다")
+    void getInviteLinkSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        String inviteCode = groupService.getInviteLink(1L, host.getId());
+
+        assertThat(inviteCode).isEqualTo(group.getInviteCode());
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 초대 링크를 재발급할 수 없다")
+    void regenerateInviteLinkFailsWhenNotHost() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> groupService.regenerateInviteLink(1L, other.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임장은 초대 링크를 재발급할 수 있고, 코드가 바뀐다")
+    void regenerateInviteLinkSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        String originalInviteCode = group.getInviteCode();
+
+        String newInviteCode = groupService.regenerateInviteLink(1L, host.getId());
+
+        assertThat(newInviteCode).isNotEqualTo(originalInviteCode);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 초대 코드로 미리보기를 조회하면 예외가 발생한다")
+    void previewInvitationFailsWhenInvalidCode() {
+        given(groupRepository.findByInviteCode("invalid")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.previewInvitation("invalid", null)).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("비로그인 상태로 초대 미리보기를 조회하면 alreadyJoined는 항상 false다")
+    void previewInvitationForGuest() {
+        Group group = group(1L, host);
+        given(groupRepository.findByInviteCode(group.getInviteCode())).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(2L);
+
+        GroupInvitationPreview preview = groupService.previewInvitation(group.getInviteCode(), null);
+
+        assertThat(preview.memberCount()).isEqualTo(2L);
+        assertThat(preview.alreadyJoined()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 가입한 사용자가 초대 미리보기를 조회하면 alreadyJoined가 true다")
+    void previewInvitationForExistingMember() {
+        Group group = group(1L, host);
+        given(groupRepository.findByInviteCode(group.getInviteCode())).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(2L);
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, host.getId())).willReturn(true);
+
+        GroupInvitationPreview preview = groupService.previewInvitation(group.getInviteCode(), host.getId());
+
+        assertThat(preview.alreadyJoined()).isTrue();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 초대 코드로 가입하면 예외가 발생한다")
+    void joinGroupFailsWhenInvalidCode() {
+        given(groupRepository.findByInviteCodeForUpdate("invalid")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> groupService.joinGroup("invalid", other.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("이미 가입한 모임에 다시 가입하면 예외가 발생한다")
+    void joinGroupFailsWhenAlreadyJoined() {
+        Group group = group(1L, host);
+        given(groupRepository.findByInviteCodeForUpdate(group.getInviteCode())).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, host.getId())).willReturn(true);
+
+        assertThatThrownBy(() -> groupService.joinGroup(group.getInviteCode(), host.getId())).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("정원이 가득 찬 모임에 가입하면 예외가 발생한다")
+    void joinGroupFailsWhenFull() {
+        Group group = group(1L, host);
+        given(groupRepository.findByInviteCodeForUpdate(group.getInviteCode())).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, other.getId())).willReturn(false);
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(4L);
+
+        assertThatThrownBy(() -> groupService.joinGroup(group.getInviteCode(), other.getId())).isInstanceOf(GroupException.class);
+        verify(groupMemberRepository, never()).save(any(GroupMember.class));
+    }
+
+    @Test
+    @DisplayName("정원이 남아있으면 초대 링크로 모임에 가입할 수 있다")
+    void joinGroupSucceeds() {
+        Group group = group(1L, host);
+        given(groupRepository.findByInviteCodeForUpdate(group.getInviteCode())).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByGroupIdAndUserId(1L, other.getId())).willReturn(false);
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(1L);
+        given(userRepository.getReferenceById(other.getId())).willReturn(other);
+
+        GroupDetail detail = groupService.joinGroup(group.getInviteCode(), other.getId());
+
+        assertThat(detail.memberCount()).isEqualTo(2L);
+        verify(groupMemberRepository).save(any(GroupMember.class));
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/group/domain/GroupTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/domain/GroupTest.java
@@ -95,4 +95,16 @@ class GroupTest {
 
         assertThat(group.isEnded()).isTrue();
     }
+
+    @Test
+    @DisplayName("초대 코드를 재발급하면 기존 코드와 달라진다")
+    void regeneratesInviteCode() {
+        Group group = Group.create(
+                "고전 뽀개기", book(), user(1L), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        String originalInviteCode = group.getInviteCode();
+
+        group.regenerateInviteCode();
+
+        assertThat(group.getInviteCode()).isNotBlank().isNotEqualTo(originalInviteCode);
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.group.application.GroupDetail;
+import com.nexters.palang.domain.group.application.GroupInvitationPreview;
 import com.nexters.palang.domain.group.application.GroupService;
 import com.nexters.palang.domain.group.common.error.GroupErrorCode;
 import com.nexters.palang.domain.group.common.error.GroupException;
@@ -241,5 +242,97 @@ class GroupControllerTest {
         mockMvc.perform(get("/api/groups/1/members"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.members[0].role").value("HOST"));
+    }
+
+    @Test
+    @DisplayName("모임장은 초대 링크를 조회할 수 있다")
+    void getInviteLink() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.getInviteLink(1L, 1L)).willReturn("invitecode123");
+
+        mockMvc.perform(get("/api/groups/1/invite-link"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.groupId").value(1))
+                .andExpect(jsonPath("$.data.inviteCode").value("invitecode123"));
+    }
+
+    @Test
+    @DisplayName("모임장이 아니면 초대 링크 조회 시 403 에러가 발생한다")
+    void getInviteLinkFailsWhenNotHost() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        given(groupService.getInviteLink(1L, 2L)).willThrow(new GroupException(GroupErrorCode.NOT_HOST));
+
+        mockMvc.perform(get("/api/groups/1/invite-link"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_1"));
+    }
+
+    @Test
+    @DisplayName("모임장은 초대 링크를 재발급할 수 있다")
+    void regenerateInviteLink() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(groupService.regenerateInviteLink(1L, 1L)).willReturn("newinvitecode456");
+
+        mockMvc.perform(post("/api/groups/1/invite-link/regenerate"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.inviteCode").value("newinvitecode456"));
+    }
+
+    @Test
+    @DisplayName("초대 링크를 미리보기하면 모임 정보를 반환한다")
+    void previewInvitation() throws Exception {
+        Group group = group(1L, user(1L));
+        given(groupService.previewInvitation(group.getInviteCode(), null))
+                .willReturn(new GroupInvitationPreview(group, 2L, false));
+
+        mockMvc.perform(get("/api/groups/invitations/" + group.getInviteCode()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberCount").value(2))
+                .andExpect(jsonPath("$.data.full").value(false))
+                .andExpect(jsonPath("$.data.alreadyJoined").value(false));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 초대 코드를 미리보기하면 404 에러가 발생한다")
+    void previewInvitationFailsWhenInvalidCode() throws Exception {
+        given(groupService.previewInvitation("invalid", null))
+                .willThrow(new GroupException(GroupErrorCode.INVALID_INVITE_CODE));
+
+        mockMvc.perform(get("/api/groups/invitations/invalid"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("GROUP_404_2"));
+    }
+
+    @Test
+    @DisplayName("초대 코드로 모임에 가입하면 가입된 모임 정보를 반환한다")
+    void joinGroup() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        Group group = group(1L, user(1L));
+        given(groupService.joinGroup(group.getInviteCode(), 2L)).willReturn(new GroupDetail(group, 2L));
+
+        mockMvc.perform(post("/api/groups/invitations/" + group.getInviteCode() + "/join"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberCount").value(2));
+    }
+
+    @Test
+    @DisplayName("인증 없이 모임에 가입하면 401 에러가 발생한다")
+    void joinGroupFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(post("/api/groups/invitations/somecode/join"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("정원이 가득 찬 모임에 가입하면 409 에러가 발생한다")
+    void joinGroupFailsWhenFull() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        given(groupService.joinGroup("somecode", 2L)).willThrow(new GroupException(GroupErrorCode.GROUP_FULL));
+
+        mockMvc.perform(post("/api/groups/invitations/somecode/join"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.title").value("GROUP_409_3"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #126

## 🚀 개요
모임 초대 링크를 조회/재발급하고, 그 링크로 새 멤버가 모임에 가입할 수 있는 API를 추가합니다. 초대 코드는 모임 기간(`endDate`)과 무관하게 계속 유효합니다.

## 📄 작업 내용
- `Group`에 `regenerateInviteCode()` 추가 (기존 코드 즉시 무효화), `invite_code` 컬럼 `updatable=false` 해제
- `GroupErrorCode`에 초대/가입 관련 에러코드 추가: `INVALID_INVITE_CODE`(404), `ALREADY_JOINED`(409), `GROUP_FULL`(409)
- `GroupRepository`에 조회용 `findByInviteCode`, 가입 전용 `findByInviteCodeForUpdate`(비관적 락) 추가
- `GroupService`에 초대 링크 조회/재발급(host만), 초대 미리보기(비로그인 허용), 가입 로직 추가
- `GroupApi`/`GroupController`에 아래 4개 엔드포인트 추가

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/groups/{groupId}/invite-link` | 초대 링크 조회 (host만) |
| POST | `/api/groups/{groupId}/invite-link/regenerate` | 초대 링크 재발급 (host만, 기존 코드 무효화) |
| GET | `/api/groups/invitations/{inviteCode}` | 초대 미리보기 (비로그인 허용, 로그인 시 alreadyJoined 포함) |
| POST | `/api/groups/invitations/{inviteCode}/join` | 초대 코드로 가입 |

**설계 결정**
- 초대 코드는 별도 만료 시각을 두지 않으며, 모임 기간이 지나도 무효화되지 않습니다 (모임 기간은 강제되지 않는 안내용 값이라는 이전 결정과 일관되게 유지). 유출 등으로 재발급이 필요할 때만 host가 수동으로 재발급합니다.
- 동시 가입으로 정원을 초과하는 것(TOCTOU)을 막기 위해, 가입 시점에 `Group` row에 비관적 락(`PESSIMISTIC_WRITE`)을 걸고 그 안에서 정원을 재확인한 뒤 멤버를 추가합니다. 같은 모임에 대한 동시 가입 요청은 이 락으로 직렬화됩니다.
- 초대 미리보기는 멤버 목록·host 정보 없이 최소한의 정보(모임명/책 정보/인원 현황)만 노출합니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava compileTestJava` 통과
- `GroupTest`(9) / `GroupServiceTest`(20) / `GroupControllerTest`(21) 전부 통과 — group 패키지 non-DataJpaTest 51개 전부 통과

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인 (`GroupQueryRepositoryTest` 제외 — 위 테스트 결과 참고)
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 정원 초과 방지를 위한 `PESSIMISTIC_WRITE` 락 방식이 적절할지 (동시 가입 요청이 많아지는 시나리오에서 락 대기가 병목이 될 가능성)
- 초대 코드에 만료 시각을 두지 않는 결정(#125 리뷰에서 이어짐)이 여전히 맞는 방향인지 — 유출 시 재발급 외에 추가 방어가 필요한지
- 초대 미리보기 응답에서 노출 범위(모임명/책 정보/인원 현황까지만)가 적절한지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 그룹 초대 링크를 조회하고 재발급할 수 있습니다.
  * 초대 링크를 통해 그룹 정보, 정원, 현재 멤버 수와 가입 가능 여부를 미리 확인할 수 있습니다.
  * 유효한 초대 코드로 그룹에 가입할 수 있습니다.
  * 잘못된 초대 코드, 중복 가입, 정원 초과 상황을 안내합니다.
  * 초대 코드는 그룹 종료일 이후에도 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->