### PR TITLE
Feat/#131 좋아요/댓글/책 신규 의견 알림 (인앱 저장 + FCM 푸시)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 
+	// FCM 푸시 알림. 서비스 계정 키 없이도(firebase.credentials-base64 미설정) 앱이 정상 구동되도록
+	// FirebaseConfig에서 조건부로만 초기화한다.
+	implementation 'com.google.firebase:firebase-admin:9.5.0'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
+++ b/src/main/java/com/nexters/palang/domain/comment/application/CommentService.java
@@ -3,6 +3,7 @@ package com.nexters.palang.domain.comment.application;
 import com.nexters.palang.domain.comment.common.CommentErrorCode;
 import com.nexters.palang.domain.comment.common.CommentException;
 import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.domain.event.CommentCreatedEvent;
 import com.nexters.palang.domain.comment.infrastructure.CommentQueryRepository;
 import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
 import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
@@ -18,6 +19,7 @@ import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class CommentService {
     private final CommentQueryRepository commentQueryRepository;
     private final OpinionRepository opinionRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public Page<RootCommentGroup> getRootComments(Long opinionId, Pageable pageable, Long currentUserId) {
         validateOpinionExists(opinionId);
@@ -63,15 +66,20 @@ public class CommentService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
+        Comment saved;
         if (request.parentCommentId() == null) {
-            return commentRepository.save(Comment.root(opinion, user, request.content()));
+            saved = commentRepository.save(Comment.root(opinion, user, request.content()));
+        } else {
+            Comment parent = getEditableComment(request.parentCommentId());
+            if (!parent.getOpinion().getId().equals(opinionId)) {
+                throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
+            }
+            saved = commentRepository.save(Comment.reply(parent, user, request.content()));
         }
 
-        Comment parent = getEditableComment(request.parentCommentId());
-        if (!parent.getOpinion().getId().equals(opinionId)) {
-            throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
-        }
-        return commentRepository.save(Comment.reply(parent, user, request.content()));
+        eventPublisher.publishEvent(
+                new CommentCreatedEvent(saved.getId(), opinionId, opinion.getUser().getId(), userId));
+        return saved;
     }
 
     @Transactional

--- a/src/main/java/com/nexters/palang/domain/comment/domain/event/CommentCreatedEvent.java
+++ b/src/main/java/com/nexters/palang/domain/comment/domain/event/CommentCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.nexters.palang.domain.comment.domain.event;
+
+public record CommentCreatedEvent(Long commentId, Long opinionId, Long opinionOwnerId, Long actorUserId) {
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/BookNewOpinionsNotifier.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/BookNewOpinionsNotifier.java
@@ -1,0 +1,70 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * "내가 의견 남긴 책에 새 의견 N개 이상" 알림의 집계/중복방지 로직.
+ * 별도 캐시(Redis) 없이 Notification 테이블 자체를 상태 저장소로 재사용한다: 마지막으로 보낸
+ * BOOK_NEW_OPINIONS 알림의 opinionCountSnapshot과 현재 의견 수의 차이가 threshold 이상이면 다시 알린다.
+ */
+@Component
+public class BookNewOpinionsNotifier {
+
+    private final OpinionRepository opinionRepository;
+    private final NotificationRepository notificationRepository;
+    private final BookRepository bookRepository;
+    private final NotificationCreationService notificationCreationService;
+    private final int threshold;
+
+    public BookNewOpinionsNotifier(
+            OpinionRepository opinionRepository,
+            NotificationRepository notificationRepository,
+            BookRepository bookRepository,
+            NotificationCreationService notificationCreationService,
+            @Value("${notification.book-new-opinions-threshold:5}") int threshold
+    ) {
+        this.opinionRepository = opinionRepository;
+        this.notificationRepository = notificationRepository;
+        this.bookRepository = bookRepository;
+        this.notificationCreationService = notificationCreationService;
+        this.threshold = threshold;
+    }
+
+    @Transactional
+    public void notifyIfThresholdReached(Long bookId, Long actorUserId) {
+        long currentCount = opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(bookId);
+        List<Long> candidateReceiverIds = opinionRepository.findDistinctUserIdsByBookId(bookId);
+        if (candidateReceiverIds.isEmpty()) {
+            return;
+        }
+
+        Book book = bookRepository.findById(bookId).orElse(null);
+        String bookTitle = book != null ? book.getTitle() : "관심 도서";
+        String title = "새로운 의견 소식";
+        String body = "'%s'에 새로운 의견이 %d개 이상 달렸어요.".formatted(bookTitle, threshold);
+
+        for (Long receiverId : candidateReceiverIds) {
+            if (receiverId.equals(actorUserId)) {
+                continue;
+            }
+            int lastSnapshot = notificationRepository
+                    .findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                            receiverId, NotificationType.BOOK_NEW_OPINIONS, bookId)
+                    .map(n -> n.getOpinionCountSnapshot() == null ? 0 : n.getOpinionCountSnapshot())
+                    .orElse(0);
+
+            if (currentCount - lastSnapshot >= threshold) {
+                notificationCreationService.create(receiverId, null, NotificationType.BOOK_NEW_OPINIONS,
+                        title, body, null, bookId, null, (int) currentCount);
+            }
+        }
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/DeviceTokenService.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/DeviceTokenService.java
@@ -1,0 +1,38 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.notification.domain.DevicePlatform;
+import com.nexters.palang.domain.notification.domain.DeviceToken;
+import com.nexters.palang.domain.notification.infrastructure.DeviceTokenRepository;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserRepository userRepository;
+
+    // FCM 토큰은 기기 단위로 유일하다. 같은 토큰이 다른 사용자로 재등록되면(재설치/재로그인) 소유자를 교체한다.
+    @Transactional
+    public void registerOrRefresh(Long userId, String token, DevicePlatform platform) {
+        DeviceToken existing = deviceTokenRepository.findByToken(token).orElse(null);
+        if (existing != null) {
+            User user = userRepository.getReferenceById(userId);
+            existing.reassign(user, platform);
+            return;
+        }
+
+        User user = userRepository.getReferenceById(userId);
+        deviceTokenRepository.save(DeviceToken.builder().user(user).token(token).platform(platform).build());
+    }
+
+    @Transactional
+    public void remove(Long userId, String token) {
+        deviceTokenRepository.deleteByTokenAndUserId(token, userId);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationCreationService.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationCreationService.java
@@ -1,0 +1,53 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 알림 생성 공통 경로: 자기알림 제외, 저장, 푸시 트리거를 한 곳에서 처리한다.
+@Service
+@RequiredArgsConstructor
+public class NotificationCreationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final NotificationPushDispatcher pushDispatcher;
+
+    @Transactional
+    public void create(
+            Long receiverId,
+            Long actorId,
+            NotificationType type,
+            String title,
+            String body,
+            Long opinionId,
+            Long bookId,
+            Long commentId,
+            Integer opinionCountSnapshot
+    ) {
+        if (actorId != null && actorId.equals(receiverId)) {
+            return;
+        }
+
+        User receiver = userRepository.getReferenceById(receiverId);
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .type(type)
+                .title(title)
+                .body(body)
+                .actorId(actorId)
+                .opinionId(opinionId)
+                .bookId(bookId)
+                .commentId(commentId)
+                .opinionCountSnapshot(opinionCountSnapshot)
+                .build();
+        notificationRepository.save(notification);
+
+        pushDispatcher.dispatch(receiverId, type, title, body, notification.getId());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationCreationService.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationCreationService.java
@@ -6,10 +6,12 @@ import com.nexters.palang.domain.notification.infrastructure.NotificationReposit
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 // 알림 생성 공통 경로: 자기알림 제외, 저장, 푸시 트리거를 한 곳에서 처리한다.
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationCreationService {
@@ -48,6 +50,11 @@ public class NotificationCreationService {
                 .build();
         notificationRepository.save(notification);
 
-        pushDispatcher.dispatch(receiverId, type, title, body, notification.getId());
+        try {
+            pushDispatcher.dispatch(receiverId, type, title, body, notification.getId());
+        } catch (Exception e) {
+            // 푸시 발송 실패가 방금 저장한 알림까지 롤백시키면 안 된다 (인앱 알림은 이미 유효한 결과).
+            log.error("FCM 푸시 발송 실패 (notificationId={})", notification.getId(), e);
+        }
     }
 }

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationEventListener.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationEventListener.java
@@ -1,0 +1,62 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.comment.domain.event.CommentCreatedEvent;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.opinion.domain.event.OpinionCreatedEvent;
+import com.nexters.palang.domain.opinion.domain.event.OpinionLikedEvent;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+// 좋아요/댓글 API 응답 지연을 막기 위해 커밋 이후 비동기로 처리한다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationCreationService notificationCreationService;
+    private final BookNewOpinionsNotifier bookNewOpinionsNotifier;
+    private final UserRepository userRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOpinionLiked(OpinionLikedEvent event) {
+        User actor = userRepository.findById(event.actorUserId()).orElse(null);
+        if (actor == null) {
+            log.warn("좋아요 알림 생성 스킵: actor {}를 찾을 수 없음", event.actorUserId());
+            return;
+        }
+
+        String title = "새로운 좋아요";
+        String body = "%s님이 회원님의 흔적을 좋아합니다.".formatted(actor.getNickname());
+        notificationCreationService.create(event.opinionOwnerId(), event.actorUserId(), NotificationType.OPINION_LIKED,
+                title, body, event.opinionId(), null, null, null);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCommentCreated(CommentCreatedEvent event) {
+        User actor = userRepository.findById(event.actorUserId()).orElse(null);
+        if (actor == null) {
+            log.warn("댓글 알림 생성 스킵: actor {}를 찾을 수 없음", event.actorUserId());
+            return;
+        }
+
+        String title = "새로운 댓글";
+        String body = "%s님이 회원님의 흔적에 댓글을 남겼습니다.".formatted(actor.getNickname());
+        notificationCreationService.create(
+                event.opinionOwnerId(), event.actorUserId(), NotificationType.OPINION_COMMENTED,
+                title, body, event.opinionId(), null, event.commentId(), null);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOpinionCreated(OpinionCreatedEvent event) {
+        bookNewOpinionsNotifier.notifyIfThresholdReached(event.bookId(), event.actorUserId());
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationPushDispatcher.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationPushDispatcher.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
@@ -17,7 +18,9 @@ public class NotificationPushDispatcher {
     private final DeviceTokenRepository deviceTokenRepository;
     private final FcmPushSender fcmPushSender;
 
-    @Transactional
+    // REQUIRES_NEW: 알림 저장 트랜잭션과 분리해서, 여기서 나는 예외가 방금 저장한 Notification까지
+    // 롤백시키지 않게 한다 (호출부인 NotificationCreationService.create()의 try-catch와 한 쌍).
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void dispatch(Long receiverId, NotificationType type, String title, String body, Long notificationId) {
         List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(receiverId);
         if (deviceTokens.isEmpty()) {

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationPushDispatcher.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationPushDispatcher.java
@@ -1,0 +1,37 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.notification.domain.DeviceToken;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.DeviceTokenRepository;
+import com.nexters.palang.domain.notification.infrastructure.fcm.FcmPushSender;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationPushDispatcher {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final FcmPushSender fcmPushSender;
+
+    @Transactional
+    public void dispatch(Long receiverId, NotificationType type, String title, String body, Long notificationId) {
+        List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(receiverId);
+        if (deviceTokens.isEmpty()) {
+            return;
+        }
+
+        List<String> tokens = deviceTokens.stream().map(DeviceToken::getToken).toList();
+        Map<String, String> data = Map.of(
+                "type", type.name(),
+                "notificationId", String.valueOf(notificationId)
+        );
+
+        List<String> invalidTokens = fcmPushSender.sendMulticast(tokens, title, body, data);
+        invalidTokens.forEach(token -> deviceTokenRepository.findByToken(token)
+                .ifPresent(deviceTokenRepository::delete));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/nexters/palang/domain/notification/application/NotificationService.java
@@ -1,0 +1,38 @@
+package com.nexters.palang.domain.notification.application;
+
+import com.nexters.palang.domain.notification.common.error.NotificationErrorCode;
+import com.nexters.palang.domain.notification.common.error.NotificationException;
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public Page<Notification> getNotifications(Long userId, Pageable pageable) {
+        return notificationRepository.findByReceiverIdOrderByCreatedAtDesc(userId, pageable);
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!notification.getReceiver().getId().equals(userId)) {
+            throw new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.markAllAsRead(userId);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/common/error/NotificationErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/notification/common/error/NotificationErrorCode.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.notification.common.error;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_404_1", "해당 알림을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/domain/notification/common/error/NotificationException.java
+++ b/src/main/java/com/nexters/palang/domain/notification/common/error/NotificationException.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.notification.common.error;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class NotificationException extends AppException {
+
+    public NotificationException(NotificationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/domain/DevicePlatform.java
+++ b/src/main/java/com/nexters/palang/domain/notification/domain/DevicePlatform.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.notification.domain;
+
+public enum DevicePlatform {
+    IOS,
+    ANDROID,
+}

--- a/src/main/java/com/nexters/palang/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/com/nexters/palang/domain/notification/domain/DeviceToken.java
@@ -1,0 +1,69 @@
+package com.nexters.palang.domain.notification.domain;
+
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "device_tokens",
+        uniqueConstraints = @UniqueConstraint(name = "uq_device_tokens_token", columnNames = "token"),
+        indexes = @Index(name = "idx_device_tokens_user", columnList = "user_id")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceToken extends BaseEntity {
+
+    public static final int TOKEN_MAX_LENGTH = 255;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "token", length = TOKEN_MAX_LENGTH, nullable = false)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false)
+    private DevicePlatform platform;
+
+    @Column(name = "last_active_at", nullable = false)
+    private LocalDateTime lastActiveAt;
+
+    @Builder
+    private DeviceToken(User user, String token, DevicePlatform platform) {
+        this.user = user;
+        this.token = token;
+        this.platform = platform;
+        this.lastActiveAt = LocalDateTime.now();
+    }
+
+    // 같은 기기에서 재로그인/재설치로 토큰이 재등록될 때: 소유자와 플랫폼을 최신 상태로 교체한다.
+    public void reassign(User user, DevicePlatform platform) {
+        this.user = user;
+        this.platform = platform;
+        this.lastActiveAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/domain/Notification.java
+++ b/src/main/java/com/nexters/palang/domain/notification/domain/Notification.java
@@ -1,0 +1,110 @@
+package com.nexters.palang.domain.notification.domain;
+
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_receiver", columnList = "receiver_id, created_at"),
+                // BookNewOpinionsNotifier가 (receiver, book) 기준 가장 최근 알림의 snapshot을 조회하는 데 사용.
+                @Index(name = "idx_notifications_receiver_book", columnList = "receiver_id, book_id, created_at")
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private NotificationType type;
+
+    // 알림 리스트는 조인 없이 바로 렌더링할 수 있도록 생성 시점에 title/body를 스냅샷으로 저장한다.
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "body", nullable = false)
+    private String body;
+
+    // 알림을 유발한 사용자(좋아요/댓글 작성자). BOOK_NEW_OPINIONS는 특정 한 명이 아니라 null.
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    @Column(name = "opinion_id")
+    private Long opinionId;
+
+    @Column(name = "book_id")
+    private Long bookId;
+
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    // BOOK_NEW_OPINIONS 전용: 알림 생성 시점의 책 전체(살아있는) 의견 수. 다음 알림 발송 여부 판단 기준값.
+    @Column(name = "opinion_count_snapshot")
+    private Integer opinionCountSnapshot;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Builder
+    private Notification(
+            User receiver,
+            NotificationType type,
+            String title,
+            String body,
+            Long actorId,
+            Long opinionId,
+            Long bookId,
+            Long commentId,
+            Integer opinionCountSnapshot
+    ) {
+        this.receiver = receiver;
+        this.type = type;
+        this.title = title;
+        this.body = body;
+        this.actorId = actorId;
+        this.opinionId = opinionId;
+        this.bookId = bookId;
+        this.commentId = commentId;
+        this.opinionCountSnapshot = opinionCountSnapshot;
+        this.read = false;
+    }
+
+    public void markAsRead() {
+        if (this.read) {
+            return;
+        }
+        this.read = true;
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/nexters/palang/domain/notification/domain/NotificationType.java
@@ -1,0 +1,7 @@
+package com.nexters.palang.domain.notification.domain;
+
+public enum NotificationType {
+    OPINION_LIKED,
+    OPINION_COMMENTED,
+    BOOK_NEW_OPINIONS,
+}

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/DeviceTokenRepository.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/DeviceTokenRepository.java
@@ -1,0 +1,15 @@
+package com.nexters.palang.domain.notification.infrastructure;
+
+import com.nexters.palang.domain.notification.domain.DeviceToken;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByToken(String token);
+
+    List<DeviceToken> findAllByUserId(Long userId);
+
+    void deleteByTokenAndUserId(String token, Long userId);
+}

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,25 @@
+package com.nexters.palang.domain.notification.infrastructure;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    Page<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId, Pageable pageable);
+
+    // BookNewOpinionsNotifier: 이 사용자에게 이 책에 대해 마지막으로 보낸 BOOK_NEW_OPINIONS 알림의 snapshot을 조회.
+    Optional<Notification> findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+            Long receiverId, NotificationType type, Long bookId);
+
+    @Modifying
+    @Query("update Notification n set n.read = true, n.readAt = current_timestamp "
+            + "where n.receiver.id = :receiverId and n.read = false")
+    int markAllAsRead(@Param("receiverId") Long receiverId);
+}

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/FcmPushSender.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/FcmPushSender.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.notification.infrastructure.fcm;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FcmPushSender {
+
+    /**
+     * 주어진 토큰들로 푸시를 발송하고, 더 이상 유효하지 않은(재설치/삭제 등으로 무효화된) 토큰 목록을 반환한다.
+     * 호출부(NotificationPushDispatcher)는 이 목록을 DeviceToken 테이블에서 정리한다.
+     */
+    List<String> sendMulticast(List<String> tokens, String title, String body, Map<String, String> data);
+}

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/FirebaseFcmPushSender.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/FirebaseFcmPushSender.java
@@ -1,0 +1,61 @@
+package com.nexters.palang.domain.notification.infrastructure.fcm;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FirebaseFcmPushSender implements FcmPushSender {
+
+    private final FirebaseApp firebaseApp;
+
+    @Override
+    public List<String> sendMulticast(List<String> tokens, String title, String body, Map<String, String> data) {
+        if (tokens.isEmpty()) {
+            return List.of();
+        }
+
+        MulticastMessage message = MulticastMessage.builder()
+                .addAllTokens(tokens)
+                .setNotification(Notification.builder().setTitle(title).setBody(body).build())
+                .putAllData(data)
+                .build();
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance(firebaseApp).sendEachForMulticast(message);
+            return invalidTokens(tokens, response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 멀티캐스트 발송 실패", e);
+            return List.of();
+        }
+    }
+
+    private List<String> invalidTokens(List<String> tokens, BatchResponse response) {
+        List<String> invalid = new ArrayList<>();
+        List<SendResponse> responses = response.getResponses();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse sendResponse = responses.get(i);
+            if (sendResponse.isSuccessful()) {
+                continue;
+            }
+            MessagingErrorCode errorCode = sendResponse.getException() != null
+                    ? sendResponse.getException().getMessagingErrorCode()
+                    : null;
+            if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                invalid.add(tokens.get(i));
+            }
+        }
+        return invalid;
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/NoOpFcmPushSender.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/fcm/NoOpFcmPushSender.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.notification.infrastructure.fcm;
+
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Firebase 서비스 계정 키(firebase.credentials-base64)가 설정되지 않은 환경(로컬/CI 기본값)에서
+ * 앱 부팅이 깨지지 않도록 하는 폴백 구현체. 실제 푸시는 보내지 않고 로그만 남긴다.
+ */
+@Slf4j
+public class NoOpFcmPushSender implements FcmPushSender {
+
+    @Override
+    public List<String> sendMulticast(List<String> tokens, String title, String body, Map<String, String> data) {
+        log.info("[FCM 비활성화] 푸시 발송 스킵: tokens={}, title={}", tokens.size(), title);
+        return List.of();
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/DeviceTokenApi.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/DeviceTokenApi.java
@@ -1,0 +1,49 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import com.nexters.palang.domain.notification.presentation.dto.RegisterDeviceTokenRequest;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "DeviceToken", description = "FCM 디바이스 토큰 API")
+public interface DeviceTokenApi {
+
+    @Operation(summary = "디바이스 토큰 등록/갱신",
+            description = "FCM 디바이스 토큰을 등록합니다. 이미 등록된 토큰이면(재설치/재로그인 등) 소유자를 현재 로그인 사용자로 갱신합니다. "
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록/갱신 성공"),
+            @ApiResponse(responseCode = "400", description = "토큰 누락 (COMMON_400_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/device-tokens\",\"title\":\"COMMON_400_1\","
+                                    + "\"status\":400,\"detail\":\"디바이스 토큰은 필수입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/device-tokens\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> registerDeviceToken(@Valid RegisterDeviceTokenRequest request);
+
+    @Operation(summary = "디바이스 토큰 삭제", description = "로그아웃 등으로 더 이상 유효하지 않은 디바이스 토큰을 삭제합니다. "
+            + "본인 소유가 아니거나 존재하지 않는 토큰이어도 멱등하게 200을 반환합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/device-tokens\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> removeDeviceToken(
+            @Parameter(description = "삭제할 디바이스 토큰", required = true) String token
+    );
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/DeviceTokenController.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/DeviceTokenController.java
@@ -1,0 +1,38 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import com.nexters.palang.domain.notification.application.DeviceTokenService;
+import com.nexters.palang.domain.notification.presentation.dto.RegisterDeviceTokenRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DeviceTokenController implements DeviceTokenApi {
+
+    private final DeviceTokenService deviceTokenService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @PutMapping("/api/notifications/device-tokens")
+    public ResponseEntity<DataResponse<Void>> registerDeviceToken(@RequestBody @Valid RegisterDeviceTokenRequest request) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        deviceTokenService.registerOrRefresh(currentUserId, request.token(), request.platform());
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @DeleteMapping("/api/notifications/device-tokens")
+    public ResponseEntity<DataResponse<Void>> removeDeviceToken(@RequestParam String token) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        deviceTokenService.remove(currentUserId, token);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/NotificationApi.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/NotificationApi.java
@@ -1,0 +1,61 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import com.nexters.palang.domain.notification.presentation.dto.NotificationListResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Notification", description = "알림 API")
+public interface NotificationApi {
+
+    @Operation(summary = "알림 목록 조회",
+            description = "내가 받은 알림을 최신순으로 페이지네이션 조회합니다. "
+                    + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<NotificationListResponse>> getNotifications(
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
+    );
+
+    @Operation(summary = "알림 단건 읽음 처리", description = "본인이 받은 알림 하나를 읽음 상태로 변경합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/1/read\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
+            @ApiResponse(responseCode = "404", description = "본인에게 온 알림이 아니거나 존재하지 않음 (NOTIFICATION_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/1/read\",\"title\":\"NOTIFICATION_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 알림을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> readNotification(
+            @Parameter(description = "알림 ID", required = true) Long notificationId
+    );
+
+    @Operation(summary = "알림 전체 읽음 처리", description = "본인이 받은 안 읽은 알림을 모두 읽음 상태로 변경합니다. "
+            + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/notifications/read-all\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> readAllNotifications();
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/NotificationController.java
@@ -1,0 +1,57 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import com.nexters.palang.domain.notification.application.NotificationService;
+import com.nexters.palang.domain.notification.presentation.dto.NotificationListResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController implements NotificationApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final NotificationService notificationService;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @GetMapping("/api/notifications")
+    public ResponseEntity<DataResponse<NotificationListResponse>> getNotifications(
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return ResponseEntity.ok(DataResponse.from(NotificationListResponse.from(
+                notificationService.getNotifications(currentUserId, pageable(page, size)))));
+    }
+
+    @Override
+    @PatchMapping("/api/notifications/{notificationId}/read")
+    public ResponseEntity<DataResponse<Void>> readNotification(@PathVariable Long notificationId) {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        notificationService.markAsRead(currentUserId, notificationId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    @Override
+    @PatchMapping("/api/notifications/read-all")
+    public ResponseEntity<DataResponse<Void>> readAllNotifications() {
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        notificationService.markAllAsRead(currentUserId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/dto/NotificationListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/dto/NotificationListResponse.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.notification.presentation.dto;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record NotificationListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<NotificationResponse> notifications,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+    public static NotificationListResponse from(Page<Notification> page) {
+        List<NotificationResponse> notifications = page.getContent().stream()
+                .map(NotificationResponse::from)
+                .toList();
+        return new NotificationListResponse(notifications, PageInfo.from(page));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/dto/NotificationResponse.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/dto/NotificationResponse.java
@@ -1,0 +1,32 @@
+package com.nexters.palang.domain.notification.presentation.dto;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long notificationId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) NotificationType type,
+        @Schema(example = "새로운 좋아요", requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(example = "책읽는고양이님이 회원님의 흔적을 좋아합니다.", requiredMode = Schema.RequiredMode.REQUIRED) String body,
+        @Schema(example = "3", nullable = true) Long opinionId,
+        @Schema(example = "10", nullable = true) Long bookId,
+        @Schema(example = "5", nullable = true) Long commentId,
+        @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isRead,
+        @Schema(example = "2026-08-19T10:00:00", requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getOpinionId(),
+                notification.getBookId(),
+                notification.getCommentId(),
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/notification/presentation/dto/RegisterDeviceTokenRequest.java
+++ b/src/main/java/com/nexters/palang/domain/notification/presentation/dto/RegisterDeviceTokenRequest.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.notification.presentation.dto;
+
+import com.nexters.palang.domain.notification.domain.DevicePlatform;
+import com.nexters.palang.domain.notification.domain.DeviceToken;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegisterDeviceTokenRequest(
+        @NotBlank(message = "디바이스 토큰은 필수입니다.")
+        @Size(max = DeviceToken.TOKEN_MAX_LENGTH, message = "디바이스 토큰이 너무 깁니다.")
+        @Schema(example = "fcm-device-token-example", requiredMode = Schema.RequiredMode.REQUIRED)
+        String token,
+        @NotNull(message = "플랫폼은 필수입니다.")
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        DevicePlatform platform
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionLikeService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionLikeService.java
@@ -4,11 +4,13 @@ import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.domain.OpinionLike;
+import com.nexters.palang.domain.opinion.domain.event.OpinionLikedEvent;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class OpinionLikeService {
     private final OpinionRepository opinionRepository;
     private final OpinionLikeRepository opinionLikeRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public OpinionLikeResult toggleLike(Long userId, Long opinionId) {
@@ -35,6 +38,7 @@ public class OpinionLikeService {
         User user = userRepository.getReferenceById(userId);
         opinionLikeRepository.save(OpinionLike.builder().user(user).opinion(opinion).build());
         opinion.increaseLikeCount();
+        eventPublisher.publishEvent(new OpinionLikedEvent(opinion.getId(), opinion.getUser().getId(), userId));
         return new OpinionLikeResult(opinion.getId(), true, opinion.getLikeCount());
     }
 

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -10,6 +10,7 @@ import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.opinion.domain.event.OpinionCreatedEvent;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
@@ -26,6 +27,7 @@ import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -42,6 +44,7 @@ public class OpinionService {
     private final PassageRepository passageRepository;
     private final BookRepository bookRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 흔적 목록(FR-OPINION-03): 최신순(기본)/좋아요순. currentUserId는 비로그인 시 null(liked는 항상 false).
     public Page<OpinionSummaryProjection> getOpinions(
@@ -114,6 +117,7 @@ public class OpinionService {
 
         Opinion opinion = Opinion.createWithDecorations(passage, user, request.content(), decorations);
         opinionRepository.save(opinion);
+        eventPublisher.publishEvent(new OpinionCreatedEvent(opinion.getId(), passage.getBook().getId(), userId));
         return opinion;
     }
 

--- a/src/main/java/com/nexters/palang/domain/opinion/domain/event/OpinionCreatedEvent.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/domain/event/OpinionCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.nexters.palang.domain.opinion.domain.event;
+
+public record OpinionCreatedEvent(Long opinionId, Long bookId, Long actorUserId) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/domain/event/OpinionLikedEvent.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/domain/event/OpinionLikedEvent.java
@@ -1,0 +1,4 @@
+package com.nexters.palang.domain.opinion.domain.event;
+
+public record OpinionLikedEvent(Long opinionId, Long opinionOwnerId, Long actorUserId) {
+}

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.opinion.domain.Opinion;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,11 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
     // 참조하므로 트랜잭션 안에서 미리 로딩해야 LazyInitializationException을 피할 수 있다.
     @Query("select distinct o from Opinion o join fetch o.user left join fetch o.decorations where o.id = :id")
     Optional<Opinion> findDetailById(@Param("id") Long id);
+
+    // "책에 새 의견 N개" 알림(BookNewOpinionsNotifier)의 현재 카운트 기준값.
+    long countByPassage_Book_IdAndDeletedAtIsNull(Long bookId);
+
+    // 위 알림의 수신 대상 후보: 이 책에 살아있는 의견을 남긴 적 있는 사용자 목록(작성자 본인 제외는 호출부 책임).
+    @Query("select distinct o.user.id from Opinion o where o.passage.book.id = :bookId and o.deletedAt is null")
+    List<Long> findDistinctUserIdsByBookId(@Param("bookId") Long bookId);
 }

--- a/src/main/java/com/nexters/palang/global/config/AsyncConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.nexters.palang.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/nexters/palang/global/config/FirebaseConfig.java
+++ b/src/main/java/com/nexters/palang/global/config/FirebaseConfig.java
@@ -1,0 +1,40 @@
+package com.nexters.palang.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.nexters.palang.domain.notification.infrastructure.fcm.FcmPushSender;
+import com.nexters.palang.domain.notification.infrastructure.fcm.FirebaseFcmPushSender;
+import com.nexters.palang.domain.notification.infrastructure.fcm.NoOpFcmPushSender;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Firebase 서비스 계정 키(firebase.credentials-base64)가 아직 발급되지 않은 상태에서도
+ * 로컬/CI 빌드·구동이 깨지지 않도록, 값이 비어 있으면 FirebaseApp을 아예 초기화하지 않고
+ * NoOpFcmPushSender로 폴백한다.
+ * (프로퍼티 자체는 항상 존재하고 빈 문자열만 비어있는 상태이므로 @ConditionalOnProperty로는
+ * "설정 안 됨"을 정확히 구분할 수 없어, 팩토리 메서드 안에서 직접 분기한다.)
+ */
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FcmPushSender fcmPushSender(@Value("${firebase.credentials-base64:}") String credentialsBase64) throws Exception {
+        if (credentialsBase64 == null || credentialsBase64.isBlank()) {
+            log.warn("firebase.credentials-base64가 설정되지 않아 FCM 푸시가 비활성화됩니다 (NoOpFcmPushSender 사용).");
+            return new NoOpFcmPushSender();
+        }
+
+        byte[] decoded = Base64.getDecoder().decode(credentialsBase64);
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(decoded));
+        FirebaseOptions options = FirebaseOptions.builder().setCredentials(credentials).build();
+        FirebaseApp app = FirebaseApp.getApps().isEmpty() ? FirebaseApp.initializeApp(options) : FirebaseApp.getApps().get(0);
+        return new FirebaseFcmPushSender(app);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,3 +37,11 @@ storage:
   upload-dir: ${IMAGE_UPLOAD_DIR:./uploads}
   base-url: /images
   public-base-url: ${STORAGE_PUBLIC_BASE_URL:http://localhost:8080/images}
+
+# 서비스 계정 키(JSON)를 base64로 인코딩해 주입. 비어있으면 FirebaseConfig가 NoOpFcmPushSender로 폴백한다.
+firebase:
+  credentials-base64: ${FIREBASE_CREDENTIALS_BASE64:}
+
+notification:
+  # "책에 새 의견 N개 이상" 알림 트리거 기준값.
+  book-new-opinions-threshold: ${NOTIFICATION_BOOK_NEW_OPINIONS_THRESHOLD:5}

--- a/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/comment/application/CommentServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import com.nexters.palang.domain.comment.common.CommentException;
 import com.nexters.palang.domain.comment.common.NestedReplyNotAllowedException;
 import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.domain.event.CommentCreatedEvent;
 import com.nexters.palang.domain.comment.infrastructure.CommentQueryRepository;
 import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
 import com.nexters.palang.domain.comment.presentation.dto.CreateCommentRequest;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -47,6 +49,9 @@ class CommentServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private CommentService commentService;
 
     private Opinion opinion;
@@ -55,7 +60,8 @@ class CommentServiceTest {
 
     @BeforeEach
     void setUp() {
-        commentService = new CommentService(commentRepository, commentQueryRepository, opinionRepository, userRepository);
+        commentService = new CommentService(
+                commentRepository, commentQueryRepository, opinionRepository, userRepository, eventPublisher);
         writer = user(10L);
         opinion = opinion(1L);
         otherUser = user(20L);
@@ -199,6 +205,7 @@ class CommentServiceTest {
         assertThat(created.getParentComment()).isNull();
         assertThat(created.getContent()).isEqualTo("내용");
         assertThat(created.getUser()).isEqualTo(writer);
+        org.mockito.Mockito.verify(eventPublisher).publishEvent(any(CommentCreatedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/notification/application/BookNewOpinionsNotifierTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/BookNewOpinionsNotifierTest.java
@@ -1,0 +1,141 @@
+package com.nexters.palang.domain.notification.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BookNewOpinionsNotifierTest {
+
+    private static final int THRESHOLD = 5;
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private NotificationCreationService notificationCreationService;
+
+    private BookNewOpinionsNotifier notifier;
+
+    @BeforeEach
+    void setUp() {
+        notifier = new BookNewOpinionsNotifier(
+                opinionRepository, notificationRepository, bookRepository, notificationCreationService, THRESHOLD);
+    }
+
+    private Book book(Long id) {
+        Book book = Book.builder().title("제목").author("작가").publisher("출판사").pageCount(100).build();
+        ReflectionTestUtils.setField(book, "id", id);
+        return book;
+    }
+
+    private Notification notificationWithSnapshot(int snapshot) {
+        Notification notification = Notification.builder()
+                .type(NotificationType.BOOK_NEW_OPINIONS)
+                .title("t").body("b")
+                .opinionCountSnapshot(snapshot)
+                .build();
+        return notification;
+    }
+
+    @Test
+    @DisplayName("현재 의견 수와 마지막 알림 스냅샷의 차이가 threshold 미만이면 알림을 생성하지 않는다")
+    void doesNotNotifyWhenBelowThreshold() {
+        given(opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(1L)).willReturn(4L);
+        given(opinionRepository.findDistinctUserIdsByBookId(1L)).willReturn(List.of(10L));
+        given(notificationRepository.findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                10L, NotificationType.BOOK_NEW_OPINIONS, 1L)).willReturn(Optional.empty());
+
+        notifier.notifyIfThresholdReached(1L, 99L);
+
+        verify(notificationCreationService, never())
+                .create(anyLong(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("현재 의견 수가 threshold 이상 누적되면 알림을 생성한다")
+    void notifiesWhenThresholdReached() {
+        given(opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(1L)).willReturn(5L);
+        given(opinionRepository.findDistinctUserIdsByBookId(1L)).willReturn(List.of(10L));
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book(1L)));
+        given(notificationRepository.findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                10L, NotificationType.BOOK_NEW_OPINIONS, 1L)).willReturn(Optional.empty());
+
+        notifier.notifyIfThresholdReached(1L, 99L);
+
+        verify(notificationCreationService).create(
+                eq(10L), eq(null), eq(NotificationType.BOOK_NEW_OPINIONS), any(), any(), eq(null), eq(1L), eq(null), eq(5));
+    }
+
+    @Test
+    @DisplayName("이미 보낸 알림의 스냅샷 이후 threshold만큼 쌓이지 않았으면 다시 보내지 않는다(중복 방지)")
+    void doesNotNotifyAgainBeforeNextThreshold() {
+        given(opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(1L)).willReturn(8L);
+        given(opinionRepository.findDistinctUserIdsByBookId(1L)).willReturn(List.of(10L));
+        given(notificationRepository.findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                10L, NotificationType.BOOK_NEW_OPINIONS, 1L)).willReturn(Optional.of(notificationWithSnapshot(5)));
+
+        notifier.notifyIfThresholdReached(1L, 99L);
+
+        verify(notificationCreationService, never())
+                .create(anyLong(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 보낸 알림의 스냅샷 이후 threshold만큼 다시 쌓이면 재알림한다")
+    void notifiesAgainOnceNextThresholdReached() {
+        given(opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(1L)).willReturn(10L);
+        given(opinionRepository.findDistinctUserIdsByBookId(1L)).willReturn(List.of(10L));
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book(1L)));
+        given(notificationRepository.findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                10L, NotificationType.BOOK_NEW_OPINIONS, 1L)).willReturn(Optional.of(notificationWithSnapshot(5)));
+
+        notifier.notifyIfThresholdReached(1L, 99L);
+
+        verify(notificationCreationService, times(1)).create(
+                eq(10L), eq(null), eq(NotificationType.BOOK_NEW_OPINIONS), any(), any(), eq(null), eq(1L), eq(null), eq(10));
+    }
+
+    @Test
+    @DisplayName("의견을 새로 작성한 사용자 본인은 후보에서 제외한다")
+    void excludesActorFromCandidates() {
+        given(opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(1L)).willReturn(5L);
+        given(opinionRepository.findDistinctUserIdsByBookId(1L)).willReturn(List.of(10L, 99L));
+        given(bookRepository.findById(1L)).willReturn(Optional.of(book(1L)));
+        given(notificationRepository.findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                10L, NotificationType.BOOK_NEW_OPINIONS, 1L)).willReturn(Optional.empty());
+
+        notifier.notifyIfThresholdReached(1L, 99L);
+
+        verify(notificationCreationService, times(1)).create(
+                eq(10L), any(), eq(NotificationType.BOOK_NEW_OPINIONS), any(), any(), any(), eq(1L), any(), any());
+        verify(notificationCreationService, never()).create(
+                eq(99L), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/application/DeviceTokenServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/DeviceTokenServiceTest.java
@@ -1,0 +1,81 @@
+package com.nexters.palang.domain.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.notification.domain.DevicePlatform;
+import com.nexters.palang.domain.notification.domain.DeviceToken;
+import com.nexters.palang.domain.notification.infrastructure.DeviceTokenRepository;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceTokenServiceTest {
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private DeviceTokenService deviceTokenService;
+
+    @BeforeEach
+    void setUp() {
+        deviceTokenService = new DeviceTokenService(deviceTokenRepository, userRepository);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("처음 등록하는 토큰이면 새 DeviceToken을 저장한다")
+    void registerOrRefreshSavesNewTokenWhenNotExists() {
+        given(deviceTokenRepository.findByToken("token-a")).willReturn(Optional.empty());
+        given(userRepository.getReferenceById(1L)).willReturn(user(1L));
+
+        deviceTokenService.registerOrRefresh(1L, "token-a", DevicePlatform.ANDROID);
+
+        ArgumentCaptor<DeviceToken> captor = ArgumentCaptor.forClass(DeviceToken.class);
+        verify(deviceTokenRepository).save(captor.capture());
+        assertThat(captor.getValue().getToken()).isEqualTo("token-a");
+        assertThat(captor.getValue().getPlatform()).isEqualTo(DevicePlatform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("이미 등록된 토큰이면 저장 대신 소유자/플랫폼을 갱신한다")
+    void registerOrRefreshReassignsExistingToken() {
+        User previousOwner = user(1L);
+        DeviceToken existing = DeviceToken.builder().user(previousOwner).token("token-a").platform(DevicePlatform.IOS).build();
+        given(deviceTokenRepository.findByToken("token-a")).willReturn(Optional.of(existing));
+        given(userRepository.getReferenceById(2L)).willReturn(user(2L));
+
+        deviceTokenService.registerOrRefresh(2L, "token-a", DevicePlatform.ANDROID);
+
+        assertThat(existing.getUser().getId()).isEqualTo(2L);
+        assertThat(existing.getPlatform()).isEqualTo(DevicePlatform.ANDROID);
+        verify(deviceTokenRepository, org.mockito.Mockito.never()).save(any());
+    }
+
+    @Test
+    @DisplayName("토큰 삭제를 요청하면 본인 소유 토큰만 삭제한다")
+    void removeDelegatesToRepository() {
+        deviceTokenService.remove(1L, "token-a");
+
+        verify(deviceTokenRepository).deleteByTokenAndUserId("token-a", 1L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/application/NotificationCreationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/NotificationCreationServiceTest.java
@@ -1,0 +1,95 @@
+package com.nexters.palang.domain.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCreationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationPushDispatcher pushDispatcher;
+
+    private NotificationCreationService notificationCreationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationCreationService = new NotificationCreationService(notificationRepository, userRepository, pushDispatcher);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("본인이 유발한 알림(actorId == receiverId)이면 생성/발송하지 않는다")
+    void doesNotCreateSelfNotification() {
+        notificationCreationService.create(
+                1L, 1L, NotificationType.OPINION_LIKED, "제목", "내용", 10L, null, null, null);
+
+        verify(notificationRepository, never()).save(any());
+        verify(pushDispatcher, never()).dispatch(anyLong(), any(), any(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("타인이 유발한 알림이면 저장하고 푸시를 발송한다")
+    void createsNotificationAndDispatchesPush() {
+        given(userRepository.getReferenceById(1L)).willReturn(user(1L));
+        given(notificationRepository.save(any(Notification.class))).willAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            ReflectionTestUtils.setField(notification, "id", 100L);
+            return notification;
+        });
+
+        notificationCreationService.create(
+                1L, 2L, NotificationType.OPINION_LIKED, "제목", "내용", 10L, null, null, null);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getTitle()).isEqualTo("제목");
+        assertThat(captor.getValue().getActorId()).isEqualTo(2L);
+        verify(pushDispatcher).dispatch(1L, NotificationType.OPINION_LIKED, "제목", "내용", 100L);
+    }
+
+    @Test
+    @DisplayName("actorId가 없는 알림(BOOK_NEW_OPINIONS)도 정상적으로 생성된다")
+    void createsNotificationWithoutActor() {
+        given(userRepository.getReferenceById(3L)).willReturn(user(3L));
+        given(notificationRepository.save(any(Notification.class))).willAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            ReflectionTestUtils.setField(notification, "id", 200L);
+            return notification;
+        });
+
+        notificationCreationService.create(
+                3L, null, NotificationType.BOOK_NEW_OPINIONS, "새 의견", "내용", null, 5L, null, 7);
+
+        verify(notificationRepository).save(any(Notification.class));
+        verify(pushDispatcher).dispatch(3L, NotificationType.BOOK_NEW_OPINIONS, "새 의견", "내용", 200L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/application/NotificationCreationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/NotificationCreationServiceTest.java
@@ -1,9 +1,11 @@
 package com.nexters.palang.domain.notification.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -91,5 +93,24 @@ class NotificationCreationServiceTest {
 
         verify(notificationRepository).save(any(Notification.class));
         verify(pushDispatcher).dispatch(3L, NotificationType.BOOK_NEW_OPINIONS, "새 의견", "내용", 200L);
+    }
+
+    @Test
+    @DisplayName("푸시 발송이 실패해도 예외를 전파하지 않는다 (방금 저장한 알림이 롤백되면 안 된다)")
+    void doesNotPropagateExceptionWhenPushDispatchFails() {
+        given(userRepository.getReferenceById(1L)).willReturn(user(1L));
+        given(notificationRepository.save(any(Notification.class))).willAnswer(invocation -> {
+            Notification notification = invocation.getArgument(0);
+            ReflectionTestUtils.setField(notification, "id", 100L);
+            return notification;
+        });
+        willThrow(new RuntimeException("FCM 초기화 실패"))
+                .given(pushDispatcher).dispatch(anyLong(), any(), any(), any(), anyLong());
+
+        assertThatCode(() -> notificationCreationService.create(
+                1L, 2L, NotificationType.OPINION_LIKED, "제목", "내용", 10L, null, null, null))
+                .doesNotThrowAnyException();
+
+        verify(notificationRepository).save(any(Notification.class));
     }
 }

--- a/src/test/java/com/nexters/palang/domain/notification/application/NotificationEventListenerTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/NotificationEventListenerTest.java
@@ -1,0 +1,88 @@
+package com.nexters.palang.domain.notification.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.comment.domain.event.CommentCreatedEvent;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.opinion.domain.event.OpinionCreatedEvent;
+import com.nexters.palang.domain.opinion.domain.event.OpinionLikedEvent;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @Mock
+    private NotificationCreationService notificationCreationService;
+
+    @Mock
+    private BookNewOpinionsNotifier bookNewOpinionsNotifier;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private NotificationEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new NotificationEventListener(notificationCreationService, bookNewOpinionsNotifier, userRepository);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Test
+    @DisplayName("좋아요 이벤트를 받으면 흔적 작성자에게 OPINION_LIKED 알림 생성을 요청한다")
+    void onOpinionLikedCreatesNotification() {
+        given(userRepository.findById(2L)).willReturn(Optional.of(user(2L)));
+
+        listener.onOpinionLiked(new OpinionLikedEvent(10L, 1L, 2L));
+
+        verify(notificationCreationService).create(
+                eq(1L), eq(2L), eq(NotificationType.OPINION_LIKED), any(), any(), eq(10L), eq(null), eq(null), eq(null));
+    }
+
+    @Test
+    @DisplayName("좋아요를 누른 사용자를 찾을 수 없으면 알림을 생성하지 않는다")
+    void onOpinionLikedSkipsWhenActorMissing() {
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        listener.onOpinionLiked(new OpinionLikedEvent(10L, 1L, 2L));
+
+        verify(notificationCreationService, never()).create(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("댓글 생성 이벤트를 받으면 흔적 작성자에게 OPINION_COMMENTED 알림 생성을 요청한다")
+    void onCommentCreatedCreatesNotification() {
+        given(userRepository.findById(2L)).willReturn(Optional.of(user(2L)));
+
+        listener.onCommentCreated(new CommentCreatedEvent(5L, 10L, 1L, 2L));
+
+        verify(notificationCreationService).create(
+                eq(1L), eq(2L), eq(NotificationType.OPINION_COMMENTED), any(), any(), eq(10L), eq(null), eq(5L), eq(null));
+    }
+
+    @Test
+    @DisplayName("의견 생성 이벤트를 받으면 BookNewOpinionsNotifier에 위임한다")
+    void onOpinionCreatedDelegatesToBookNewOpinionsNotifier() {
+        listener.onOpinionCreated(new OpinionCreatedEvent(20L, 3L, 2L));
+
+        verify(bookNewOpinionsNotifier).notifyIfThresholdReached(3L, 2L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/application/NotificationServiceTest.java
@@ -1,0 +1,104 @@
+package com.nexters.palang.domain.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.notification.common.error.NotificationException;
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.user.domain.User;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(notificationRepository);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Notification notification(Long id, User receiver) {
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .type(NotificationType.OPINION_LIKED)
+                .title("제목").body("내용")
+                .build();
+        ReflectionTestUtils.setField(notification, "id", id);
+        return notification;
+    }
+
+    @Test
+    @DisplayName("알림 목록을 조회하면 Repository 결과를 그대로 반환한다")
+    void getNotificationsReturnsPageFromRepository() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Notification> expected = new PageImpl<>(java.util.List.of(notification(1L, user(1L))), pageable, 1);
+        given(notificationRepository.findByReceiverIdOrderByCreatedAtDesc(1L, pageable)).willReturn(expected);
+
+        Page<Notification> results = notificationService.getNotifications(1L, pageable);
+
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("본인이 받은 알림을 읽음 처리하면 읽음 상태가 된다")
+    void markAsReadUpdatesNotification() {
+        Notification notification = notification(1L, user(10L));
+        given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+        notificationService.markAsRead(10L, 1L);
+
+        assertThat(notification.isRead()).isTrue();
+    }
+
+    @Test
+    @DisplayName("본인이 받은 알림이 아니면 읽음 처리 시 예외가 발생한다")
+    void markAsReadThrowsExceptionWhenNotOwner() {
+        Notification notification = notification(1L, user(10L));
+        given(notificationRepository.findById(1L)).willReturn(Optional.of(notification));
+
+        assertThatThrownBy(() -> notificationService.markAsRead(999L, 1L))
+                .isInstanceOf(NotificationException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알림을 읽음 처리하면 예외가 발생한다")
+    void markAsReadThrowsExceptionWhenNotFound() {
+        given(notificationRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.markAsRead(10L, 999L))
+                .isInstanceOf(NotificationException.class);
+    }
+
+    @Test
+    @DisplayName("전체 읽음 처리를 요청하면 Repository의 bulk update를 호출한다")
+    void markAllAsReadDelegatesToRepository() {
+        notificationService.markAllAsRead(10L);
+
+        verify(notificationRepository).markAllAsRead(10L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.nexters.palang.domain.notification.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class NotificationRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private User receiver;
+
+    @BeforeEach
+    void setUp() {
+        receiver = entityManager.persistAndFlush(User.builder()
+                .nickname("수신자")
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId("receiver")
+                .termsAgreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Notification save(NotificationType type, Long bookId, Integer snapshot) {
+        Notification notification = Notification.builder()
+                .receiver(receiver)
+                .type(type)
+                .title("제목").body("내용")
+                .bookId(bookId)
+                .opinionCountSnapshot(snapshot)
+                .build();
+        return entityManager.persistAndFlush(notification);
+    }
+
+    @Test
+    @DisplayName("알림 목록을 조회하면 최신순으로 반환한다")
+    void findByReceiverIdOrderByCreatedAtDesc() {
+        Notification older = save(NotificationType.OPINION_LIKED, null, null);
+        Notification newer = save(NotificationType.OPINION_COMMENTED, null, null);
+
+        Page<Notification> results = notificationRepository
+                .findByReceiverIdOrderByCreatedAtDesc(receiver.getId(), PageRequest.of(0, 20));
+
+        assertThat(results.getContent()).extracting(Notification::getId)
+                .containsExactly(newer.getId(), older.getId());
+    }
+
+    @Test
+    @DisplayName("같은 책에 대해 가장 최근 BOOK_NEW_OPINIONS 알림의 snapshot을 조회한다")
+    void findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc() {
+        save(NotificationType.BOOK_NEW_OPINIONS, 1L, 5);
+        Notification latest = save(NotificationType.BOOK_NEW_OPINIONS, 1L, 10);
+        save(NotificationType.BOOK_NEW_OPINIONS, 2L, 99);
+
+        Optional<Notification> found = notificationRepository
+                .findFirstByReceiverIdAndTypeAndBookIdOrderByCreatedAtDesc(
+                        receiver.getId(), NotificationType.BOOK_NEW_OPINIONS, 1L);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(latest.getId());
+        assertThat(found.get().getOpinionCountSnapshot()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("전체 읽음 처리를 하면 안 읽은 알림만 읽음으로 바뀐다")
+    void markAllAsRead() {
+        Notification unread1 = save(NotificationType.OPINION_LIKED, null, null);
+        Notification unread2 = save(NotificationType.OPINION_COMMENTED, null, null);
+
+        int updated = notificationRepository.markAllAsRead(receiver.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(updated).isEqualTo(2);
+        assertThat(notificationRepository.findById(unread1.getId()).orElseThrow().isRead()).isTrue();
+        assertThat(notificationRepository.findById(unread2.getId()).orElseThrow().isRead()).isTrue();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/infrastructure/fcm/NoOpFcmPushSenderTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/infrastructure/fcm/NoOpFcmPushSenderTest.java
@@ -1,0 +1,21 @@
+package com.nexters.palang.domain.notification.infrastructure.fcm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoOpFcmPushSenderTest {
+
+    @Test
+    @DisplayName("발송을 시도해도 예외 없이 빈 무효 토큰 목록을 반환한다")
+    void sendMulticastReturnsEmptyList() {
+        NoOpFcmPushSender sender = new NoOpFcmPushSender();
+
+        List<String> invalidTokens = sender.sendMulticast(List.of("token-a"), "제목", "내용", Map.of());
+
+        assertThat(invalidTokens).isEmpty();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/presentation/DeviceTokenControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/presentation/DeviceTokenControllerTest.java
@@ -1,0 +1,91 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.notification.application.DeviceTokenService;
+import com.nexters.palang.domain.notification.domain.DevicePlatform;
+import com.nexters.palang.domain.notification.presentation.dto.RegisterDeviceTokenRequest;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DeviceTokenController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DeviceTokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private DeviceTokenService deviceTokenService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    @Test
+    @DisplayName("디바이스 토큰을 등록하면 서비스에 위임한다")
+    void registerDeviceToken() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(put("/api/notifications/device-tokens")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterDeviceTokenRequest("token-a", DevicePlatform.ANDROID))))
+                .andExpect(status().isOk());
+
+        verify(deviceTokenService).registerOrRefresh(1L, "token-a", DevicePlatform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 등록을 요청하면 400 에러가 발생한다")
+    void registerDeviceTokenFailsWhenTokenBlank() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(put("/api/notifications/device-tokens")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterDeviceTokenRequest(" ", DevicePlatform.ANDROID))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("COMMON_400_1"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 등록을 요청하면 401 에러가 발생한다")
+    void registerDeviceTokenFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(put("/api/notifications/device-tokens")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterDeviceTokenRequest("token-a", DevicePlatform.ANDROID))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("디바이스 토큰을 삭제하면 서비스에 위임한다")
+    void removeDeviceToken() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(delete("/api/notifications/device-tokens").param("token", "token-a"))
+                .andExpect(status().isOk());
+
+        verify(deviceTokenService).remove(eq(1L), eq("token-a"));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/notification/presentation/NotificationControllerTest.java
@@ -1,0 +1,121 @@
+package com.nexters.palang.domain.notification.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.nexters.palang.domain.notification.application.NotificationService;
+import com.nexters.palang.domain.notification.common.error.NotificationErrorCode;
+import com.nexters.palang.domain.notification.common.error.NotificationException;
+import com.nexters.palang.domain.notification.domain.Notification;
+import com.nexters.palang.domain.notification.domain.NotificationType;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import com.nexters.palang.global.security.LoginRequiredException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private CurrentUserProvider currentUserProvider;
+
+    private static final Pageable DEFAULT_PAGEABLE = PageRequest.of(0, 20);
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Notification notification(Long id) {
+        Notification notification = Notification.builder()
+                .receiver(user(1L))
+                .type(NotificationType.OPINION_LIKED)
+                .title("새로운 좋아요").body("책읽는고양이님이 회원님의 흔적을 좋아합니다.")
+                .opinionId(3L)
+                .build();
+        ReflectionTestUtils.setField(notification, "id", id);
+        return notification;
+    }
+
+    @Test
+    @DisplayName("알림 목록을 조회하면 알림을 반환한다")
+    void getNotifications() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        given(notificationService.getNotifications(eq(1L), any())).willReturn(
+                new PageImpl<>(List.of(notification(1L)), DEFAULT_PAGEABLE, 1));
+
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.notifications[0].notificationId").value(1))
+                .andExpect(jsonPath("$.data.notifications[0].type").value("OPINION_LIKED"));
+    }
+
+    @Test
+    @DisplayName("인증 없이 알림 목록을 조회하면 401 에러가 발생한다")
+    void getNotificationsFailsWhenUnauthenticated() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willThrow(new LoginRequiredException());
+
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value("AUTH_401_1"));
+    }
+
+    @Test
+    @DisplayName("알림을 단건 읽음 처리하면 서비스에 위임한다")
+    void readNotification() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/notifications/1/read"))
+                .andExpect(status().isOk());
+
+        verify(notificationService).markAsRead(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("본인이 받은 알림이 아니면 읽음 처리 시 404 에러가 발생한다")
+    void readNotificationFailsWhenNotOwner() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        org.mockito.Mockito.doThrow(new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND))
+                .when(notificationService).markAsRead(1L, 1L);
+
+        mockMvc.perform(patch("/api/notifications/1/read"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value("NOTIFICATION_404_1"));
+    }
+
+    @Test
+    @DisplayName("전체 읽음 처리를 요청하면 서비스에 위임한다")
+    void readAllNotifications() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+
+        mockMvc.perform(patch("/api/notifications/read-all"))
+                .andExpect(status().isOk());
+
+        verify(notificationService).markAllAsRead(1L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
@@ -1,0 +1,103 @@
+package com.nexters.palang.domain.opinion.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.domain.event.OpinionLikedEvent;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OpinionLikeServiceTest {
+
+    @Mock
+    private OpinionRepository opinionRepository;
+
+    @Mock
+    private OpinionLikeRepository opinionLikeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private OpinionLikeService opinionLikeService;
+
+    private void init() {
+        opinionLikeService = new OpinionLikeService(
+                opinionRepository, opinionLikeRepository, userRepository, eventPublisher);
+    }
+
+    private User user(Long id) {
+        User user = User.builder().nickname("닉네임" + id).build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Opinion opinion(Long id, User owner) {
+        Opinion opinion = Opinion.builder().user(owner).content("흔적 내용").build();
+        ReflectionTestUtils.setField(opinion, "id", id);
+        return opinion;
+    }
+
+    @Test
+    @DisplayName("좋아요를 누르면 좋아요 카운트가 증가하고 알림 이벤트가 발행된다")
+    void likeIncreasesCountAndPublishesEvent() {
+        init();
+        User owner = user(1L);
+        Opinion opinion = opinion(10L, owner);
+        given(opinionRepository.findById(10L)).willReturn(Optional.of(opinion));
+        given(opinionLikeRepository.existsByUserIdAndOpinionId(2L, 10L)).willReturn(false);
+        given(userRepository.getReferenceById(2L)).willReturn(user(2L));
+
+        OpinionLikeResult result = opinionLikeService.toggleLike(2L, 10L);
+
+        assertThat(result.liked()).isTrue();
+        assertThat(opinion.getLikeCount()).isEqualTo(1);
+        verify(eventPublisher).publishEvent(new OpinionLikedEvent(10L, 1L, 2L));
+    }
+
+    @Test
+    @DisplayName("이미 좋아요를 누른 상태에서 다시 요청하면 좋아요가 취소되고 알림 이벤트는 발행되지 않는다")
+    void unlikeDecreasesCountAndDoesNotPublishEvent() {
+        init();
+        User owner = user(1L);
+        Opinion opinion = opinion(10L, owner);
+        opinion.increaseLikeCount();
+        given(opinionRepository.findById(10L)).willReturn(Optional.of(opinion));
+        given(opinionLikeRepository.existsByUserIdAndOpinionId(2L, 10L)).willReturn(true);
+
+        OpinionLikeResult result = opinionLikeService.toggleLike(2L, 10L);
+
+        assertThat(result.liked()).isFalse();
+        assertThat(opinion.getLikeCount()).isZero();
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 흔적에 좋아요를 시도하면 예외가 발생한다")
+    void toggleLikeThrowsExceptionWhenOpinionNotFound() {
+        init();
+        given(opinionRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> opinionLikeService.toggleLike(2L, 999L))
+                .isInstanceOf(OpinionException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -15,6 +15,7 @@ import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.common.error.OpinionException;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.opinion.domain.OpinionSortType;
+import com.nexters.palang.domain.opinion.domain.event.OpinionCreatedEvent;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionQueryRepository;
 import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
 import com.nexters.palang.domain.opinion.presentation.dto.CreateOpinionRequest;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -58,12 +60,16 @@ class OpinionServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private OpinionService opinionService;
 
     @BeforeEach
     void setUp() {
         opinionService = new OpinionService(
-                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository);
+                opinionRepository, opinionQueryRepository, passageRepository, bookRepository, userRepository,
+                eventPublisher);
     }
 
     private User user(Long id) {
@@ -111,6 +117,7 @@ class OpinionServiceTest {
 
         assertThat(opinion.getPassage().getBook().getId()).isEqualTo(10L);
         assertThat(opinion.getDecorations()).hasSize(1);
+        verify(eventPublisher).publishEvent(any(OpinionCreatedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class OpinionRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    private Book book;
+    private Passage passage;
+
+    private User user(String nickname) {
+        return entityManager.persistAndFlush(User.builder()
+                .nickname(nickname)
+                .snsProvider(SnsProvider.KAKAO)
+                .snsId(nickname)
+                .termsAgreedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @BeforeEach
+    void setUp() {
+        User creator = user("작성자");
+        book = entityManager.persistAndFlush(Book.builder()
+                .title("책").author("작가").publisher("출판사").pageCount(300).build());
+        passage = entityManager.persistAndFlush(Passage.builder()
+                .book(book).creator(creator).pageNumber(1).quotedText("발췌 문장").isSpoiler(false)
+                .normalizedHash("hash").build());
+    }
+
+    @Test
+    @DisplayName("책에 살아있는 의견 수를 센다 (삭제된 의견은 제외)")
+    void countByPassageBookIdAndDeletedAtIsNull() {
+        User writer = user("작성자2");
+        Opinion alive = entityManager.persistAndFlush(
+                Opinion.builder().passage(passage).user(writer).content("살아있음").build());
+        Opinion deleted = entityManager.persistAndFlush(
+                Opinion.builder().passage(passage).user(writer).content("삭제됨").build());
+        deleted.delete();
+        entityManager.persistAndFlush(deleted);
+
+        long count = opinionRepository.countByPassage_Book_IdAndDeletedAtIsNull(book.getId());
+
+        assertThat(count).isEqualTo(1);
+        assertThat(alive.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("책에 의견을 남긴 사용자 id 목록을 중복 없이 조회한다")
+    void findDistinctUserIdsByBookId() {
+        User writerA = user("작성자A");
+        User writerB = user("작성자B");
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writerA).content("의견1").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writerA).content("의견2").build());
+        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writerB).content("의견3").build());
+
+        List<Long> userIds = opinionRepository.findDistinctUserIdsByBookId(book.getId());
+
+        assertThat(userIds).containsExactlyInAnyOrder(writerA.getId(), writerB.getId());
+    }
+}

--- a/src/test/java/com/nexters/palang/global/config/FirebaseConfigTest.java
+++ b/src/test/java/com/nexters/palang/global/config/FirebaseConfigTest.java
@@ -1,0 +1,24 @@
+package com.nexters.palang.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.notification.infrastructure.fcm.FcmPushSender;
+import com.nexters.palang.domain.notification.infrastructure.fcm.NoOpFcmPushSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class FirebaseConfigTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withUserConfiguration(FirebaseConfig.class);
+
+    @Test
+    @DisplayName("firebase.credentials-base64가 비어 있으면 NoOpFcmPushSender로 폴백한다")
+    void fallsBackToNoOpWhenCredentialsMissing() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(FcmPushSender.class);
+            assertThat(context.getBean(FcmPushSender.class)).isInstanceOf(NoOpFcmPushSender.class);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #131

## 🚀 개요
좋아요/댓글/책 신규 의견(N개 이상)에 대한 알림을 인앱에 저장하고 FCM으로 푸시하는 기능을 추가합니다. 이벤트 기반 알림 인프라(ApplicationEventPublisher + @TransactionalEventListener)를 처음 도입하고, FCM 서비스 계정 키가 아직 없는 상태에서도 로컬/CI 빌드·구동이 깨지지 않도록 설계했습니다.

## 📄 작업 내용
- `notification` 도메인 신규 생성: `Notification`/`DeviceToken` 엔티티, `NotificationType`(OPINION_LIKED / OPINION_COMMENTED / BOOK_NEW_OPINIONS) / `DevicePlatform` enum
- `OpinionLikeService`(좋아요), `CommentService`(댓글), `OpinionService`(의견 작성)에서 `ApplicationEventPublisher`로 도메인 이벤트 발행, `notification.application.NotificationEventListener`가 `@Async @TransactionalEventListener(AFTER_COMMIT)`로 수신해 알림 생성 (본인 행위에 대한 자기알림은 제외)
- "책에 새 의견 N개 이상" 알림(`BookNewOpinionsNotifier`): 별도 캐시 없이 `Notification` 테이블의 `opinionCountSnapshot`을 상태값으로 재사용해 집계/중복방지, N은 `notification.book-new-opinions-threshold`(기본 5) 프로퍼티
- FCM 연동: `firebase-admin` 의존성 추가, `FirebaseConfig`가 `firebase.credentials-base64`가 비어있으면 `NoOpFcmPushSender`로 자동 폴백 (키 없이도 정상 부팅)
- API
  | Method | Path | 설명 |
  |---|---|---|
  | GET | /api/notifications | 알림 목록 조회 (page/size) |
  | PATCH | /api/notifications/{id}/read | 알림 단건 읽음 처리 |
  | PATCH | /api/notifications/read-all | 알림 전체 읽음 처리 |
  | PUT | /api/notifications/device-tokens | FCM 디바이스 토큰 등록/갱신 |
  | DELETE | /api/notifications/device-tokens | FCM 디바이스 토큰 삭제 |
- Swagger 문서화(`NotificationApi`, `DeviceTokenApi`) 및 단위/슬라이스/`@DataJpaTest` 테스트 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test`: 495개 중 492개 통과. 실패 3개는 모두 이 PR과 무관한 기존 `AladinBookApiClientCacheTest`(로컬에 Redis 서버가 없어 발생하는 환경 의존 실패)
- FCM 키 미설정 상태로 `./gradlew bootRun` 정상 기동 확인, `/v3/api-docs`에서 신규 알림 API 노출 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- "책 신규 의견 N개 이상" 중복방지를 Redis가 아니라 `Notification` 테이블의 스냅샷 비교로 구현했습니다. 트랜잭션 일관성은 얻지만 후보 수신자 수만큼 쿼리가 도는 구조라, 책 하나에 의견을 남긴 사용자가 아주 많아지면 성능을 다시 봐야 할 수 있습니다.
- 댓글 알림은 답글이어도 원댓글 작성자가 아니라 흔적(Opinion) 작성자에게만 보냅니다. 스레드 알림까지 필요한지 기획 확인 부탁드립니다.
- FCM 서비스 계정 키가 아직 없어 `FirebaseFcmPushSender` 실제 발송 경로는 실기기로 검증하지 못했습니다. 키 발급 후 별도 검증이 필요합니다.

---
## 🧭 이어서 작업하는 사람을 위한 전체 맥락 (다른 컴퓨터에서 이어받을 때 참고)

### 설계 배경 / 결정 사항
- **이벤트 인프라**: `ApplicationEventPublisher` + `@TransactionalEventListener(phase = AFTER_COMMIT)`. 이벤트는 발생 도메인(`opinion`, `comment`)의 `domain.event` 패키지에 최소 id만 담는 record로 정의(`OpinionLikedEvent`, `OpinionCreatedEvent`, `CommentCreatedEvent`). 엔티티를 직접 이벤트에 담지 않은 이유: AFTER_COMMIT 시점엔 영속성 컨텍스트가 닫혀 있어 지연 로딩이 위험하기 때문. 리스너는 `notification.application.NotificationEventListener`.
- **비동기 처리**: 좋아요/댓글 API 응답 지연을 막기 위해 리스너 메서드에 `@Async` 적용. `global/config/AsyncConfig`에서 `@EnableAsync`만 켰고 커스텀 스레드풀은 두지 않음(기본 `SimpleAsyncTaskExecutor`) — 현재 트래픽 규모에서 과설계라 판단.
- **자기 알림 제외**: `NotificationCreationService.create()` 진입점에서 `actorId.equals(receiverId)`면 저장/발송 자체를 스킵. 좋아요/댓글은 리스너에서 이 서비스를 거치므로 자동으로 걸러짐.
- **"책에 새 의견 N개 이상" 집계 로직** (`BookNewOpinionsNotifier`): Redis 캐시 대신 `Notification` 테이블 자체를 상태 저장소로 재사용. `BOOK_NEW_OPINIONS` 타입 알림을 만들 때마다 그 시점의 책 전체(살아있는) 의견 수를 `opinionCountSnapshot` 컬럼에 함께 저장해두고, 새 의견이 생길 때마다 "그 책에 살아있는 의견을 남긴 적 있는 사용자(방금 의견을 쓴 사람 본인 제외)" 각각에 대해 `현재 의견 수 - 그 사용자에게 보낸 마지막 BOOK_NEW_OPINIONS 알림의 snapshot >= N`이면 새 알림을 만드는 방식. DB 트랜잭션 안에서 원자적으로 처리되어 Redis TTL/레이스 컨디션 걱정이 없음. N은 `notification.book-new-opinions-threshold`(기본 5, `NOTIFICATION_BOOK_NEW_OPINIONS_THRESHOLD` 환경변수로 오버라이드 가능).
- **알림 엔티티는 비정규화**: `Notification`의 title/body는 생성 시점에 스냅샷 문자열로 저장(조인 없이 목록 렌더링 가능하게, 다른 프로젝션들의 관례와 동일). 이후 사용자 닉네임이 바뀌어도 과거 알림 문구는 그대로 유지됨(의도된 동작).
- **읽음 처리 API 범위**: 이슈 문구가 "읽음 처리"로 모호했지만 프런트 배지 UX상 단건/전체 둘 다 필요하다고 판단해 `PATCH /{id}/read`와 `PATCH /read-all` 둘 다 구현.
- **FCM 키 부재 대응**: 처음엔 `@ConditionalOnProperty`/`@ConditionalOnMissingBean` 조합으로 설계했으나, `firebase.credentials-base64: ${FIREBASE_CREDENTIALS_BASE64:}`처럼 프로퍼티 키 자체는 항상 존재하고 값만 빈 문자열이 되는 구조라 `@ConditionalOnProperty`가 "설정 안 됨"을 구분하지 못해(빈 문자열도 "존재함"으로 인식) 컨텍스트 로딩이 깨지는 문제가 있었음. 그래서 `FirebaseConfig`를 단일 `@Bean` 팩토리 메서드(`fcmPushSender`) 안에서 빈 문자열 여부를 직접 분기하는 방식으로 단순화함. 값이 없으면 `NoOpFcmPushSender`(로그만 남김), 있으면 base64 디코딩 → `GoogleCredentials` → `FirebaseApp` 초기화 → `FirebaseFcmPushSender` 반환.

### 트리거 지점 (알림이 어디서 발생하는지)
- `OpinionLikeService.like()`: 좋아요를 **누를 때만** `OpinionLikedEvent` 발행 (좋아요 취소는 알림 없음).
- `CommentService.createComment()`: 원댓글/답글 관계없이 **흔적(Opinion) 작성자**에게 `CommentCreatedEvent` 발행. 답글이어도 원댓글 작성자가 아니라 흔적 작성자로 통일(스레드 복잡도를 늘리지 않으려는 단순화 — PR 리뷰 포인트 참고).
- `OpinionService.createOpinion()`: 흔적 생성 후 `OpinionCreatedEvent` 발행 → `BookNewOpinionsNotifier.notifyIfThresholdReached()`로 위임.

### 패키지 구조
```
domain/notification/
  domain/            Notification, NotificationType, DeviceToken, DevicePlatform
  infrastructure/    NotificationRepository, DeviceTokenRepository
    fcm/             FcmPushSender(interface), FirebaseFcmPushSender, NoOpFcmPushSender
  application/       NotificationService(목록/읽음), NotificationCreationService(생성 공통 경로: 자기알림 제외→저장→푸시),
                     NotificationEventListener(3개 이벤트 수신), BookNewOpinionsNotifier(집계/중복방지),
                     NotificationPushDispatcher(DeviceToken 조회→FcmPushSender 호출→무효 토큰 정리), DeviceTokenService
  common/error/      NotificationErrorCode, NotificationException
  presentation/      NotificationController/Api, DeviceTokenController/Api, dto/*

global/config/
  FirebaseConfig.java   FCM 키 유무에 따라 FcmPushSender 빈 분기
  AsyncConfig.java      @EnableAsync

opinion/domain/event/   OpinionLikedEvent, OpinionCreatedEvent
comment/domain/event/   CommentCreatedEvent
```

### 아직 안 한 것 / 다음에 할 일
1. **FCM 서비스 계정 키 발급 및 반영** — 현재는 `FIREBASE_CREDENTIALS_BASE64` 미설정 상태(NoOp 경로)로만 검증했음. 키 발급되면:
   - dev/prod 서버 환경변수(`FIREBASE_CREDENTIALS_BASE64`)에 서비스 계정 JSON을 base64 인코딩해서 주입
   - 실기기(또는 FCM 테스트 콘솔)로 실제 푸시 도착까지 end-to-end 확인 — `FirebaseFcmPushSender`는 아직 실제 발송 경로 미검증
2. **PR 리뷰 대응 필요 항목**:
   - "책 신규 의견 N개" 알림을 Redis가 아니라 DB 스냅샷 비교로 구현한 것 — 책 하나에 의견을 남긴 사용자가 아주 많아지면 후보 수신자 수만큼 쿼리가 도는 구조라 성능 재검토 여지 있음(`BookNewOpinionsNotifier.notifyIfThresholdReached`)
   - 댓글 알림을 원댓글 작성자가 아니라 흔적 작성자에게만 보내는 단순화가 기획 의도와 맞는지 확인 필요 (맞다면 그대로, 아니면 `CommentCreatedEvent`에 parentCommentAuthorId 추가해서 리스너에서 분기해야 함)
3. **로컬 Redis 미기동으로 실패하는 기존 테스트**: `AladinBookApiClientCacheTest`가 로컬에 Redis 서버가 없으면 3개 실패함(이번 PR과 무관, 기존부터 있던 이슈). 다음에 이 도메인 건드릴 때 `docker run redis` 등으로 로컬 Redis 띄우고 확인할 것.
4. **프런트 연동**: 새 API 4종(`GET /api/notifications`, `PATCH .../read`, `PATCH .../read-all`, `PUT|DELETE .../device-tokens`) 스펙을 프런트 담당자에게 공유하고, 앱에서 FCM 토큰 등록 타이밍(로그인 직후/앱 실행 시 등)을 맞춰야 함.
5. (선택) CI가 있다면 이 PR의 CI 통과 여부 확인 필요 — 로컬에서는 `./gradlew test` 통과 확인만 했음.

### 로컬 재현/검증 방법
```bash
export JAVA_HOME="/c/Program Files/Eclipse Adoptium/jdk-21.0.11.10-hotspot"
export PATH=$JAVA_HOME/bin:$PATH
./gradlew test                 # 495개 중 492 통과 (Redis 미기동 3개 제외)
./gradlew bootRun              # FCM 키 없이도 정상 기동, http://localhost:8080/swagger-ui.html 에서 Notification/DeviceToken 태그 확인
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 알림 목록 조회, 개별 알림 읽음 처리 및 전체 읽음 처리를 지원합니다.
  * 좋아요, 댓글, 도서의 새 의견 발생 시 알림을 제공합니다.
  * 알림 발생 기준을 충족하면 관련 사용자에게 자동으로 안내합니다.
  * 디바이스 토큰 등록·갱신·삭제 및 모바일 푸시 알림을 지원합니다.
  * 푸시 설정이 없는 환경에서도 서비스가 정상적으로 실행됩니다.
* **문서화**
  * 알림 및 디바이스 토큰 API의 요청·응답 설명과 입력 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->