### PR TITLE
Feat/#130 읽기상태 완독 값 추가 및 해제 API

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/UserBookStatusService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/UserBookStatusService.java
@@ -72,4 +72,12 @@ public class UserBookStatusService {
             throw new BookException(BookErrorCode.INVALID_CURRENT_PAGE);
         }
     }
+
+    @Transactional
+    public void removeBookStatus(Long userId, Long bookId) {
+        if (!userBookStatusRepository.existsByUserIdAndBookId(userId, bookId)) {
+            throw new BookException(BookErrorCode.USER_BOOK_STATUS_NOT_FOUND);
+        }
+        userBookStatusRepository.deleteByUserIdAndBookId(userId, bookId);
+    }
 }

--- a/src/main/java/com/nexters/palang/domain/book/common/error/BookErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/book/common/error/BookErrorCode.java
@@ -13,6 +13,7 @@ public enum BookErrorCode implements BaseErrorCode {
     EXTERNAL_SEARCH_FAILED(HttpStatus.BAD_REQUEST, "BOOK_400_1", "외부 도서 검색에 실패했습니다. 잠시 후 다시 시도해주세요."),
     INVALID_CURRENT_PAGE(HttpStatus.BAD_REQUEST, "BOOK_400_2", "현재 페이지는 도서의 전체 페이지 수를 초과할 수 없습니다."),
     INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "BOOK_400_3", "이미지 파일만 업로드할 수 있습니다."),
+    USER_BOOK_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_404_2", "설정된 읽기 상태를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/nexters/palang/domain/book/domain/ReadingStatus.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/ReadingStatus.java
@@ -2,5 +2,6 @@ package com.nexters.palang.domain.book.domain;
 
 public enum ReadingStatus {
     READING,
-    PLANNED
+    PLANNED,
+    FINISHED
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
@@ -7,4 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserBookStatusRepository extends JpaRepository<UserBookStatus, Long> {
 
     Optional<UserBookStatus> findByUserIdAndBookId(Long userId, Long bookId);
+
+    boolean existsByUserIdAndBookId(Long userId, Long bookId);
+
+    void deleteByUserIdAndBookId(Long userId, Long bookId);
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusApi.java
@@ -5,6 +5,7 @@ import com.nexters.palang.domain.book.presentation.dto.UserBookStatusResponse;
 import com.nexters.palang.global.common.error.ErrorResponse;
 import com.nexters.palang.global.common.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,5 +43,24 @@ public interface UserBookStatusApi {
     })
     ResponseEntity<DataResponse<UserBookStatusResponse>> updateBookStatus(
             @Valid UpdateUserBookStatusRequest request
+    );
+
+    @Operation(summary = "읽기상태 해제", description = "로그인한 사용자의 특정 도서에 설정된 읽기상태를 삭제합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"type\":\"/api/users/me/book-status\",\"title\":\"AUTH_401_1\",\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))
+            ),
+            @ApiResponse(responseCode = "404", description = "설정된 읽기 상태를 찾을 수 없음 (BOOK_404_2)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"type\":\"/api/users/me/book-status\",\"title\":\"BOOK_404_2\",\"status\":404,\"detail\":\"설정된 읽기 상태를 찾을 수 없습니다.\"}"))
+            )
+    })
+    ResponseEntity<DataResponse<Void>> deleteBookStatus(
+            @Parameter(description = "읽기상태를 해제할 도서 ID", required = true) Long bookId
     );
 }

--- a/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusController.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/UserBookStatusController.java
@@ -9,8 +9,10 @@ import com.nexters.palang.global.security.CurrentUserProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,5 +29,13 @@ public class UserBookStatusController implements UserBookStatusApi {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         UserBookStatus userBookStatus = userBookStatusService.updateBookStatus(currentUserId, request);
         return ResponseEntity.ok(DataResponse.from(UserBookStatusResponse.from(userBookStatus)));
+    }
+
+    @Override
+    @DeleteMapping("/api/users/me/book-status")
+    public ResponseEntity<DataResponse<Void>> deleteBookStatus(@RequestParam Long bookId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        userBookStatusService.removeBookStatus(currentUserId, bookId);
+        return ResponseEntity.ok(DataResponse.from(null));
     }
 }

