### PR TITLE
Feat/#127 모임 내 흔적 및 의견 공유

### DIFF
--- a/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
+++ b/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
@@ -7,6 +7,8 @@ import com.nexters.palang.domain.comment.infrastructure.CommentQueryRepository;
 import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
 import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
 import com.nexters.palang.domain.comment.presentation.dto.UpdateCommentRequest;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -35,9 +37,12 @@ public class CommentService {
     private final CommentQueryRepository commentQueryRepository;
     private final OpinionRepository opinionRepository;
     private final UserRepository userRepository;
+    private final GroupAccessValidator groupAccessValidator;
 
+    // 흔적이 모임 전용이면(passage.group != null) 모임원만 댓글을 보거나 남길 수 있다.
     public Page<RootCommentGroup> getRootComments(Long opinionId, Pageable pageable, Long currentUserId) {
-        validateOpinionExists(opinionId);
+        Opinion opinion = getExistingOpinion(opinionId);
+        validateGroupAccess(opinion, currentUserId);
 
         Page<Comment> roots = commentQueryRepository.findRootComments(opinionId, pageable, currentUserId);
         List<Long> rootIds = roots.getContent().stream().map(Comment::getId).toList();
@@ -53,13 +58,15 @@ public class CommentService {
 
     public Page<Comment> getReplies(Long parentCommentId, Pageable pageable, Long currentUserId) {
         Comment parent = getExistingComment(parentCommentId);
-        getExistingOpinion(parent.getOpinion().getId());
+        Opinion opinion = getExistingOpinion(parent.getOpinion().getId());
+        validateGroupAccess(opinion, currentUserId);
         return commentQueryRepository.findReplies(parentCommentId, pageable, currentUserId);
     }
 
     @Transactional
     public Comment createComment(Long opinionId, Long userId, CreateCommentRequest request) {
         Opinion opinion = getExistingOpinion(opinionId);
+        validateGroupAccess(opinion, userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
@@ -89,8 +96,11 @@ public class CommentService {
         comment.delete();
     }
 
-    private void validateOpinionExists(Long opinionId) {
-        getExistingOpinion(opinionId);
+    private void validateGroupAccess(Opinion opinion, Long userId) {
+        Group group = opinion.getPassage().getGroup();
+        if (group != null) {
+            groupAccessValidator.validateMember(group.getId(), userId);
+        }
     }
 
     private Opinion getExistingOpinion(Long opinionId) {

--- a/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
+++ b/src/main/java/com/nexters/palang/domain/comment/presentation/CommentApi.java
@@ -25,13 +25,18 @@ public interface CommentApi {
             description = "흔적에 달린 원댓글과 답글을 조회합니다. 원댓글은 page/size로 페이지네이션되며, "
                     + "각 원댓글에는 답글이 최대 5개까지 미리보기로 포함됩니다. 5개를 초과하면 hasMoreReplies=true이며, "
                     + "나머지는 GET /api/comments/{commentId}/replies로 조회합니다. "
-                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 댓글/답글은 목록에서 제외됩니다.")
+                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 댓글/답글은 목록에서 제외됩니다. "
+                    + "흔적이 모임 전용이면 모임원만 조회할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 흔적인데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"GROUP_403_2\","
+                                    + "\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"OPINION_404_1\","
@@ -45,13 +50,18 @@ public interface CommentApi {
 
     @Operation(summary = "답글 더보기",
             description = "특정 원댓글에 달린 답글을 page/size로 페이지네이션 조회합니다. "
-                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 답글은 목록에서 제외됩니다.")
+                    + "로그인 상태면(Authorization 헤더) 내가 차단한 사용자의 답글은 목록에서 제외됩니다. "
+                    + "흔적이 모임 전용이면 모임원만 조회할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/comments/1/replies\",\"title\":\"COMMON_400_1\","
                                     + "\"status\":400,\"detail\":\"'page' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 흔적인데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/comments/1/replies\",\"title\":\"GROUP_403_2\","
+                                    + "\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음 (COMMENT_404_1) "
                     + "또는 해당 댓글이 속한 흔적이 삭제됨 (OPINION_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
@@ -72,6 +82,7 @@ public interface CommentApi {
     @Operation(summary = "댓글/답글 작성",
             description = "흔적에 댓글 또는 답글을 작성합니다. parentCommentId가 없으면 원댓글, 있으면 답글로 생성됩니다. "
                     + "답글에는 다시 답글을 남길 수 없습니다(1-depth). 삭제된 댓글을 부모로 답글을 작성할 수 없습니다. "
+                    + "흔적이 모임 전용이면 모임원만 작성할 수 있습니다. "
                     + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "작성 성공"),
@@ -89,6 +100,10 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"AUTH_401_1\","
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 흔적인데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1/comments\",\"title\":\"GROUP_403_2\","
+                                    + "\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "흔적 또는 부모 댓글을 찾을 수 없음 "
                     + "(OPINION_404_1/COMMENT_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupAccessValidator.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupAccessValidator.java
@@ -1,0 +1,24 @@
+package com.nexters.palang.domain.group.application;
+
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// 모임 스코프 리소스(모임 자체는 물론, 모임에 속한 흔적/의견 등)에 대한 "이 사용자가 모임원인가" 검증을
+// 한 곳에 모은다. group 도메인 밖(passage/opinion 등)에서도 재사용하므로 별도 컴포넌트로 뺐다.
+@Component
+@RequiredArgsConstructor
+public class GroupAccessValidator {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    // userId가 null이면(비로그인) 애초에 모임원일 수 없으므로 곧바로 거절한다(Soft Authentication 경로에서
+    // groupId가 있는 리소스에 접근할 때 유용 — 로그인 여부와 무관하게 "모임원 아님" 하나로 처리).
+    public void validateMember(Long groupId, Long userId) {
+        if (userId == null || !groupMemberRepository.existsByGroupIdAndUserId(groupId, userId)) {
+            throw new GroupException(GroupErrorCode.NOT_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/group/common/error/GroupErrorCode.java
@@ -13,6 +13,7 @@ public enum GroupErrorCode implements BaseErrorCode {
     INVALID_INVITE_CODE(HttpStatus.NOT_FOUND, "GROUP_404_2", "유효하지 않은 초대 코드입니다."),
     INVALID_GROUP_PERIOD(HttpStatus.BAD_REQUEST, "GROUP_400_1", "시작일은 종료일보다 늦을 수 없습니다."),
     INVALID_GROUP_CAPACITY(HttpStatus.BAD_REQUEST, "GROUP_400_2", "인원은 2명 이상 10명 이하여야 합니다."),
+    GROUP_BOOK_MISMATCH(HttpStatus.BAD_REQUEST, "GROUP_400_3", "선택한 도서가 모임의 지정 도서와 일치하지 않습니다."),
     NOT_HOST(HttpStatus.FORBIDDEN, "GROUP_403_1", "모임장만 가능한 작업입니다."),
     NOT_MEMBER(HttpStatus.FORBIDDEN, "GROUP_403_2", "모임원만 조회할 수 있습니다."),
     CAPACITY_BELOW_MEMBER_COUNT(HttpStatus.CONFLICT, "GROUP_409_1", "인원을 현재 참여 인원보다 적게 설정할 수 없습니다."),

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionLikeService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionLikeService.java
@@ -1,5 +1,7 @@
 package com.nexters.palang.domain.opinion.application;
 
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -21,10 +23,12 @@ public class OpinionLikeService {
     private final OpinionRepository opinionRepository;
     private final OpinionLikeRepository opinionLikeRepository;
     private final UserRepository userRepository;
+    private final GroupAccessValidator groupAccessValidator;
 
     @Transactional
     public OpinionLikeResult toggleLike(Long userId, Long opinionId) {
         Opinion opinion = getExistingOpinion(opinionId);
+        validateGroupAccess(opinion, userId);
         if (opinionLikeRepository.existsByUserIdAndOpinionId(userId, opinionId)) {
             return unlike(userId, opinion);
         }
@@ -51,5 +55,13 @@ public class OpinionLikeService {
             throw new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND);
         }
         return opinion;
+    }
+
+    // 흔적이 모임 전용이면(passage.group != null) 모임원만 좋아요를 남기거나 취소할 수 있다.
+    private void validateGroupAccess(Opinion opinion, Long userId) {
+        Group group = opinion.getPassage().getGroup();
+        if (group != null) {
+            groupAccessValidator.validateMember(group.getId(), userId);
+        }
     }
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -6,6 +6,11 @@ import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
 import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -25,6 +30,7 @@ import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -42,19 +48,30 @@ public class OpinionService {
     private final PassageRepository passageRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+    private final GroupAccessValidator groupAccessValidator;
 
     // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순. currentUserId는 비로그인 시 null(liked는 항상 false).
+    // 대목이 모임 전용이면(passage.group != null) 모임원만 조회할 수 있다.
     public Page<OpinionSummaryProjection> getOpinions(
             Long passageId, OpinionSortType sortType, Pageable pageable, Long currentUserId) {
-        if (!passageRepository.existsByIdAndDeletedAtIsNull(passageId)) {
-            throw new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND);
+        Passage passage = passageRepository.findByIdAndDeletedAtIsNull(passageId)
+                .orElseThrow(() -> new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
+        if (passage.getGroup() != null) {
+            groupAccessValidator.validateMember(passage.getGroup().getId(), currentUserId);
         }
         return opinionQueryRepository.findOpinions(passageId, sortType, pageable, currentUserId);
     }
 
     // 흔적 상세(FR-OPINION-05): 이 흔적 작성자가 기록한 꾸밈을 그대로 보여준다.
-    public Opinion getOpinion(Long opinionId) {
-        return getExistingOpinion(opinionId);
+    // 대목이 모임 전용이면 모임원만 조회할 수 있다. currentUserId는 비로그인 시 null(Soft Authentication).
+    public Opinion getOpinion(Long opinionId, Long currentUserId) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        Group group = opinion.getPassage().getGroup();
+        if (group != null) {
+            groupAccessValidator.validateMember(group.getId(), currentUserId);
+        }
+        return opinion;
     }
 
     @Transactional
@@ -95,10 +112,14 @@ public class OpinionService {
     }
 
     // Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 한 트랜잭션에서 원자적으로 생성한다. (직접 입력만)
+    // request.groupId()가 있으면 그 모임 전용 흔적/대목이 되며, 작성자가 모임원인지 먼저 검증한다.
     @Transactional
     public Opinion createOpinion(Long userId, CreateOpinionRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        if (request.groupId() != null) {
+            groupAccessValidator.validateMember(request.groupId(), userId);
+        }
 
         boolean merged = request.passageId() != null;
         Passage passage = merged ? mergeIntoExistingPassage(request) : createNewPassage(request, user);
@@ -125,6 +146,12 @@ public class OpinionService {
         }
         if (!existing.getBook().getId().equals(request.bookId())) {
             throw new PassageException(PassageErrorCode.PASSAGE_BOOK_MISMATCH);
+        }
+        // 병합 대상 대목의 소속 모임과 요청이 지정한 모임이 정확히 일치해야 한다(둘 다 null=전역 공개도 일치).
+        // 그렇지 않으면 전역 공개 대목에 모임 흔적이 섞이거나 그 반대가 될 수 있다.
+        Long existingGroupId = existing.getGroup() != null ? existing.getGroup().getId() : null;
+        if (!Objects.equals(existingGroupId, request.groupId())) {
+            throw new PassageException(PassageErrorCode.PASSAGE_GROUP_MISMATCH);
         }
         return existing;
     }
@@ -175,14 +202,30 @@ public class OpinionService {
     private Passage createNewPassage(CreateOpinionRequest request, User creator) {
         Book book = bookRepository.findById(request.bookId())
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
+        Group group = resolveGroup(request.groupId(), request.bookId());
         Passage passage = Passage.builder()
                 .book(book)
                 .creator(creator)
+                .group(group)
                 .pageNumber(request.pageNumber())
                 .quotedText(request.quotedText())
                 .isSpoiler(request.isSpoiler())
                 .normalizedHash(PassageNormalizer.normalizedHash(request.quotedText()))
                 .build();
         return passageRepository.save(passage);
+    }
+
+    // 모임은 생성 시 책이 고정되므로(Group 불변식), 이 모임 소속으로 새 대목을 만들 때 요청의 bookId가
+    // 그 모임의 책과 다르면 막는다.
+    private Group resolveGroup(Long groupId, Long bookId) {
+        if (groupId == null) {
+            return null;
+        }
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+        if (!group.getBook().getId().equals(bookId)) {
+            throw new GroupException(GroupErrorCode.GROUP_BOOK_MISMATCH);
+        }
+        return group;
     }
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -74,6 +74,10 @@ public class OpinionService {
         return opinion;
     }
 
+    // 모임 전용 흔적이어도 별도 group 검증은 하지 않는다: 수정/삭제는 작성자 본인만 가능하고(validateOwner),
+    // 이 앱에는 모임 나가기/강퇴가 없어 한 번 모임원이면 계속 모임원이다 — 즉 작성 시점에 이미 모임원임이
+    // 확인됐던 사람이라면 지금도 여전히 모임원이라는 뜻이라 owner 검증만으로 충분하다. 나가기/강퇴가 생기면
+    // 이 가정이 깨지므로 그때는 group 검증을 함께 추가해야 한다.
     @Transactional
     public Opinion modifyOpinion(Long opinionId, Long userId, UpdateOpinionRequest request) {
         Opinion opinion = getExistingOpinion(opinionId);
@@ -84,6 +88,7 @@ public class OpinionService {
 
     // 대목은 여러 사용자가 공유하는 단위이므로, 이 삭제로 그 대목에 살아있는 흔적이 하나도 남지 않을 때만
     // 대목도 함께 소프트 삭제한다 (PM 요구사항: 흔적 0개인 대목은 존재할 수 없다).
+    // group 검증 불필요 이유는 modifyOpinion 주석 참고.
     @Transactional
     public void removeOpinion(Long opinionId, Long userId) {
         Opinion opinion = getExistingOpinion(opinionId);
@@ -113,16 +118,18 @@ public class OpinionService {
 
     // Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 한 트랜잭션에서 원자적으로 생성한다. (직접 입력만)
     // request.groupId()가 있으면 그 모임 전용 흔적/대목이 되며, 작성자가 모임원인지 먼저 검증한다.
+    // 존재하지 않는 groupId는 (멤버십 검증이 항상 false로 실패해 403을 내기 전에) 여기서 먼저 404로 걸러낸다.
     @Transactional
     public Opinion createOpinion(Long userId, CreateOpinionRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-        if (request.groupId() != null) {
-            groupAccessValidator.validateMember(request.groupId(), userId);
+        Group group = resolveGroup(request.groupId());
+        if (group != null) {
+            groupAccessValidator.validateMember(group.getId(), userId);
         }
 
         boolean merged = request.passageId() != null;
-        Passage passage = merged ? mergeIntoExistingPassage(request) : createNewPassage(request, user);
+        Passage passage = merged ? mergeIntoExistingPassage(request) : createNewPassage(request, user, group);
 
         List<Decoration> decorations = request.decorations().stream()
                 .map(d -> Decoration.builder()
@@ -199,10 +206,14 @@ public class OpinionService {
         return opinionRepository.countByUserIdAndDeletedAtIsNull(userId);
     }
 
-    private Passage createNewPassage(CreateOpinionRequest request, User creator) {
+    // 모임은 생성 시 책이 고정되므로(Group 불변식), 이 모임 소속으로 새 대목을 만들 때 요청의 bookId가
+    // 그 모임의 책과 다르면 막는다.
+    private Passage createNewPassage(CreateOpinionRequest request, User creator, Group group) {
         Book book = bookRepository.findById(request.bookId())
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
-        Group group = resolveGroup(request.groupId(), request.bookId());
+        if (group != null && !group.getBook().getId().equals(request.bookId())) {
+            throw new GroupException(GroupErrorCode.GROUP_BOOK_MISMATCH);
+        }
         Passage passage = Passage.builder()
                 .book(book)
                 .creator(creator)
@@ -215,17 +226,11 @@ public class OpinionService {
         return passageRepository.save(passage);
     }
 
-    // 모임은 생성 시 책이 고정되므로(Group 불변식), 이 모임 소속으로 새 대목을 만들 때 요청의 bookId가
-    // 그 모임의 책과 다르면 막는다.
-    private Group resolveGroup(Long groupId, Long bookId) {
+    private Group resolveGroup(Long groupId) {
         if (groupId == null) {
             return null;
         }
-        Group group = groupRepository.findById(groupId)
+        return groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
-        if (!group.getBook().getId().equals(bookId)) {
-            throw new GroupException(GroupErrorCode.GROUP_BOOK_MISMATCH);
-        }
-        return group;
     }
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -15,6 +15,10 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
 
     // open-in-view: false 환경에서 컨트롤러 단 응답 매핑이 opinion.getUser()/getDecorations()를
     // 참조하므로 트랜잭션 안에서 미리 로딩해야 LazyInitializationException을 피할 수 있다.
-    @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations where o.id = :id")
+    // passage/passage.group도 함께 fetch join한다 — OpinionService.getOpinion()이 모임 스코프 흔적인지
+    // 판단하려면 group을 초기화해야 하는데, 서비스 메서드 트랜잭션이 끝난 뒤(컨트롤러 매핑 시점)에는
+    // 지연 로딩이 막혀 있어 이 시점에 함께 가져와야 한다.
+    @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations "
+            + "left join fetch o.passage p left join fetch p.group where o.id = :id")
     Optional<Opinion> findDetailById(@Param("id") Long id);
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
@@ -152,6 +152,7 @@ public interface OpinionApi {
 
     @Operation(summary = "흔적 좋아요 토글",
             description = "좋아요를 누르지 않은 상태면 좋아요를 남기고, 이미 눌렀다면 취소합니다. "
+                    + "흔적이 모임 전용이면 모임원만 좋아요를 남기거나 취소할 수 있습니다. "
                     + "X-Debug-User-Id 헤더로 인증합니다(임시 스탠드인).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "좋아요 토글 성공"),
@@ -159,6 +160,11 @@ public interface OpinionApi {
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = "{\"type\":\"/api/opinions/1/like\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))
+            ),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 흔적인데 모임원이 아님",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"type\":\"/api/opinions/1/like\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))
             ),
             @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
                     content = @Content(

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionApi.java
@@ -26,6 +26,9 @@ public interface OpinionApi {
     @Operation(summary = "흔적 작성 (직접 입력)",
             description = "Passage(신규 생성 또는 기존 병합) + Opinion + Decoration을 원자적으로 생성합니다. "
                     + "passageId가 없으면 새 Passage를 만들고, 있으면 해당 Passage에 병합합니다(Q-06). "
+                    + "groupId를 지정하면 그 모임 전용 흔적/대목이 되며(요청자는 모임원이어야 함), "
+                    + "생략하면 기존처럼 전역 공개로 생성됩니다. passageId와 groupId를 함께 지정한 경우 "
+                    + "기존 대목의 소속 모임과 정확히 일치해야 합니다. "
                     + "OCR 입력은 별도 플로우이며 이 API는 직접 입력만 지원합니다. "
                     + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
@@ -33,12 +36,16 @@ public interface OpinionApi {
             @ApiResponse(responseCode = "400",
                     description = "필수값 누락, 인용 문구/내용 길이 초과(COMMON_400_1), "
                             + "선택한 대목이 지정한 도서와 불일치(PASSAGE_400_2), "
+                            + "선택한 대목이 지정한 모임과 불일치(PASSAGE_400_3), "
+                            + "선택한 도서가 모임의 지정 도서와 불일치(GROUP_400_3), "
                             + "꾸밈 효과 범위 오류(DECORATION_400_1) 또는 겹침(DECORATION_400_2)",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
                                     @ExampleObject(name = "COMMON_400_1: 필수값 누락/길이 초과", value = "{\"type\":\"/api/opinions\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"인용 문구는 150자를 초과할 수 없습니다.\"}"),
                                     @ExampleObject(name = "PASSAGE_400_2: 도서 불일치", value = "{\"type\":\"/api/opinions\",\"title\":\"PASSAGE_400_2\",\"status\":400,\"detail\":\"선택한 대목이 지정한 도서와 일치하지 않습니다.\"}"),
+                                    @ExampleObject(name = "PASSAGE_400_3: 모임 불일치", value = "{\"type\":\"/api/opinions\",\"title\":\"PASSAGE_400_3\",\"status\":400,\"detail\":\"선택한 대목이 지정한 모임과 일치하지 않습니다.\"}"),
+                                    @ExampleObject(name = "GROUP_400_3: 모임 도서 불일치", value = "{\"type\":\"/api/opinions\",\"title\":\"GROUP_400_3\",\"status\":400,\"detail\":\"선택한 도서가 모임의 지정 도서와 일치하지 않습니다.\"}"),
                                     @ExampleObject(name = "DECORATION_400_1: 꾸밈 범위 오류", value = "{\"type\":\"/api/opinions\",\"title\":\"DECORATION_400_1\",\"status\":400,\"detail\":\"꾸밈 효과의 시작 위치는 끝 위치보다 작아야 합니다.\"}"),
                                     @ExampleObject(name = "DECORATION_400_2: 꾸밈 영역 겹침", value = "{\"type\":\"/api/opinions\",\"title\":\"DECORATION_400_2\",\"status\":400,\"detail\":\"같은 흔적 안에서는 꾸밈 효과 영역이 겹칠 수 없습니다.\"}")
                             })
@@ -48,13 +55,20 @@ public interface OpinionApi {
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = "{\"type\":\"/api/opinions\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))
             ),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: groupId를 지정했는데 모임원이 아님",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"type\":\"/api/opinions\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))
+            ),
             @ApiResponse(responseCode = "404",
-                    description = "해당 도서를 찾을 수 없음(BOOK_404_1) 또는 해당 대목을 찾을 수 없음(PASSAGE_404_1)",
+                    description = "해당 도서를 찾을 수 없음(BOOK_404_1), 해당 대목을 찾을 수 없음(PASSAGE_404_1) "
+                            + "또는 해당 모임을 찾을 수 없음(GROUP_404_1)",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
                                     @ExampleObject(name = "BOOK_404_1: 도서 없음", value = "{\"type\":\"/api/opinions\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}"),
-                                    @ExampleObject(name = "PASSAGE_404_1: 대목 없음", value = "{\"type\":\"/api/opinions\",\"title\":\"PASSAGE_404_1\",\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}")
+                                    @ExampleObject(name = "PASSAGE_404_1: 대목 없음", value = "{\"type\":\"/api/opinions\",\"title\":\"PASSAGE_404_1\",\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}"),
+                                    @ExampleObject(name = "GROUP_404_1: 모임 없음", value = "{\"type\":\"/api/opinions\",\"title\":\"GROUP_404_1\",\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")
                             })
             )
     })
@@ -62,12 +76,16 @@ public interface OpinionApi {
             @Valid CreateOpinionRequest request
     );
 
-    @Operation(summary = "흔적 목록 조회", description = "특정 대목에 남겨진 흔적을 정렬 기준(최신순 기본/좋아요순)으로 조회합니다.")
+    @Operation(summary = "흔적 목록 조회", description = "특정 대목에 남겨진 흔적을 정렬 기준(최신순 기본/좋아요순)으로 조회합니다. "
+            + "대목이 모임 전용이면 모임원만 조회할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/passages/1/opinions\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 대목인데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/passages/1/opinions\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 대목을 찾을 수 없음 (PASSAGE_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/passages/1/opinions\",\"title\":\"PASSAGE_404_1\",\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}")))
@@ -79,9 +97,13 @@ public interface OpinionApi {
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
-    @Operation(summary = "흔적 상세 조회", description = "흔적 작성자가 기록한 꾸밈을 그대로 확인합니다(병합된 결과가 아님).")
+    @Operation(summary = "흔적 상세 조회", description = "흔적 작성자가 기록한 꾸밈을 그대로 확인합니다(병합된 결과가 아님). "
+            + "대목이 모임 전용이면 모임원만 조회할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: 모임 전용 흔적인데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/opinions/1\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 흔적을 찾을 수 없음 (OPINION_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/opinions/1\",\"title\":\"OPINION_404_1\",\"status\":404,\"detail\":\"해당 흔적을 찾을 수 없습니다.\"}")))

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/OpinionController.java
@@ -63,7 +63,8 @@ public class OpinionController implements OpinionApi {
     @Override
     @GetMapping("/api/opinions/{opinionId}")
     public ResponseEntity<DataResponse<OpinionDetailResponse>> getOpinion(@PathVariable Long opinionId) {
-        Opinion opinion = opinionService.getOpinion(opinionId);
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        Opinion opinion = opinionService.getOpinion(opinionId, currentUserId);
         return ResponseEntity.ok(DataResponse.from(OpinionDetailResponse.from(opinion)));
     }
 

--- a/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/CreateOpinionRequest.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/presentation/dto/CreateOpinionRequest.java
@@ -34,6 +34,11 @@ public record CreateOpinionRequest(
         @Schema(description = "병합할 기존 대목 ID. 없으면 새 대목을 생성합니다.", example = "5", nullable = true)
         Long passageId,
 
+        // 있으면 이 흔적/대목은 그 모임 전용이 된다(모임원만 조회 가능). 없으면 기존처럼 전역 공개.
+        // passageId를 함께 지정한 경우 기존 대목의 소속 모임과 반드시 일치해야 한다(PASSAGE_400_3).
+        @Schema(description = "모임 ID. 없으면 전역 공개 흔적/대목으로 생성됩니다.", example = "1", nullable = true)
+        Long groupId,
+
         @NotBlank(message = "흔적 내용은 비어 있을 수 없습니다.")
         @Size(max = Opinion.CONTENT_MAX_LENGTH, message = "흔적 내용은 {max}자를 초과할 수 없습니다.")
         @Schema(example = "이 문장에서 작가의 의도가 느껴져서 좋았어요.")

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -8,6 +8,7 @@ import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.decoration.application.DecorationMergeSelector;
 import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
 import java.util.LinkedHashMap;
@@ -27,19 +28,27 @@ public class PassageService {
     private final PassageQueryRepository passageQueryRepository;
     private final DecorationQueryRepository decorationQueryRepository;
     private final BookRepository bookRepository;
+    private final GroupAccessValidator groupAccessValidator;
 
     // 대목/흔적 보기 페이지 네비게이션: 발췌된 페이지 번호 목록 (스포일러 포함) + 헤더용 책 정보.
-    public PageNumbersResult getPageNumbers(Long bookId, Pageable pageable) {
+    // groupId가 있으면 그 모임 전용 대목만 대상으로 하며, 이때 userId는 모임원이어야 한다(비로그인이면 거절).
+    public PageNumbersResult getPageNumbers(Long bookId, Long groupId, Long userId, Pageable pageable) {
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
-        Page<Integer> pageNumbers = passageQueryRepository.findPageNumbers(bookId, pageable);
+        if (groupId != null) {
+            groupAccessValidator.validateMember(groupId, userId);
+        }
+        Page<Integer> pageNumbers = passageQueryRepository.findPageNumbers(bookId, groupId, pageable);
         return new PageNumbersResult(book, pageNumbers);
     }
 
     // 대목 전환: 특정 페이지의 대목들과 각 대목의 꾸밈 병합 결과.
-    public List<Passage> getPassagesByPage(Long bookId, int pageNumber) {
+    public List<Passage> getPassagesByPage(Long bookId, Long groupId, Long userId, int pageNumber) {
         validateBookExists(bookId);
-        return passageQueryRepository.findPassagesByPage(bookId, pageNumber);
+        if (groupId != null) {
+            groupAccessValidator.validateMember(groupId, userId);
+        }
+        return passageQueryRepository.findPassagesByPage(bookId, groupId, pageNumber);
     }
 
     // 내가 남긴 대목 목록: bookId 미지정 시 전체 도서, spoilerOnly=true 시 스포일러 대목만.

--- a/src/main/java/com/nexters/palang/domain/passage/application/SimilarPassageFinder.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/SimilarPassageFinder.java
@@ -3,24 +3,30 @@ package com.nexters.palang.domain.passage.application;
 import com.nexters.palang.domain.book.common.error.BookErrorCode;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 // 유사 문장 판정(FR-WRITE-07): 같은 책의 인접 페이지(±1)에 정규화 해시가 일치하는 Passage가 있는지 조회한다.
+// groupId가 있으면 그 모임 스코프 안에서만 비교한다(전역 공개 대목과는 서로 병합 후보가 되지 않는다).
 @Component
 @RequiredArgsConstructor
 public class SimilarPassageFinder {
 
     private final PassageQueryRepository passageQueryRepository;
     private final BookRepository bookRepository;
+    private final GroupAccessValidator groupAccessValidator;
 
-    public List<SimilarPassageProjection> find(Long bookId, int pageNumber, String quotedText) {
+    public List<SimilarPassageProjection> find(Long bookId, int pageNumber, String quotedText, Long groupId, Long userId) {
         if (!bookRepository.existsById(bookId)) {
             throw new BookException(BookErrorCode.BOOK_NOT_FOUND);
         }
+        if (groupId != null) {
+            groupAccessValidator.validateMember(groupId, userId);
+        }
         String normalizedHash = PassageNormalizer.normalizedHash(quotedText);
-        return passageQueryRepository.findSimilarCandidates(bookId, pageNumber, normalizedHash);
+        return passageQueryRepository.findSimilarCandidates(bookId, pageNumber, normalizedHash, groupId);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/common/error/PassageErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/passage/common/error/PassageErrorCode.java
@@ -11,6 +11,7 @@ public enum PassageErrorCode implements BaseErrorCode {
 
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "PASSAGE_400_1", "이미지 파일만 업로드할 수 있습니다."),
     PASSAGE_BOOK_MISMATCH(HttpStatus.BAD_REQUEST, "PASSAGE_400_2", "선택한 대목이 지정한 도서와 일치하지 않습니다."),
+    PASSAGE_GROUP_MISMATCH(HttpStatus.BAD_REQUEST, "PASSAGE_400_3", "선택한 대목이 지정한 모임과 일치하지 않습니다."),
     PASSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "PASSAGE_404_1", "해당 대목을 찾을 수 없습니다."),
     OCR_TEXT_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "PASSAGE_422_1", "이미지에서 텍스트를 인식하지 못했습니다."),
     OCR_REQUEST_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "PASSAGE_503_1", "OCR 처리 중 오류가 발생했습니다."),

--- a/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
+++ b/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.passage.domain;
 
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.global.common.entity.BaseEntity;
 import com.nexters.palang.domain.user.domain.User;
 import jakarta.persistence.Column;
@@ -26,7 +27,10 @@ import org.hibernate.annotations.Check;
         name = "passages",
         indexes = {
                 @Index(name = "idx_passages_book_page", columnList = "book_id, page_number"),
-                @Index(name = "idx_passages_book_hash", columnList = "book_id, normalized_hash")
+                // group_id를 포함하도록 확장(구 idx_passages_book_hash 대체): 유사 문장 판정(FR-WRITE-07)이
+                // 이제 책 전체가 아니라 (책, 모임) 단위로 이루어진다 — group_id가 NULL인 전역 공개 대목과
+                // 특정 모임 전용 대목은 서로의 중복 판정에 관여하지 않는다.
+                @Index(name = "idx_passages_book_group_hash", columnList = "book_id, group_id, normalized_hash")
         }
 )
 @Check(constraints = "page_number > 0")
@@ -48,6 +52,12 @@ public class Passage extends BaseEntity {
     @JoinColumn(name = "created_by", nullable = false)
     private User creator;
 
+    // 이 대목이 특정 모임 전용인지 표시한다. NULL이면 기존처럼 도서를 읽는 모든 사용자에게 전역 공개되고,
+    // 값이 있으면 그 모임의 멤버만 조회/작성할 수 있다(OpinionService/PassageService의 GroupAccessValidator 참고).
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
     @Column(name = "page_number", nullable = false)
     private int pageNumber;
 
@@ -66,9 +76,11 @@ public class Passage extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    private Passage(Book book, User creator, int pageNumber, String quotedText, boolean isSpoiler, String normalizedHash) {
+    private Passage(
+            Book book, User creator, Group group, int pageNumber, String quotedText, boolean isSpoiler, String normalizedHash) {
         this.book = book;
         this.creator = creator;
+        this.group = group;
         this.pageNumber = pageNumber;
         this.quotedText = quotedText;
         this.isSpoiler = isSpoiler;

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -24,7 +24,8 @@ public class PassageQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     // 같은 책의 인접 페이지(±1) 안에서 정규화 해시가 같은 Passage 후보를 연결된 흔적 수와 함께 조회한다. (FR-WRITE-07)
-    public List<SimilarPassageProjection> findSimilarCandidates(Long bookId, int pageNumber, String normalizedHash) {
+    // groupId가 null이면 전역 공개 대목만, 값이 있으면 그 모임 전용 대목만 후보로 삼는다(서로 섞이지 않는다).
+    public List<SimilarPassageProjection> findSimilarCandidates(Long bookId, int pageNumber, String normalizedHash, Long groupId) {
         QPassage passage = QPassage.passage;
         QOpinion opinion = QOpinion.opinion;
 
@@ -37,7 +38,8 @@ public class PassageQueryRepository {
                         passage.book.id.eq(bookId),
                         passage.deletedAt.isNull(),
                         passage.pageNumber.between(pageNumber - 1, pageNumber + 1),
-                        passage.normalizedHash.eq(normalizedHash)
+                        passage.normalizedHash.eq(normalizedHash),
+                        groupFilter(passage, groupId)
                 )
                 .groupBy(passage.id, passage.quotedText, passage.pageNumber)
                 .orderBy(passage.pageNumber.asc(), passage.id.asc())
@@ -45,13 +47,14 @@ public class PassageQueryRepository {
     }
 
     // 대목/흔적 조회용 페이지 번호 목록: 대목이 걸쳐 있는 서로 다른 페이지 번호를 오름차순으로.
-    public Page<Integer> findPageNumbers(Long bookId, Pageable pageable) {
+    public Page<Integer> findPageNumbers(Long bookId, Long groupId, Pageable pageable) {
         QPassage passage = QPassage.passage;
+        BooleanExpression groupFilter = groupFilter(passage, groupId);
 
         List<Integer> content = queryFactory
                 .select(passage.pageNumber)
                 .from(passage)
-                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull())
+                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull(), groupFilter)
                 .groupBy(passage.pageNumber)
                 .orderBy(passage.pageNumber.asc())
                 .offset(pageable.getOffset())
@@ -61,21 +64,27 @@ public class PassageQueryRepository {
         Long total = queryFactory
                 .select(passage.pageNumber.countDistinct())
                 .from(passage)
-                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull())
+                .where(passage.book.id.eq(bookId), passage.deletedAt.isNull(), groupFilter)
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 
     // 대목 전환용: 특정 페이지에 걸친 대목들을 등록 순으로.
-    public List<Passage> findPassagesByPage(Long bookId, int pageNumber) {
+    public List<Passage> findPassagesByPage(Long bookId, Long groupId, int pageNumber) {
         QPassage passage = QPassage.passage;
 
         return queryFactory
                 .selectFrom(passage)
-                .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber), passage.deletedAt.isNull())
+                .where(passage.book.id.eq(bookId), passage.pageNumber.eq(pageNumber), passage.deletedAt.isNull(),
+                        groupFilter(passage, groupId))
                 .orderBy(passage.id.asc())
                 .fetch();
+    }
+
+    // groupId가 없으면(null) 전역 공개 대목(group_id IS NULL)만, 있으면 그 모임 소속 대목만 대상으로 한다.
+    private BooleanExpression groupFilter(QPassage passage, Long groupId) {
+        return groupId != null ? passage.group.id.eq(groupId) : passage.group.isNull();
     }
 
     // 내가 남긴 대목(FR-...): 소유 기준은 흔적을 남긴 사용자다(최초 생성자가 아니어도 병합된 대목에 흔적을 남겼으면 포함).

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
@@ -1,9 +1,12 @@
 package com.nexters.palang.domain.passage.infrastructure;
 
 import com.nexters.palang.domain.passage.domain.Passage;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PassageRepository extends JpaRepository<Passage, Long> {
 
-    boolean existsByIdAndDeletedAtIsNull(Long id);
+    // 흔적 목록 조회 시 대상 대목의 존재 여부뿐 아니라 group 소속을 확인해야 해서(모임원 검증) 엔티티
+    // 자체를 조회한다.
+    Optional<Passage> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/PassageController.java
@@ -53,10 +53,10 @@ public class PassageController implements PassageControllerDocs {
     @PostMapping("/api/passages/similar-check")
     public DataResponse<PassageResponse.SimilarCandidates> checkSimilarPassages(
             @Valid @RequestBody PassageRequest.SimilarCheck request) {
-        // 조회 결과는 유저 무관하게 동일하지만, 인증 필요 엔드포인트이므로 로그인 여부만 확인한다.
-        currentUserProvider.getCurrentUserId();
+        // 로그인 필요 엔드포인트: groupId가 있으면 그 모임 멤버인지까지 함께 확인한다(SimilarPassageFinder).
+        Long currentUserId = currentUserProvider.getCurrentUserId();
         List<SimilarPassageProjection> candidates = similarPassageFinder.find(
-                request.bookId(), request.pageNumber(), request.quotedText());
+                request.bookId(), request.pageNumber(), request.quotedText(), request.groupId(), currentUserId);
         return DataResponse.from(PassageResponse.SimilarCandidates.from(candidates));
     }
 
@@ -64,9 +64,11 @@ public class PassageController implements PassageControllerDocs {
     @GetMapping("/api/books/{bookId}/passages")
     public DataResponse<PassageResponse.PageNumbers> getPageNumbers(
             @PathVariable Long bookId,
+            @RequestParam(required = false) Long groupId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
-        PageNumbersResult result = passageService.getPageNumbers(bookId, pageable(page, size));
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        PageNumbersResult result = passageService.getPageNumbers(bookId, groupId, currentUserId, pageable(page, size));
         return DataResponse.from(PassageResponse.PageNumbers.from(result));
     }
 
@@ -74,8 +76,10 @@ public class PassageController implements PassageControllerDocs {
     @GetMapping("/api/books/{bookId}/pages/{page}/passages")
     public DataResponse<PassageResponse.PassagesByPage> getPassagesByPage(
             @PathVariable Long bookId,
-            @PathVariable("page") int pageNumber) {
-        List<Passage> passages = passageService.getPassagesByPage(bookId, pageNumber);
+            @PathVariable("page") int pageNumber,
+            @RequestParam(required = false) Long groupId) {
+        Long currentUserId = currentUserProvider.findCurrentUserId().orElse(null);
+        List<Passage> passages = passageService.getPassagesByPage(bookId, groupId, currentUserId, pageNumber);
         Map<Long, List<DecorationMergeCandidate>> merged = passageService.getMergedDecorationsByPassageId(passages);
         return DataResponse.from(PassageResponse.PassagesByPage.from(passages, merged));
     }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/docs/PassageControllerDocs.java
@@ -46,6 +46,7 @@ public interface PassageControllerDocs {
     );
 
     @Operation(summary = "유사 문장 후보 조회", description = "저장 전 같은 도서의 인접 페이지(±1)에서 정규화 해시가 같은 대목 후보를 조회합니다. "
+            + "groupId를 지정하면 그 모임 전용 대목만(요청자는 모임원이어야 함), 생략하면 전역 공개 대목만 비교합니다. "
             + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (후보가 없으면 빈 배열)"),
@@ -60,6 +61,11 @@ public interface PassageControllerDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(value = "{\"type\":\"/api/passages/similar-check\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))
             ),
             @ApiResponse(
+                    responseCode = "403",
+                    description = "GROUP_403_2: 모임원만 조회할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(value = "{\"type\":\"/api/passages/similar-check\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))
+            ),
+            @ApiResponse(
                     responseCode = "404",
                     description = "BOOK_404_1: 해당 도서를 찾을 수 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(value = "{\"type\":\"/api/passages/similar-check\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}"))
@@ -72,18 +78,23 @@ public interface PassageControllerDocs {
     @Operation(summary = "대목 페이지 목록 조회",
             description = "도서에서 발췌된 페이지 번호를 오름차순으로 조회합니다. "
                     + "스포일러 대목이 있는 페이지도 이 목록에 포함됩니다(스포일러 블러 처리는 프론트 담당, isSpoiler 플래그 기반). "
-                    + "인증은 선택입니다(soft auth) — 헤더가 없어도 조회됩니다.")
+                    + "groupId를 지정하면 그 모임 전용 대목만(요청자는 모임원이어야 함), 생략하면 전역 공개 대목만 조회합니다. "
+                    + "인증은 선택입니다(soft auth) — groupId 없이는 헤더가 없어도 조회됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (대목이 없으면 빈 배열)"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/books/1/passages\",\"title\":\"COMMON_400_1\",\"status\":400,\"detail\":\"'size' 파라미터의 값이 올바르지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: groupId를 지정했는데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/passages\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "BOOK_404_1: 해당 도서를 찾을 수 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/books/1/passages\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}")))
     })
     DataResponse<PassageResponse.PageNumbers> getPageNumbers(
             @Parameter(description = "도서 ID", required = true) Long bookId,
+            @Parameter(description = "모임 ID. 없으면 전역 공개 대목 기준으로 조회합니다.") Long groupId,
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
             @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
@@ -93,15 +104,20 @@ public interface PassageControllerDocs {
                     + "각 대목에는 좋아요 많은 순 최대 3개, 겹치지 않는 꾸밈만 병합되어 포함됩니다. "
                     + "스포일러로 표기된 대목(isSpoiler=true)도 quotedText/decorations를 그대로 내려줍니다 — "
                     + "블러 처리 후 [버튼]을 누르면 즉시 확인 가능해야 하므로, "
-                    + "블러/확인 전환은 서버 왕복 없이 프론트에서 isSpoiler 플래그로 처리합니다.")
+                    + "블러/확인 전환은 서버 왕복 없이 프론트에서 isSpoiler 플래그로 처리합니다. "
+                    + "groupId를 지정하면 그 모임 전용 대목만(요청자는 모임원이어야 함), 생략하면 전역 공개 대목만 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공 (해당 페이지에 대목이 없으면 빈 배열)"),
+            @ApiResponse(responseCode = "403", description = "GROUP_403_2: groupId를 지정했는데 모임원이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/books/1/pages/5/passages\",\"title\":\"GROUP_403_2\",\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "BOOK_404_1: 해당 도서를 찾을 수 없습니다.",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/books/1/pages/5/passages\",\"title\":\"BOOK_404_1\",\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}")))
     })
     DataResponse<PassageResponse.PassagesByPage> getPassagesByPage(
             @Parameter(description = "도서 ID", required = true) Long bookId,
-            @Parameter(description = "페이지 번호", required = true) int page
+            @Parameter(description = "페이지 번호", required = true) int page,
+            @Parameter(description = "모임 ID. 없으면 전역 공개 대목 기준으로 조회합니다.") Long groupId
     );
 }

--- a/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
+++ b/src/main/java/com/nexters/palang/domain/passage/presentation/request/PassageRequest.java
@@ -21,7 +21,11 @@ public class PassageRequest {
             @NotBlank(message = "인용 문구는 비어 있을 수 없습니다.")
             @Size(max = Passage.QUOTED_TEXT_MAX_LENGTH, message = "인용 문구는 {max}자를 초과할 수 없습니다.")
             @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.")
-            String quotedText
+            String quotedText,
+
+            // 있으면 그 모임 전용 대목만 비교 대상으로 삼는다(요청자는 모임원이어야 함). 없으면 기존처럼 전역 공개 대목만 비교한다.
+            @Schema(description = "모임 ID. 없으면 전역 공개 대목 기준으로 비교합니다.", example = "1", nullable = true)
+            Long groupId
     ) {
     }
 }

--- a/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
@@ -4,7 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.comment.common.CommentException;
 import com.nexters.palang.domain.comment.common.NestedReplyNotAllowedException;
 import com.nexters.palang.domain.comment.domain.Comment;
@@ -12,11 +16,17 @@ import com.nexters.palang.domain.comment.infrastructure.CommentQueryRepository;
 import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
 import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
 import com.nexters.palang.domain.comment.presentation.dto.UpdateCommentRequest;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,6 +57,9 @@ class CommentServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private GroupAccessValidator groupAccessValidator;
+
     private CommentService commentService;
 
     private Opinion opinion;
@@ -55,14 +68,27 @@ class CommentServiceTest {
 
     @BeforeEach
     void setUp() {
-        commentService = new CommentService(commentRepository, commentQueryRepository, opinionRepository, userRepository);
+        commentService = new CommentService(
+                commentRepository, commentQueryRepository, opinionRepository, userRepository, groupAccessValidator);
         writer = user(10L);
         opinion = opinion(1L);
         otherUser = user(20L);
     }
 
     private Opinion opinion(Long id) {
-        Opinion built = Opinion.builder().user(writer).content("흔적 내용").build();
+        return opinion(id, null);
+    }
+
+    private Opinion opinion(Long id, Group group) {
+        Passage passage = Passage.builder().group(group).build();
+        Opinion built = Opinion.builder().user(writer).passage(passage).content("흔적 내용").build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Group group(Long id) {
+        Book book = Book.builder().title("제목").author("작가").publisher("출판사").pageCount(300).build();
+        Group built = Group.create("모임", book, writer, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
         ReflectionTestUtils.setField(built, "id", id);
         return built;
     }
@@ -334,5 +360,60 @@ class CommentServiceTest {
         commentService.removeComment(1L, 10L);
 
         assertThat(comment.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적의 댓글 목록을 모임원이 아닌 사용자가 조회하면 예외가 발생한다")
+    void getRootCommentsFailsWhenNotGroupMember() {
+        Group group = group(9L);
+        Opinion groupOpinion = opinion(1L, group);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(groupOpinion));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 20L);
+
+        assertThatThrownBy(() -> commentService.getRootComments(1L, PageRequest.of(0, 20), 20L))
+                .isInstanceOf(GroupException.class);
+        verify(commentQueryRepository, never()).findRootComments(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적의 답글을 모임원이 아닌 사용자가 조회하면 예외가 발생한다")
+    void getRepliesFailsWhenNotGroupMember() {
+        Group group = group(9L);
+        Opinion groupOpinion = opinion(1L, group);
+        Comment root = rootComment(1L, groupOpinion, writer);
+        given(commentRepository.findByIdWithUser(1L)).willReturn(Optional.of(root));
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(groupOpinion));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 20L);
+
+        assertThatThrownBy(() -> commentService.getReplies(1L, PageRequest.of(0, 20), 20L))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임원이 아닌 사용자가 모임 전용 흔적에 댓글을 작성하려 하면 예외가 발생한다")
+    void createCommentFailsWhenNotGroupMember() {
+        Group group = group(9L);
+        Opinion groupOpinion = opinion(1L, group);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(groupOpinion));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 20L);
+
+        assertThatThrownBy(() -> commentService.createComment(1L, 20L, new CreateCommentRequest(null, "내용")))
+                .isInstanceOf(GroupException.class);
+        verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모임원이 모임 전용 흔적에 댓글을 작성하면 정상적으로 저장된다")
+    void createCommentSucceedsWhenGroupMember() {
+        Group group = group(9L);
+        Opinion groupOpinion = opinion(1L, group);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(groupOpinion));
+        given(userRepository.findById(10L)).willReturn(Optional.of(writer));
+        given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        Comment created = commentService.createComment(1L, 10L, new CreateCommentRequest(null, "내용"));
+
+        assertThat(created.getContent()).isEqualTo("내용");
+        verify(groupAccessValidator).validateMember(9L, 10L);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/presentation/CommentControllerTest.java
@@ -21,6 +21,8 @@ import com.nexters.palang.domain.comment.common.NestedReplyNotAllowedException;
 import com.nexters.palang.domain.comment.domain.Comment;
 import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
 import com.nexters.palang.domain.comment.presentation.dto.UpdateCommentRequest;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -185,6 +187,20 @@ class CommentControllerTest {
                         .content(objectMapper.writeValueAsString(new CreateCommentRequest(null, " "))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("모임원이 아닌 사용자가 모임 전용 흔적에 댓글을 작성하려 하면 403 에러가 발생한다")
+    void createCommentFailsWhenNotGroupMember() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(commentService.createComment(eq(1L), eq(1L), any(CreateCommentRequest.class)))
+                .willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(post("/api/opinions/1/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateCommentRequest(null, "댓글 내용"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
@@ -1,0 +1,141 @@
+package com.nexters.palang.domain.opinion.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.OpinionLike;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OpinionLikeServiceTest {
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
+    @Mock
+    private OpinionLikeRepository opinionLikeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GroupAccessValidator groupAccessValidator;
+
+    private OpinionLikeService opinionLikeService;
+
+    private User writer;
+
+    @BeforeEach
+    void setUp() {
+        opinionLikeService = new OpinionLikeService(opinionRepository, opinionLikeRepository, userRepository, groupAccessValidator);
+        writer = user(1L);
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Opinion opinion(Long id, Group group) {
+        Passage passage = Passage.builder().group(group).build();
+        Opinion built = Opinion.builder().user(writer).passage(passage).content("흔적 내용").build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    private Group group(Long id) {
+        Book book = Book.builder().title("제목").author("작가").publisher("출판사").pageCount(300).build();
+        Group built = Group.create("모임", book, writer, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 흔적에 좋아요를 시도하면 예외가 발생한다")
+    void toggleLikeFailsWhenOpinionNotFound() {
+        given(opinionRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> opinionLikeService.toggleLike(1L, 999L)).isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요를 누르지 않은 흔적에 토글하면 좋아요가 생성되고 카운트가 증가한다")
+    void toggleLikeLikesWhenNotAlreadyLiked() {
+        Opinion opinion = opinion(1L, null);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionLikeRepository.existsByUserIdAndOpinionId(1L, 1L)).willReturn(false);
+
+        OpinionLikeResult result = opinionLikeService.toggleLike(1L, 1L);
+
+        assertThat(result.liked()).isTrue();
+        assertThat(result.likeCount()).isEqualTo(1);
+        verify(opinionLikeRepository).save(any(OpinionLike.class));
+    }
+
+    @Test
+    @DisplayName("이미 좋아요를 누른 흔적에 토글하면 좋아요가 취소되고 카운트가 감소한다")
+    void toggleLikeUnlikesWhenAlreadyLiked() {
+        Opinion opinion = opinion(1L, null);
+        opinion.increaseLikeCount();
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionLikeRepository.existsByUserIdAndOpinionId(1L, 1L)).willReturn(true);
+
+        OpinionLikeResult result = opinionLikeService.toggleLike(1L, 1L);
+
+        assertThat(result.liked()).isFalse();
+        assertThat(result.likeCount()).isZero();
+        verify(opinionLikeRepository).deleteByUserIdAndOpinionId(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적에 모임원이 아닌 사용자가 좋아요를 시도하면 예외가 발생한다")
+    void toggleLikeFailsWhenNotGroupMember() {
+        Group group = group(9L);
+        Opinion opinion = opinion(1L, group);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 20L);
+
+        assertThatThrownBy(() -> opinionLikeService.toggleLike(20L, 1L)).isInstanceOf(GroupException.class);
+        verify(opinionLikeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적에 모임원이 좋아요를 시도하면 정상적으로 처리된다")
+    void toggleLikeSucceedsWhenGroupMember() {
+        Group group = group(9L);
+        Opinion opinion = opinion(1L, group);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionLikeRepository.existsByUserIdAndOpinionId(10L, 1L)).willReturn(false);
+
+        OpinionLikeResult result = opinionLikeService.toggleLike(10L, 1L);
+
+        assertThat(result.liked()).isTrue();
+        verify(groupAccessValidator).validateMember(9L, 10L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -213,12 +213,26 @@ class OpinionServiceTest {
     @Test
     @DisplayName("모임원이 아닌 사용자가 groupId를 지정해 흔적을 생성하려 하면 예외가 발생한다")
     void createOpinionFailsWhenNotGroupMember() {
+        Group group = group(9L, book(10L));
         given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(groupRepository.findById(9L)).willReturn(Optional.of(group));
         doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 1L);
 
         assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, null, 9L)))
                 .isInstanceOf(GroupException.class);
         verify(passageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 groupId로 흔적을 생성하려 하면 (멤버십이 아니라) 모임을 찾을 수 없다는 예외가 발생한다")
+    void createOpinionFailsWhenGroupDoesNotExist() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(groupRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, null, 999L)))
+                .isInstanceOf(GroupException.class)
+                .satisfies(e -> assertThat(((GroupException) e).getErrorCode()).isEqualTo(GroupErrorCode.GROUP_NOT_FOUND));
+        verify(groupAccessValidator, never()).validateMember(any(), any());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.nexters.palang.domain.book.application.BookOptionProjection;
@@ -12,6 +14,11 @@ import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.domain.OpinionSortType;
@@ -25,6 +32,7 @@ import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -58,12 +66,19 @@ class OpinionServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupAccessValidator groupAccessValidator;
+
     private OpinionService opinionService;
 
     @BeforeEach
     void setUp() {
         opinionService = new OpinionService(
-                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository);
+                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository,
+                groupRepository, groupAccessValidator);
     }
 
     private User user(Long id) {
@@ -84,9 +99,25 @@ class OpinionServiceTest {
         return passage;
     }
 
+    private Passage passage(Long id, Book book, Group group) {
+        Passage passage = Passage.builder().book(book).group(group).build();
+        ReflectionTestUtils.setField(passage, "id", id);
+        return passage;
+    }
+
+    private Group group(Long id, Book book) {
+        Group group = Group.create("모임", book, user(1L), 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        ReflectionTestUtils.setField(group, "id", id);
+        return group;
+    }
+
     private CreateOpinionRequest request(Long bookId, Long passageId) {
+        return request(bookId, passageId, null);
+    }
+
+    private CreateOpinionRequest request(Long bookId, Long passageId, Long groupId) {
         return new CreateOpinionRequest(
-                bookId, 5, "발췌 문장", false, passageId, "흔적 내용",
+                bookId, 5, "발췌 문장", false, passageId, groupId, "흔적 내용",
                 List.of(new DecorationRequest(0, 5, EffectType.UNDERLINE, null))
         );
     }
@@ -163,9 +194,64 @@ class OpinionServiceTest {
     }
 
     @Test
+    @DisplayName("groupId를 지정해 새 흔적을 생성하면 대목이 그 모임 소속으로 만들어진다")
+    void createOpinionCreatesGroupScopedPassageWhenGroupIdIsGiven() {
+        Book book = book(10L);
+        Group group = group(9L, book);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(bookRepository.findById(10L)).willReturn(Optional.of(book));
+        given(groupRepository.findById(9L)).willReturn(Optional.of(group));
+        given(passageRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(opinionRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        Opinion opinion = opinionService.createOpinion(1L, request(10L, null, 9L));
+
+        assertThat(opinion.getPassage().getGroup()).isEqualTo(group);
+        verify(groupAccessValidator).validateMember(9L, 1L);
+    }
+
+    @Test
+    @DisplayName("모임원이 아닌 사용자가 groupId를 지정해 흔적을 생성하려 하면 예외가 발생한다")
+    void createOpinionFailsWhenNotGroupMember() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 1L);
+
+        assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, null, 9L)))
+                .isInstanceOf(GroupException.class);
+        verify(passageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모임의 지정 도서와 다른 bookId로 모임 전용 흔적을 생성하려 하면 예외가 발생한다")
+    void createOpinionFailsWhenGroupBookMismatch() {
+        Book otherBook = book(99L);
+        Group group = group(9L, book(10L));
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(bookRepository.findById(99L)).willReturn(Optional.of(otherBook));
+        given(groupRepository.findById(9L)).willReturn(Optional.of(group));
+
+        assertThatThrownBy(() -> opinionService.createOpinion(1L, request(99L, null, 9L)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("기존 대목의 소속 모임과 요청의 groupId가 다르면 예외가 발생한다")
+    void createOpinionFailsWhenMergePassageGroupMismatch() {
+        Book book = book(10L);
+        Group group = group(9L, book);
+        Passage existingInGroup = passage(100L, book, group);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user(1L)));
+        given(passageRepository.findById(100L)).willReturn(Optional.of(existingInGroup));
+
+        // groupId 없이(전역 공개로 착각하고) 모임 전용 대목에 병합을 시도하는 경우
+        assertThatThrownBy(() -> opinionService.createOpinion(1L, request(10L, 100L, null)))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
     @DisplayName("존재하는 대목으로 흔적 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
     void getOpinionsReturnsQueryRepositoryResult() {
-        given(passageRepository.existsByIdAndDeletedAtIsNull(100L)).willReturn(true);
+        given(passageRepository.findByIdAndDeletedAtIsNull(100L)).willReturn(Optional.of(passage(100L, book(10L))));
         Pageable pageable = PageRequest.of(0, 20);
 
         opinionService.getOpinions(100L, OpinionSortType.LATEST, pageable, 1L);
@@ -176,10 +262,22 @@ class OpinionServiceTest {
     @Test
     @DisplayName("존재하지 않는 대목으로 흔적 목록을 조회하면 예외가 발생한다")
     void getOpinionsThrowsExceptionWhenPassageDoesNotExist() {
-        given(passageRepository.existsByIdAndDeletedAtIsNull(100L)).willReturn(false);
+        given(passageRepository.findByIdAndDeletedAtIsNull(100L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20), 1L))
                 .isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("모임 전용 대목의 흔적 목록을 모임원이 아닌 사용자가 조회하면 예외가 발생한다")
+    void getOpinionsFailsWhenPassageBelongsToGroupAndNotMember() {
+        Group group = group(9L, book(10L));
+        given(passageRepository.findByIdAndDeletedAtIsNull(100L)).willReturn(Optional.of(passage(100L, book(10L), group)));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 2L);
+
+        assertThatThrownBy(() -> opinionService.getOpinions(100L, OpinionSortType.LATEST, PageRequest.of(0, 20), 2L))
+                .isInstanceOf(GroupException.class);
+        verify(opinionQueryRepository, never()).findOpinions(any(), any(), any(), any());
     }
 
     @Test
@@ -188,7 +286,7 @@ class OpinionServiceTest {
         Opinion opinion = opinionOwnedBy(1L, 1L);
         given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
-        Opinion result = opinionService.getOpinion(1L);
+        Opinion result = opinionService.getOpinion(1L, null);
 
         assertThat(result).isSameAs(opinion);
     }
@@ -200,8 +298,39 @@ class OpinionServiceTest {
         opinion.delete();
         given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
 
-        assertThatThrownBy(() -> opinionService.getOpinion(1L))
+        assertThatThrownBy(() -> opinionService.getOpinion(1L, null))
                 .isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적을 모임원이 아닌 사용자가 조회하면 예외가 발생한다")
+    void getOpinionFailsWhenPassageBelongsToGroupAndNotMember() {
+        Group group = group(9L, book(10L));
+        Passage passage = passage(100L, book(10L), group);
+        Opinion opinion = Opinion.createWithDecorations(passage, user(1L), "흔적 내용",
+                List.of(Decoration.builder().startOffset(0).endOffset(5).effectType(EffectType.UNDERLINE).build()));
+        ReflectionTestUtils.setField(opinion, "id", 1L);
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 2L);
+
+        assertThatThrownBy(() -> opinionService.getOpinion(1L, 2L))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적을 모임원이 조회하면 정상적으로 반환된다")
+    void getOpinionSucceedsWhenGroupMember() {
+        Group group = group(9L, book(10L));
+        Passage passage = passage(100L, book(10L), group);
+        Opinion opinion = Opinion.createWithDecorations(passage, user(1L), "흔적 내용",
+                List.of(Decoration.builder().startOffset(0).endOffset(5).effectType(EffectType.UNDERLINE).build()));
+        ReflectionTestUtils.setField(opinion, "id", 1L);
+        given(opinionRepository.findDetailById(1L)).willReturn(Optional.of(opinion));
+
+        Opinion result = opinionService.getOpinion(1L, 2L);
+
+        assertThat(result).isSameAs(opinion);
+        verify(groupAccessValidator).validateMember(9L, 2L);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.opinion.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,6 +15,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.opinion.application.OpinionLikeResult;
 import com.nexters.palang.domain.opinion.application.OpinionLikeService;
 import com.nexters.palang.domain.opinion.application.OpinionService;
@@ -71,7 +74,7 @@ class OpinionControllerTest {
     }
 
     private CreateOpinionRequest request(Long passageId) {
-        return new CreateOpinionRequest(1L, 5, "발췌 문장", false, passageId, "흔적 내용",
+        return new CreateOpinionRequest(1L, 5, "발췌 문장", false, passageId, null, "흔적 내용",
                 List.of(new DecorationRequest(0, 5, EffectType.UNDERLINE, null)));
     }
 
@@ -116,9 +119,22 @@ class OpinionControllerTest {
     }
 
     @Test
+    @DisplayName("모임원이 아닌 사용자가 groupId를 지정해 흔적을 작성하려 하면 403 에러가 발생한다")
+    void createOpinionFailsWhenNotGroupMember() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(opinionService.createOpinion(anyLong(), any())).willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(post("/api/opinions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request(null))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
+    }
+
+    @Test
     @DisplayName("꾸밈 효과 없이 흔적을 작성하면 400 에러가 발생한다")
     void createOpinionFailsWhenDecorationsIsEmpty() throws Exception {
-        CreateOpinionRequest request = new CreateOpinionRequest(1L, 5, "발췌 문장", false, null, "흔적 내용", List.of());
+        CreateOpinionRequest request = new CreateOpinionRequest(1L, 5, "발췌 문장", false, null, null, "흔적 내용", List.of());
 
         mockMvc.perform(post("/api/opinions")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -144,7 +160,7 @@ class OpinionControllerTest {
     @Test
     @DisplayName("흔적 상세를 조회하면 작성자의 꾸밈을 그대로 반환한다")
     void getOpinion() throws Exception {
-        given(opinionService.getOpinion(1L)).willReturn(opinionWithDecoration(1L, 100L));
+        given(opinionService.getOpinion(eq(1L), any())).willReturn(opinionWithDecoration(1L, 100L));
 
         mockMvc.perform(get("/api/opinions/1"))
                 .andExpect(status().isOk())
@@ -155,11 +171,21 @@ class OpinionControllerTest {
     @Test
     @DisplayName("존재하지 않는 흔적을 상세 조회하면 404 에러가 발생한다")
     void getOpinionFailsWhenNotFound() throws Exception {
-        given(opinionService.getOpinion(1L)).willThrow(new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
+        given(opinionService.getOpinion(eq(1L), any())).willThrow(new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
 
         mockMvc.perform(get("/api/opinions/1"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value("OPINION_404_1"));
+    }
+
+    @Test
+    @DisplayName("모임 전용 흔적을 모임원이 아닌 사용자가 조회하면 403 에러가 발생한다")
+    void getOpinionFailsWhenNotGroupMember() throws Exception {
+        given(opinionService.getOpinion(eq(1L), any())).willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(get("/api/opinions/1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -2,8 +2,10 @@ package com.nexters.palang.domain.opinion.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -78,6 +80,11 @@ class OpinionControllerTest {
                 List.of(new DecorationRequest(0, 5, EffectType.UNDERLINE, null)));
     }
 
+    private CreateOpinionRequest requestWithGroup(Long groupId) {
+        return new CreateOpinionRequest(1L, 5, "발췌 문장", false, null, groupId, "흔적 내용",
+                List.of(new DecorationRequest(0, 5, EffectType.UNDERLINE, null)));
+    }
+
     @Test
     @DisplayName("passageId 없이 흔적을 작성하면 새 Passage와 함께 생성된다")
     void createOpinionWithoutPassageId() throws Exception {
@@ -122,13 +129,16 @@ class OpinionControllerTest {
     @DisplayName("모임원이 아닌 사용자가 groupId를 지정해 흔적을 작성하려 하면 403 에러가 발생한다")
     void createOpinionFailsWhenNotGroupMember() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(opinionService.createOpinion(anyLong(), any())).willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+        given(opinionService.createOpinion(eq(1L), any(CreateOpinionRequest.class)))
+                .willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
 
         mockMvc.perform(post("/api/opinions")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request(null))))
+                        .content(objectMapper.writeValueAsString(requestWithGroup(9L))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.title").value("GROUP_403_2"));
+
+        verify(opinionService).createOpinion(eq(1L), argThat(req -> req.groupId().equals(9L)));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/presentation/OpinionControllerTest.java
@@ -280,4 +280,15 @@ class OpinionControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value("OPINION_404_1"));
     }
+
+    @Test
+    @DisplayName("모임원이 아닌 사용자가 모임 전용 흔적에 좋아요를 시도하면 403 에러가 발생한다")
+    void toggleOpinionLikeFailsWhenNotGroupMember() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(opinionLikeService.toggleLike(1L, 10L)).willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(post("/api/opinions/{opinionId}/like", 10L))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
+    }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -3,13 +3,18 @@ package com.nexters.palang.domain.passage.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 
 import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
 import com.nexters.palang.domain.decoration.application.DecorationMergeCandidate;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.decoration.infrastructure.DecorationQueryRepository;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
 import java.time.LocalDateTime;
@@ -37,11 +42,14 @@ class PassageServiceTest {
     @Mock
     private BookRepository bookRepository;
 
+    @Mock
+    private GroupAccessValidator groupAccessValidator;
+
     private PassageService passageService;
 
     @BeforeEach
     void setUp() {
-        passageService = new PassageService(passageQueryRepository, decorationQueryRepository, bookRepository);
+        passageService = new PassageService(passageQueryRepository, decorationQueryRepository, bookRepository, groupAccessValidator);
     }
 
     private Passage passage(Long id) {
@@ -55,7 +63,7 @@ class PassageServiceTest {
     void getPageNumbersThrowsExceptionWhenBookDoesNotExist() {
         given(bookRepository.findById(1L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> passageService.getPageNumbers(1L, PageRequest.of(0, 20)))
+        assertThatThrownBy(() -> passageService.getPageNumbers(1L, null, 1L, PageRequest.of(0, 20)))
                 .isInstanceOf(BookException.class);
     }
 
@@ -64,7 +72,7 @@ class PassageServiceTest {
     void getPassagesByPageThrowsExceptionWhenBookDoesNotExist() {
         given(bookRepository.existsById(1L)).willReturn(false);
 
-        assertThatThrownBy(() -> passageService.getPassagesByPage(1L, 3))
+        assertThatThrownBy(() -> passageService.getPassagesByPage(1L, null, 1L, 3))
                 .isInstanceOf(BookException.class);
     }
 
@@ -72,9 +80,9 @@ class PassageServiceTest {
     @DisplayName("페이지에 대목이 없으면 예외 없이 빈 결과가 조회된다")
     void getPassagesByPageReturnsEmptyWhenNoPassagesExist() {
         given(bookRepository.existsById(1L)).willReturn(true);
-        given(passageQueryRepository.findPassagesByPage(1L, 3)).willReturn(List.of());
+        given(passageQueryRepository.findPassagesByPage(1L, null, 3)).willReturn(List.of());
 
-        List<Passage> result = passageService.getPassagesByPage(1L, 3);
+        List<Passage> result = passageService.getPassagesByPage(1L, null, 1L, 3);
 
         assertThat(result).isEmpty();
     }
@@ -83,11 +91,32 @@ class PassageServiceTest {
     @DisplayName("스포일러 대목을 포함해 해당 페이지의 모든 대목을 조회한다")
     void getPassagesByPageReturnsAllPassagesIncludingSpoilers() {
         given(bookRepository.existsById(1L)).willReturn(true);
-        given(passageQueryRepository.findPassagesByPage(1L, 3)).willReturn(List.of(passage(100L)));
+        given(passageQueryRepository.findPassagesByPage(1L, null, 3)).willReturn(List.of(passage(100L)));
 
-        List<Passage> result = passageService.getPassagesByPage(1L, 3);
+        List<Passage> result = passageService.getPassagesByPage(1L, null, 1L, 3);
 
         assertThat(result).extracting(Passage::getId).containsExactly(100L);
+    }
+
+    @Test
+    @DisplayName("groupId를 지정해 페이지 번호를 조회할 때 모임원이 아니면 예외가 발생한다")
+    void getPageNumbersFailsWhenNotGroupMember() {
+        given(bookRepository.findById(1L)).willReturn(Optional.of(
+                Book.builder().title("제목").author("작가").publisher("출판사").pageCount(300).build()));
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 1L);
+
+        assertThatThrownBy(() -> passageService.getPageNumbers(1L, 9L, 1L, PageRequest.of(0, 20)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("groupId를 지정해 페이지의 대목을 조회할 때 모임원이 아니면 예외가 발생한다")
+    void getPassagesByPageFailsWhenNotGroupMember() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 1L);
+
+        assertThatThrownBy(() -> passageService.getPassagesByPage(1L, 9L, 1L, 3))
+                .isInstanceOf(GroupException.class);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/application/SimilarPassageFinderTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/SimilarPassageFinderTest.java
@@ -6,9 +6,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.group.application.GroupAccessValidator;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.passage.infrastructure.PassageQueryRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +33,14 @@ class SimilarPassageFinderTest {
     @Mock
     private BookRepository bookRepository;
 
+    @Mock
+    private GroupAccessValidator groupAccessValidator;
+
     private SimilarPassageFinder similarPassageFinder;
 
     @BeforeEach
     void setUp() {
-        similarPassageFinder = new SimilarPassageFinder(passageQueryRepository, bookRepository);
+        similarPassageFinder = new SimilarPassageFinder(passageQueryRepository, bookRepository, groupAccessValidator);
     }
 
     @Test
@@ -39,10 +48,10 @@ class SimilarPassageFinderTest {
     void findReturnsCandidatesWhenSimilarPassageExists() {
         given(bookRepository.existsById(1L)).willReturn(true);
         SimilarPassageProjection projection = new SimilarPassageProjection(10L, "발췌 문장", 5, 2L);
-        given(passageQueryRepository.findSimilarCandidates(any(), anyInt(), anyString()))
+        given(passageQueryRepository.findSimilarCandidates(any(), anyInt(), anyString(), any()))
                 .willReturn(List.of(projection));
 
-        List<SimilarPassageProjection> results = similarPassageFinder.find(1L, 5, "발췌 문장");
+        List<SimilarPassageProjection> results = similarPassageFinder.find(1L, 5, "발췌 문장", null, 1L);
 
         assertThat(results).containsExactly(projection);
     }
@@ -52,7 +61,30 @@ class SimilarPassageFinderTest {
     void findThrowsExceptionWhenBookDoesNotExist() {
         given(bookRepository.existsById(1L)).willReturn(false);
 
-        assertThatThrownBy(() -> similarPassageFinder.find(1L, 5, "발췌 문장"))
+        assertThatThrownBy(() -> similarPassageFinder.find(1L, 5, "발췌 문장", null, 1L))
                 .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("groupId를 지정했을 때 모임원이 아니면 예외가 발생하고 조회는 수행되지 않는다")
+    void findFailsWhenNotGroupMember() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        doThrow(new GroupException(GroupErrorCode.NOT_MEMBER)).when(groupAccessValidator).validateMember(9L, 1L);
+
+        assertThatThrownBy(() -> similarPassageFinder.find(1L, 5, "발췌 문장", 9L, 1L))
+                .isInstanceOf(GroupException.class);
+        verify(passageQueryRepository, never()).findSimilarCandidates(any(), anyInt(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("groupId를 지정했을 때 모임원이면 그 모임 스코프로 조회한다")
+    void findScopesToGroupWhenMember() {
+        given(bookRepository.existsById(1L)).willReturn(true);
+        given(passageQueryRepository.findSimilarCandidates(any(), anyInt(), anyString(), any())).willReturn(List.of());
+
+        similarPassageFinder.find(1L, 5, "발췌 문장", 9L, 1L);
+
+        verify(groupAccessValidator).validateMember(9L, 1L);
+        verify(passageQueryRepository).findSimilarCandidates(1L, 5, PassageNormalizer.normalizedHash("발췌 문장"), 9L);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.nexters.palang.domain.book.application.BookOptionProjection;
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.domain.Group;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.application.MyPassageProjection;
 import com.nexters.palang.domain.passage.application.SimilarPassageProjection;
@@ -12,6 +13,7 @@ import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.global.config.JpaAuditingConfig;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +80,23 @@ class PassageQueryRepositoryTest {
                 .build());
     }
 
+    private Group group(Book book, User host) {
+        Group built = Group.create("모임", book, host, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+        return entityManager.persistAndFlush(built);
+    }
+
+    private Passage passage(Book book, User creator, Group group, int pageNumber, String quotedText, String normalizedHash) {
+        return entityManager.persistAndFlush(Passage.builder()
+                .book(book)
+                .creator(creator)
+                .group(group)
+                .pageNumber(pageNumber)
+                .quotedText(quotedText)
+                .isSpoiler(false)
+                .normalizedHash(normalizedHash)
+                .build());
+    }
+
     @Test
     @DisplayName("같은 책의 인접 페이지(±1)에서 정규화 해시가 같은 대목을 후보로 조회한다")
     void findSimilarCandidatesReturnsPassagesWithinAdjacentPages() {
@@ -87,7 +106,7 @@ class PassageQueryRepositoryTest {
         Passage adjacentPage = passage(book, writer, 6, "발췌 문장", "hash-1");
         passage(book, writer, 8, "먼 페이지 문장", "hash-1");
 
-        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1");
+        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", null);
 
         assertThat(results).extracting(SimilarPassageProjection::passageId)
                 .containsExactly(samePage.getId(), adjacentPage.getId());
@@ -100,7 +119,7 @@ class PassageQueryRepositoryTest {
         Book book = book("책");
         passage(book, writer, 5, "다른 문장", "hash-different");
 
-        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1");
+        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", null);
 
         assertThat(results).isEmpty();
     }
@@ -114,7 +133,7 @@ class PassageQueryRepositoryTest {
         entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적1").build());
         entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적2").build());
 
-        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1");
+        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", null);
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).opinionCount()).isEqualTo(2);
@@ -129,9 +148,25 @@ class PassageQueryRepositoryTest {
         deleted.delete();
         entityManager.persistAndFlush(deleted);
 
-        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1");
+        List<SimilarPassageProjection> results = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", null);
 
         assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 해시라도 모임이 다르면(또는 한쪽이 전역 공개면) 유사 후보로 묶이지 않는다")
+    void findSimilarCandidatesScopesByGroup() {
+        User writer = user("writer-13");
+        Book book = book("책");
+        Group group = group(book, writer);
+        Passage global = passage(book, writer, 5, "발췌 문장", "hash-1");
+        Passage inGroup = passage(book, writer, group, 5, "발췌 문장", "hash-1");
+
+        List<SimilarPassageProjection> globalResults = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", null);
+        List<SimilarPassageProjection> groupResults = passageQueryRepository.findSimilarCandidates(book.getId(), 5, "hash-1", group.getId());
+
+        assertThat(globalResults).extracting(SimilarPassageProjection::passageId).containsExactly(global.getId());
+        assertThat(groupResults).extracting(SimilarPassageProjection::passageId).containsExactly(inGroup.getId());
     }
 
     @Test
@@ -144,7 +179,7 @@ class PassageQueryRepositoryTest {
         passage(book, writer, 2, false);
         passage(book, writer, 1, true);
 
-        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), PageRequest.of(0, 10));
+        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).containsExactly(1, 2, 5);
     }
@@ -159,7 +194,7 @@ class PassageQueryRepositoryTest {
         deleted.delete();
         entityManager.persistAndFlush(deleted);
 
-        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), PageRequest.of(0, 10));
+        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).containsExactly(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
@@ -170,9 +205,25 @@ class PassageQueryRepositoryTest {
     void findPageNumbersReturnsEmptyWhenNoPassages() {
         Book book = book("빈 책");
 
-        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), PageRequest.of(0, 10));
+        Page<Integer> result = passageQueryRepository.findPageNumbers(book.getId(), null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("groupId를 지정하면 그 모임 전용 대목의 페이지 번호만 조회된다")
+    void findPageNumbersScopesByGroup() {
+        User writer = user("writer-14");
+        Book book = book("책");
+        Group group = group(book, writer);
+        passage(book, writer, 1, false);
+        passage(book, writer, group, 2, "모임 전용 문장", "hash-group");
+
+        Page<Integer> globalResult = passageQueryRepository.findPageNumbers(book.getId(), null, PageRequest.of(0, 10));
+        Page<Integer> groupResult = passageQueryRepository.findPageNumbers(book.getId(), group.getId(), PageRequest.of(0, 10));
+
+        assertThat(globalResult.getContent()).containsExactly(1);
+        assertThat(groupResult.getContent()).containsExactly(2);
     }
 
     @Test
@@ -184,7 +235,7 @@ class PassageQueryRepositoryTest {
         Passage second = passage(book, writer, 3, false);
         Passage spoiler = passage(book, writer, 3, true);
 
-        List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), 3);
+        List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), null, 3);
 
         assertThat(result).extracting(Passage::getId)
                 .containsExactly(first.getId(), second.getId(), spoiler.getId());
@@ -200,9 +251,25 @@ class PassageQueryRepositoryTest {
         deleted.delete();
         entityManager.persistAndFlush(deleted);
 
-        List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), 3);
+        List<Passage> result = passageQueryRepository.findPassagesByPage(book.getId(), null, 3);
 
         assertThat(result).extracting(Passage::getId).containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("groupId를 지정하면 그 모임 전용 대목만 조회되고 전역 공개 대목은 섞이지 않는다")
+    void findPassagesByPageScopesByGroup() {
+        User writer = user("writer-15");
+        Book book = book("책");
+        Group group = group(book, writer);
+        Passage global = passage(book, writer, 3, false);
+        Passage inGroup = passage(book, writer, group, 3, "모임 전용 문장", "hash-group");
+
+        List<Passage> globalResult = passageQueryRepository.findPassagesByPage(book.getId(), null, 3);
+        List<Passage> groupResult = passageQueryRepository.findPassagesByPage(book.getId(), group.getId(), 3);
+
+        assertThat(globalResult).extracting(Passage::getId).containsExactly(global.getId());
+        assertThat(groupResult).extracting(Passage::getId).containsExactly(inGroup.getId());
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/presentation/PassageControllerTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.passage.application.PageNumbersResult;
 import com.nexters.palang.domain.passage.application.PassageOcrService;
 import com.nexters.palang.domain.passage.application.PassageService;
@@ -65,10 +67,10 @@ class PassageControllerTest {
     @DisplayName("유사 문장 후보를 조회하면 대목 목록을 반환한다")
     void checkSimilarPassages() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(similarPassageFinder.find(any(), anyInt(), anyString()))
+        given(similarPassageFinder.find(any(), anyInt(), anyString(), any(), any()))
                 .willReturn(List.of(new SimilarPassageProjection(10L, "발췌 문장", 5, 2L)));
 
-        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장");
+        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장", null);
 
         mockMvc.perform(post("/api/passages/similar-check")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -82,9 +84,9 @@ class PassageControllerTest {
     @DisplayName("유사 문장 후보가 없으면 빈 배열을 반환한다")
     void checkSimilarPassagesReturnsEmptyArrayWhenNoCandidates() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(similarPassageFinder.find(any(), anyInt(), anyString())).willReturn(List.of());
+        given(similarPassageFinder.find(any(), anyInt(), anyString(), any(), any())).willReturn(List.of());
 
-        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장");
+        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장", null);
 
         mockMvc.perform(post("/api/passages/similar-check")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -98,7 +100,7 @@ class PassageControllerTest {
     void checkSimilarPassagesFailsWhenUnauthenticated() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
 
-        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장");
+        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "발췌 문장", null);
 
         mockMvc.perform(post("/api/passages/similar-check")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +112,7 @@ class PassageControllerTest {
     @Test
     @DisplayName("인용 문구 없이 유사 문장 후보를 조회하면 400 에러가 발생한다")
     void checkSimilarPassagesFailsWhenQuotedTextIsBlank() throws Exception {
-        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "");
+        PassageRequest.SimilarCheck request = new PassageRequest.SimilarCheck(1L, 5, "", null);
 
         mockMvc.perform(post("/api/passages/similar-check")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -128,7 +130,7 @@ class PassageControllerTest {
     @Test
     @DisplayName("페이지 번호 목록을 조회하면 오름차순으로, 책 정보와 함께 반환한다")
     void getPageNumbers() throws Exception {
-        given(passageService.getPageNumbers(any(), any())).willReturn(new PageNumbersResult(
+        given(passageService.getPageNumbers(any(), any(), any(), any())).willReturn(new PageNumbersResult(
                 book(), new PageImpl<>(List.of(2, 5), PageRequest.of(0, 20), 2)));
 
         mockMvc.perform(get("/api/books/1/passages"))
@@ -142,7 +144,7 @@ class PassageControllerTest {
     @Test
     @DisplayName("비로그인 사용자로 페이지 번호를 조회해도 401 없이 조회된다 (soft auth)")
     void getPageNumbersDoesNotRequireAuthentication() throws Exception {
-        given(passageService.getPageNumbers(any(), any())).willReturn(new PageNumbersResult(
+        given(passageService.getPageNumbers(any(), any(), any(), any())).willReturn(new PageNumbersResult(
                 book(), new PageImpl<>(List.of(), PageRequest.of(0, 20), 0)));
 
         mockMvc.perform(get("/api/books/1/passages"))
@@ -153,7 +155,7 @@ class PassageControllerTest {
     @DisplayName("특정 페이지의 대목과 병합된 꾸밈을 함께 반환한다")
     void getPassagesByPage() throws Exception {
         Passage passage = passage(10L, 3);
-        given(passageService.getPassagesByPage(any(), anyInt())).willReturn(List.of(passage));
+        given(passageService.getPassagesByPage(any(), any(), any(), anyInt())).willReturn(List.of(passage));
         given(passageService.getMergedDecorationsByPassageId(any())).willReturn(Map.of(10L, List.of()));
 
         mockMvc.perform(get("/api/books/1/pages/3/passages"))
@@ -166,11 +168,22 @@ class PassageControllerTest {
     @DisplayName("비로그인 사용자도 아무 페이지나 조회할 수 있다 (soft auth)")
     void getPassagesByPageDoesNotRequireAuthentication() throws Exception {
         Passage passage = passage(10L, 5);
-        given(passageService.getPassagesByPage(any(), anyInt())).willReturn(List.of(passage));
+        given(passageService.getPassagesByPage(any(), any(), any(), anyInt())).willReturn(List.of(passage));
         given(passageService.getMergedDecorationsByPassageId(any())).willReturn(Map.of(10L, List.of()));
 
         mockMvc.perform(get("/api/books/1/pages/5/passages"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].passageId").value(10));
+    }
+
+    @Test
+    @DisplayName("groupId를 지정해 페이지 번호를 조회할 때 모임원이 아니면 403 에러가 발생한다")
+    void getPageNumbersFailsWhenNotGroupMember() throws Exception {
+        given(passageService.getPageNumbers(any(), any(), any(), any()))
+                .willThrow(new GroupException(GroupErrorCode.NOT_MEMBER));
+
+        mockMvc.perform(get("/api/books/1/passages").param("groupId", "9"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("GROUP_403_2"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #127

## 🚀 개요
흔적(Passage)/의견(Opinion)을 모임 안에서는 모임원끼리만 볼 수 있도록 확장합니다. `Passage`에 nullable `group_id`를 추가해 기존 API를 그대로 재사용하면서, `groupId`가 없으면 지금까지처럼 전체 공개로 동작하고 있으면 그 모임 멤버만 접근할 수 있게 했습니다. 댓글·좋아요도 같은 기준으로 모임원만 접근하도록 함께 막았습니다.

## 📄 작업 내용
- `Passage`에 nullable `group` 연관관계 추가. 유사 문장 판정 인덱스를 `(book_id, normalized_hash)` → `(book_id, group_id, normalized_hash)`로 변경해 모임 흔적과 전역 공개 흔적이 서로 중복 판정 대상이 되지 않도록 함
- `GroupAccessValidator` 공통 컴포넌트 신설 — "이 사용자가 이 모임의 멤버인가" 검증을 한 곳에 모아 `PassageService`/`OpinionService`/`SimilarPassageFinder`/`CommentService`/`OpinionLikeService`가 공유
- `PassageRepository`/`PassageQueryRepository`/`OpinionRepository`에 모임 스코프 조회 추가 (`findByIdAndDeletedAtIsNull`, `groupId` 필터, `OpinionRepository.findDetailById`가 passage/group까지 fetch join)
- 조회 API에 `groupId` 옵셔널 파라미터 추가 (없으면 기존과 동일)

| Method | Path | 비고 |
|---|---|---|
| GET | `/api/books/{bookId}/passages` | `groupId` 파라미터 추가 |
| GET | `/api/books/{bookId}/pages/{page}/passages` | `groupId` 파라미터 추가 |
| POST | `/api/passages/similar-check` | `groupId` 필드 추가 |
| GET | `/api/passages/{passageId}/opinions` | 대상 대목이 모임 소속이면 자동으로 모임원 검증 |
| GET | `/api/opinions/{opinionId}` | 〃 |
| GET/POST | `/api/opinions/{opinionId}/comments` | 〃 (파라미터 변경 없음) |
| GET | `/api/comments/{commentId}/replies` | 〃 |
| POST | `/api/opinions/{opinionId}/like` | 〃 |

- `POST /api/opinions`(`CreateOpinionRequest`)에 `groupId` 옵셔널 필드 추가
  - 새 대목 생성 시: 요청자가 모임원인지 + 그 모임의 고정 도서와 `bookId`가 일치하는지 검증 (`GROUP_400_3`)
  - 기존 대목에 병합 시: 대상 대목의 소속 모임과 요청의 `groupId`가 정확히 일치해야 함 (`PASSAGE_400_3`)
- 댓글 조회/작성(`getRootComments`/`getReplies`/`createComment`), 좋아요 토글(`toggleLike`)에도 모임원 검증 추가 — `opinionId`/`commentId`로 대상이 이미 특정되므로 클라이언트가 넘기는 파라미터 변경 없이 서비스 내부에서 대상 흔적의 소속 모임을 유추해 검증
- 꾸밈(`Decoration`)은 별도 공개 조회 API가 없고 항상 Passage/Opinion 응답에 얹혀서만 노출되므로, 위 항목들이 막히면 자동으로 함께 보호됩니다 — 별도 작업 불필요

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava compileTestJava` 통과
- `PassageServiceTest`(8) / `SimilarPassageFinderTest`(4) / `OpinionServiceTest`(28) / `CommentServiceTest`(24) / `OpinionLikeServiceTest`(5) / `PassageControllerTest`(14) / `OpinionControllerTest`(18) / `CommentControllerTest`(14) — 전부 통과

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인 (`@SpringBootTest` 통합 테스트 미확인 — 위 테스트 결과 참고)
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `GroupAccessValidator`를 새로 만들면서 기존 `GroupService`의 private `validateMember`는 리스크를 줄이려고 그대로 남겨뒀습니다(중복). 나중에 `GroupService`도 이 컴포넌트를 쓰도록 정리하면 좋을 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모임 전용 대목과 의견을 생성하고 조회할 수 있습니다.
  * 모임별 페이지, 유사 대목, 의견 조회를 지원합니다.
  * 모임원이 아닌 경우 모임 전용 콘텐츠 접근이 제한됩니다.
  * 의견 생성 시 모임과 도서·대목의 일치 여부를 검증합니다.

* **버그 수정**
  * 전역 콘텐츠와 모임 전용 콘텐츠가 서로 섞여 조회되지 않도록 개선했습니다.
  * 모임과 일치하지 않는 대목 사용 시 명확한 오류를 제공합니다.

* **문서**
  * 모임 전용 API의 요청 방식과 오류 응답 안내를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->