### PR TITLE
Chore/#137 Group 관련 API Swagger 명세에 에러 응답 구체화

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java
@@ -29,11 +29,22 @@ public interface GroupApi {
             @ApiResponse(responseCode = "200", description = "생성 성공"),
             @ApiResponse(responseCode = "400", description = "필수값 누락, 인원이 2~10명 범위를 벗어남(COMMON_400_1) "
                     + "또는 시작일이 종료일보다 늦음 (GROUP_400_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "COMMON_400_1: 필수값 누락/인원 범위 초과",
+                                    value = "{\"type\":\"/api/groups\",\"title\":\"COMMON_400_1\","
+                                            + "\"status\":400,\"detail\":\"인원은 최소 2명 이상이어야 합니다.\"}"),
+                            @ExampleObject(name = "GROUP_400_1: 시작일이 종료일보다 늦음",
+                                    value = "{\"type\":\"/api/groups\",\"title\":\"GROUP_400_1\","
+                                            + "\"status\":400,\"detail\":\"시작일은 종료일보다 늦을 수 없습니다.\"}")
+                    })),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 도서를 찾을 수 없음 (BOOK_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups\",\"title\":\"BOOK_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 도서를 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupDetailResponse>> createGroup(@Valid CreateGroupRequest request);
 
@@ -42,7 +53,9 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupListResponse>> getMyGroups(
             @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
@@ -54,9 +67,13 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임원이 아님 (GROUP_403_2)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_403_2\","
+                                    + "\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
                             value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_404_1\","
@@ -72,15 +89,30 @@ public interface GroupApi {
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "필수값 누락, 인원이 2~10명 범위를 벗어남(COMMON_400_1) "
                     + "또는 시작일이 종료일보다 늦음 (GROUP_400_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "COMMON_400_1: 필수값 누락/인원 범위 초과",
+                                    value = "{\"type\":\"/api/groups/1\",\"title\":\"COMMON_400_1\","
+                                            + "\"status\":400,\"detail\":\"인원은 최대 10명까지 가능합니다.\"}"),
+                            @ExampleObject(name = "GROUP_400_1: 시작일이 종료일보다 늦음",
+                                    value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_400_1\","
+                                            + "\"status\":400,\"detail\":\"시작일은 종료일보다 늦을 수 없습니다.\"}")
+                    })),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_403_1\","
+                                    + "\"status\":403,\"detail\":\"모임장만 가능한 작업입니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}"))),
             @ApiResponse(responseCode = "409", description = "인원을 현재 참여 인원보다 적게 설정 (GROUP_409_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_409_1\","
+                                    + "\"status\":409,\"detail\":\"인원을 현재 참여 인원보다 적게 설정할 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupDetailResponse>> updateGroup(
             @Parameter(description = "모임 ID", required = true) Long groupId,
@@ -92,11 +124,17 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_403_1\","
+                                    + "\"status\":403,\"detail\":\"모임장만 가능한 작업입니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<Void>> deleteGroup(
             @Parameter(description = "모임 ID", required = true) Long groupId
@@ -107,11 +145,17 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/members\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임원이 아님 (GROUP_403_2)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/members\",\"title\":\"GROUP_403_2\","
+                                    + "\"status\":403,\"detail\":\"모임원만 조회할 수 있습니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/members\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupMemberListResponse>> getGroupMembers(
             @Parameter(description = "모임 ID", required = true) Long groupId,
@@ -124,11 +168,17 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link\",\"title\":\"GROUP_403_1\","
+                                    + "\"status\":403,\"detail\":\"모임장만 가능한 작업입니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupInviteLinkResponse>> getInviteLink(
             @Parameter(description = "모임 ID", required = true) Long groupId
@@ -139,11 +189,17 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "재발급 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link/regenerate\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "403", description = "모임장이 아님 (GROUP_403_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link/regenerate\",\"title\":\"GROUP_403_1\","
+                                    + "\"status\":403,\"detail\":\"모임장만 가능한 작업입니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/1/invite-link/regenerate\",\"title\":\"GROUP_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 모임을 찾을 수 없습니다.\"}")))
     })
     ResponseEntity<DataResponse<GroupInviteLinkResponse>> regenerateInviteLink(
             @Parameter(description = "모임 ID", required = true) Long groupId
@@ -167,11 +223,22 @@ public interface GroupApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "가입 성공"),
             @ApiResponse(responseCode = "401", description = "인증 토큰 누락 (AUTH_401_1)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/invitations/abc123/join\",\"title\":\"AUTH_401_1\","
+                                    + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}"))),
             @ApiResponse(responseCode = "404", description = "유효하지 않은 초대 코드 (GROUP_404_2)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/groups/invitations/abc123/join\",\"title\":\"GROUP_404_2\","
+                                    + "\"status\":404,\"detail\":\"유효하지 않은 초대 코드입니다.\"}"))),
             @ApiResponse(responseCode = "409", description = "이미 가입된 모임 (GROUP_409_2) 또는 정원이 가득 참 (GROUP_409_3)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = {
+                            @ExampleObject(name = "GROUP_409_2: 이미 가입된 모임",
+                                    value = "{\"type\":\"/api/groups/invitations/abc123/join\",\"title\":\"GROUP_409_2\","
+                                            + "\"status\":409,\"detail\":\"이미 가입된 모임입니다.\"}"),
+                            @ExampleObject(name = "GROUP_409_3: 정원 초과",
+                                    value = "{\"type\":\"/api/groups/invitations/abc123/join\",\"title\":\"GROUP_409_3\","
+                                            + "\"status\":409,\"detail\":\"모임 정원이 가득 찼습니다.\"}")
+                    }))
     })
     ResponseEntity<DataResponse<GroupDetailResponse>> joinGroup(
             @Parameter(description = "초대 코드", required = true) String inviteCode


### PR DESCRIPTION
## 📌 관련 이슈
- Close #137

## 🚀 개요
Group 도메인 API(`GroupApi.java`)의 Swagger 명세에서 누락되어 있던 에러 응답 예시(`@ExampleObject`)를 모든 400/401/403/404/409 케이스에 추가했습니다.

## 📄 작업 내용
- [GroupApi.java](src/main/java/com/nexters/palang/domain/group/presentation/GroupApi.java)의 전체 10개 오퍼레이션에 걸쳐 예시가 없던 `ApiResponse`에 실제 에러 응답 JSON(`type`/`title`/`status`/`detail`) 추가
- 하나의 상태 코드에 에러 코드가 여러 개 매핑되는 경우, `@ExampleObject(name = "코드: 설명", ...)`로 케이스별로 분리
  - `createGroup` / `updateGroup`의 400: `COMMON_400_1`(필수값 누락·인원 범위 초과) / `GROUP_400_1`(기간 역전)
  - `joinGroup`의 409: `GROUP_409_2`(이미 가입) / `GROUP_409_3`(정원 초과)
- `type` 필드는 각 엔드포인트의 실제 매핑 경로(`GroupController`)와 일치하도록 작성 (예: `/api/groups/{groupId}` → `/api/groups/1`)
- 기존에 예시가 있던 케이스(`getGroupDetail`의 404, `previewInvitation`의 404)는 그대로 유지, 나머지 케이스에 동일 컨벤션으로 신규 추가

| Operation | 추가된 예시 |
|---|---|
| `createGroup` | 400(2종), 401, 404 |
| `getMyGroups` | 401 |
| `getGroupDetail` | 401, 403 |
| `updateGroup` | 400(2종), 401, 403, 404, 409 |
| `deleteGroup` | 401, 403, 404 |
| `getGroupMembers` | 401, 403, 404 |
| `getInviteLink` | 401, 403, 404 |
| `regenerateInviteLink` | 401, 403, 404 |
| `joinGroup` | 401, 404, 409(2종) |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test --tests "com.nexters.palang.domain.group.presentation.GroupControllerTest"` 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요? *(Swagger 어노테이션 전용 변경으로 해당 없음)*
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [x] API 동작 확인 *(컴파일 및 어노테이션 값 확인, `/v3/api-docs` 실제 기동 검증은 미실시)*

---
## 🔍 리뷰 포인트 (Review Points)
반영 후 프론트팀과 논의하여 개선할 점 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 그룹 관련 API의 오류 응답 예시를 Swagger/OpenAPI 문서에 추가했습니다.
  * 오류 코드별 `type`, `title`, `status`, `detail` 형식의 실제 JSON 응답 예시를 확인할 수 있습니다.
  * 그룹 생성, 조회, 수정, 삭제, 멤버 관리 및 초대 링크 관련 엔드포인트의 오류 문서가 더욱 구체화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->