--- a/src/test/java/com/nexters/palang/domain/book/application/UserBookStatusServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/UserBookStatusServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
@@ -124,6 +125,25 @@ class UserBookStatusServiceTest {
 
         assertThatThrownBy(() -> userBookStatusService.updateBookStatus(
                 1L, new UpdateUserBookStatusRequest(10L, ReadingStatus.READING, 50)))
+                .isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("설정된 읽기상태를 해제하면 삭제된다")
+    void removeBookStatusDeletesExistingStatus() {
+        given(userBookStatusRepository.existsByUserIdAndBookId(1L, 10L)).willReturn(true);
+
+        userBookStatusService.removeBookStatus(1L, 10L);
+
+        verify(userBookStatusRepository).deleteByUserIdAndBookId(1L, 10L);
+    }
+
+    @Test
+    @DisplayName("설정된 읽기상태가 없으면 해제 시 예외가 발생한다")
+    void removeBookStatusThrowsExceptionWhenStatusDoesNotExist() {
+        given(userBookStatusRepository.existsByUserIdAndBookId(1L, 10L)).willReturn(false);
+
+        assertThatThrownBy(() -> userBookStatusService.removeBookStatus(1L, 10L))
                 .isInstanceOf(BookException.class);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/book/presentation/UserBookStatusControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/presentation/UserBookStatusControllerTest.java
@@ -3,12 +3,17 @@ package com.nexters.palang.domain.book.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.palang.domain.book.application.UserBookStatusService;
+import com.nexters.palang.domain.book.common.error.BookErrorCode;
+import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.ReadingStatus;
 import com.nexters.palang.domain.book.domain.UserBookStatus;
@@ -94,5 +99,38 @@ class UserBookStatusControllerTest {
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("읽기상태를 해제하면 성공 응답을 반환한다")
+    void deleteBookStatus() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/users/me/book-status").param("bookId", "10"))
+                .andExpect(status().isOk());
+
+        verify(userBookStatusService).removeBookStatus(1L, 10L);
+    }
+
+    @Test
+    @DisplayName("인증 없이 읽기상태를 해제하면 401 에러가 발생한다")
+    void deleteBookStatusFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(delete("/api/users/me/book-status").param("bookId", "10"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("설정된 읽기상태가 없으면 해제 시 404 에러가 발생한다")
+    void deleteBookStatusFailsWhenStatusDoesNotExist() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        willThrow(new BookException(BookErrorCode.USER_BOOK_STATUS_NOT_FOUND))
+                .given(userBookStatusService).removeBookStatus(1L, 10L);
+
+        mockMvc.perform(delete("/api/users/me/book-status").param("bookId", "10"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("BOOK_404_2"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #130

## 🚀 개요
> 마이페이지 내 서재의 책 상태 설정 화면에서 "완독" 표시와 상태 해제를 지원하기 위해 `UserBookStatus` API를 확장했습니다.

## 📄 작업 내용
- `ReadingStatus` enum에 `FINISHED` 추가 (`READING`, `PLANNED`, `FINISHED`) — `PLANNED`는 흔적 작성 화면(FR-WRITE-08, 이슈 #42)에서 계속 사용 중이라 유지
- `DELETE /api/users/me/book-status?bookId={bookId}` 신설 — 로그인 사용자의 읽기상태 레코드 삭제, 대상이 없으면 `404 BOOK_404_2`
- `BookErrorCode.USER_BOOK_STATUS_NOT_FOUND (BOOK_404_2)` 추가
- `UserBookStatusRepository`에 `existsByUserIdAndBookId`, `deleteByUserIdAndBookId` 추가
- `UserBookStatusService.removeBookStatus` 추가 (존재 검증 후 삭제)
- `UserBookStatusApi` Swagger 문서화 및 컨트롤러/서비스 테스트 추가

| Method | Path | 설명 |
|---|---|---|
| PUT | /api/users/me/book-status | 읽기상태/현재 페이지 설정 (기존) |
| DELETE | /api/users/me/book-status?bookId={bookId} | 읽기상태 해제 (신규) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test --tests "*UserBookStatus*"` 13건 전부 통과
- 전체 스위트 실행 결과 실패 3건은 로컬 Redis 미기동으로 인한 `AladinBookApiClientCacheTest`의 사전 존재 이슈이며 이번 변경과 무관

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 해제 방식을 `DELETE` 엔드포인트 신설로 결정했습니다 (PUT body의 `status` nullable 허용 대신). REST 관례상 명확하고 기존 `UpdateUserBookStatusRequest`의 `@NotNull` 검증을 건드리지 않아도 되어서인데, 이 판단이 맞는지 확인 부탁드립니다.
- 원 요청에는 `PLANNED` 제거도 포함되어 있었지만, 흔적 작성 화면에서 여전히 쓰이는 값(이슈 #42로 유지 확정)이라 이번 PR에는 반영하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 도서의 읽기 상태를 삭제할 수 있는 API가 추가되었습니다.
  * 읽기 상태에 `완독` 상태가 추가되었습니다.
  * 존재하지 않는 읽기 상태 삭제 시 404 오류가 반환됩니다.

* **테스트**
  * 읽기 상태 삭제 성공, 인증 실패, 대상 없음 상황에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->