### PR TITLE
Feat/#140 마이페이지 후속 API 요청 4건 반영

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/domain/ReadingStatus.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/ReadingStatus.java
@@ -2,6 +2,5 @@ package com.nexters.palang.domain.book.domain;
 
 public enum ReadingStatus {
     READING,
-    PLANNED,
     FINISHED
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepository.java
@@ -7,16 +7,24 @@ import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.QBook;
+import com.nexters.palang.domain.book.domain.QUserBookStatus;
 import com.nexters.palang.domain.opinion.domain.QOpinion;
 import com.nexters.palang.domain.passage.domain.QPassage;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -142,12 +150,64 @@ public class BookQueryRepository {
         return countBooksWithPassages();
     }
 
-    // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남긴 도서만 대상으로 한다. 대목 수는 홈 캐러셀과 동일하게
-    // 도서 전체 기준으로 보여주지만, 흔적 수는 opinionCountScope에 따라 도서 전체(ALL, 홈 노출용) 또는
-    // 로그인 사용자 본인이 남긴 것(MINE, 마이페이지 노출용)만 집계한다. 정렬 기준은 스코프와 무관하게 사용자가
-    // 해당 도서에 남긴 가장 최근 흔적 시각이다(최신순).
+    // 내 서재는 로그인한 사용자가 흔적(Opinion)을 남겼거나, 읽기 상태(UserBookStatus)를 설정한 도서를 모두
+    // 대상으로 한다(PM 확인: 상태만 설정하고 흔적은 없는 책도 노출). 대목 수는 홈 캐러셀과 동일하게 도서 전체
+    // 기준으로 보여주지만, 흔적 수는 opinionCountScope에 따라 도서 전체(ALL, 홈 노출용) 또는 로그인 사용자
+    // 본인이 남긴 것(MINE, 마이페이지 노출용)만 집계한다. 정렬 기준은 "이 도서에 대한 내 최근 활동 시각"이며,
+    // 흔적을 남긴 시각(opinion.createdAt)과 읽기 상태를 설정/갱신한 시각(userBookStatus.updatedAt) 중 더
+    // 나중 것을 쓴다. 두 활동의 시각 컬럼이 서로 다른 테이블에 있어 하나의 JOIN/GROUP BY로 합쳐 정렬하기
+    // 까다로우므로, 두 후보 집합을 각각 조회해 Java에서 병합·정렬·페이지네이션한 뒤 해당 페이지의 도서만
+    // 집계 쿼리로 채운다.
     public Page<BookActivityProjection> findMyLibraryBooks(
             Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
+        Map<Long, LocalDateTime> lastActivityByBookId = new LinkedHashMap<>();
+
+        QOpinion opinionMine = QOpinion.opinion;
+        QPassage passageForActivity = QPassage.passage;
+        for (Tuple row : queryFactory
+                .select(passageForActivity.book.id, opinionMine.createdAt.max())
+                .from(opinionMine)
+                .join(opinionMine.passage, passageForActivity)
+                .where(opinionMine.user.id.eq(userId), opinionMine.deletedAt.isNull(),
+                        passageForActivity.deletedAt.isNull())
+                .groupBy(passageForActivity.book.id)
+                .fetch()) {
+            lastActivityByBookId.put(row.get(passageForActivity.book.id), row.get(opinionMine.createdAt.max()));
+        }
+
+        QUserBookStatus userBookStatus = QUserBookStatus.userBookStatus;
+        for (Tuple row : queryFactory
+                .select(userBookStatus.book.id, userBookStatus.updatedAt)
+                .from(userBookStatus)
+                .where(userBookStatus.user.id.eq(userId))
+                .fetch()) {
+            Long bookId = row.get(userBookStatus.book.id);
+            LocalDateTime updatedAt = row.get(userBookStatus.updatedAt);
+            lastActivityByBookId.merge(bookId, updatedAt, (opinionTime, statusTime) ->
+                    opinionTime.isAfter(statusTime) ? opinionTime : statusTime);
+        }
+
+        List<Long> sortedBookIds = lastActivityByBookId.entrySet().stream()
+                .sorted(Map.Entry.<Long, LocalDateTime>comparingByValue().reversed()
+                        .thenComparing(Comparator.comparing(Map.Entry::getKey, Comparator.reverseOrder())))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        List<Long> pageBookIds = sortedBookIds.stream()
+                .skip(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .toList();
+
+        List<BookActivityProjection> content = fetchActivityByBookIds(pageBookIds, userId, opinionCountScope);
+        return new PageImpl<>(content, pageable, sortedBookIds.size());
+    }
+
+    private List<BookActivityProjection> fetchActivityByBookIds(
+            List<Long> bookIds, Long userId, OpinionCountScope opinionCountScope) {
+        if (bookIds.isEmpty()) {
+            return List.of();
+        }
+
         QBook book = QBook.book;
         QPassage passage = QPassage.passage;
         QOpinion opinionMine = new QOpinion("opinionMine");
@@ -157,16 +217,17 @@ public class BookQueryRepository {
                 ? opinionMine.countDistinct()
                 : opinionAll.countDistinct();
 
-        // opinionMine/opinionAll은 도서 전체 집계용 passage 조인과 별개로 passage.book을 통해 book에 직접
-        // 연결한다. 특정 passage 행을 공유해서 조인하면 opinionMine의 innerJoin이 passage를 "내가 흔적을 남긴
-        // 대목"으로 제한해버려서, passageCount/opinionAll(ALL)이 도서 전체가 아니라 그 대목만 집계하게 된다.
+        // opinionMine/opinionAll은 passageCount 집계용 passage 조인과 별개로 passage.book을 통해 book에
+        // 직접 연결한다. 같은 passage 행을 공유해서 조인하면 opinionMine이 passage를 "내가 흔적을 남긴 대목"
+        // 으로 제한해버려서, passageCount/opinionAll(ALL)이 도서 전체가 아니라 그 대목만 집계하게 된다.
+        // 대목이 하나도 없는 도서(읽기 상태만 설정)도 대상이므로 passage는 leftJoin이다.
         JPAQuery<BookActivityProjection> query = queryFactory
                 .select(Projections.constructor(BookActivityProjection.class,
                         book.id, book.title, book.author, book.publisher, book.coverImageUrl,
                         passage.countDistinct(), opinionCount))
                 .from(book)
-                .innerJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
-                .innerJoin(opinionMine).on(opinionMine.passage.book.eq(book)
+                .leftJoin(passage).on(passage.book.eq(book).and(passage.deletedAt.isNull()))
+                .leftJoin(opinionMine).on(opinionMine.passage.book.eq(book)
                         .and(opinionMine.user.id.eq(userId))
                         .and(opinionMine.deletedAt.isNull()));
         if (opinionCountScope == OpinionCountScope.ALL) {
@@ -175,29 +236,13 @@ public class BookQueryRepository {
         }
 
         List<BookActivityProjection> content = query
+                .where(book.id.in(bookIds))
                 .groupBy(book.id, book.title, book.author, book.publisher, book.coverImageUrl)
-                .orderBy(opinionMine.createdAt.max().desc(), book.id.asc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(content, pageable, countMyLibraryBooks(userId));
-    }
-
-    private long countMyLibraryBooks(Long userId) {
-        QBook book = QBook.book;
-        QPassage passage = QPassage.passage;
-        QOpinion opinionMine = QOpinion.opinion;
-
-        Long count = queryFactory
-                .select(book.countDistinct())
-                .from(book)
-                .innerJoin(passage).on(passage.book.eq(book))
-                .innerJoin(opinionMine).on(opinionMine.passage.eq(passage)
-                        .and(opinionMine.user.id.eq(userId))
-                        .and(opinionMine.deletedAt.isNull()))
-                .fetchOne();
-        return count != null ? count : 0L;
+        Map<Long, BookActivityProjection> byBookId = content.stream()
+                .collect(Collectors.toMap(BookActivityProjection::bookId, p -> p));
+        return bookIds.stream().map(byBookId::get).filter(Objects::nonNull).toList();
     }
 
     public Page<BookActivityProjection> findPopularBooks(Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -198,8 +198,8 @@ public class OpinionService {
     }
 
     // 좋아요 관리 화면의 "전체 책 보기" 드롭다운: 내가 좋아요를 누른 흔적이 있는 도서 목록.
-    public List<BookOptionProjection> getLikedBookOptions(Long userId) {
-        return opinionQueryRepository.findLikedBookOptions(userId);
+    public Page<BookOptionProjection> getLikedBookOptions(Long userId, Pageable pageable) {
+        return opinionQueryRepository.findLikedBookOptions(userId, pageable);
     }
 
     public long getMyOpinionCount(Long userId) {

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepository.java
@@ -161,13 +161,13 @@ public class OpinionQueryRepository {
     }
 
     // 좋아요·스포일러 관리 화면 공용 "전체 책 보기" 드롭다운: 활동(좋아요/스포일러) 최신순으로 중복 없이 책만 나열.
-    public List<BookOptionProjection> findLikedBookOptions(Long userId) {
+    public Page<BookOptionProjection> findLikedBookOptions(Long userId, Pageable pageable) {
         QOpinionLike opinionLike = QOpinionLike.opinionLike;
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
         QBook book = QBook.book;
 
-        return queryFactory
+        List<BookOptionProjection> content = queryFactory
                 .select(Projections.constructor(BookOptionProjection.class, book.id, book.title))
                 .from(opinionLike)
                 .join(opinionLike.opinion, opinion)
@@ -176,6 +176,19 @@ public class OpinionQueryRepository {
                 .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
                 .groupBy(book.id, book.title)
                 .orderBy(opinionLike.createdAt.max().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        Long total = queryFactory
+                .select(book.countDistinct())
+                .from(opinionLike)
+                .join(opinionLike.opinion, opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinionLike.user.id.eq(userId), opinion.deletedAt.isNull())
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/passage/application/MyPassageProjection.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/MyPassageProjection.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 public record MyPassageProjection(
         Long passageId,
         Long bookId,
+        Long opinionId,
         int pageNumber,
         String quotedText,
         boolean isSpoiler,

--- a/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
+++ b/src/main/java/com/nexters/palang/domain/passage/application/PassageService.java
@@ -63,8 +63,8 @@ public class PassageService {
     }
 
     // 스포일러 관리 화면의 "전체 책 보기" 드롭다운: 내가 스포일러로 남긴 대목이 있는 도서 목록.
-    public List<BookOptionProjection> getSpoilerBookOptions(Long userId) {
-        return passageQueryRepository.findSpoilerBookOptions(userId);
+    public Page<BookOptionProjection> getSpoilerBookOptions(Long userId, Pageable pageable) {
+        return passageQueryRepository.findSpoilerBookOptions(userId, pageable);
     }
 
     // 대목 스포일러 설정 변경: 소유 기준은 findMyPassages와 동일하게 이 대목에 흔적을 남긴 사용자.

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepository.java
@@ -9,6 +9,7 @@ import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.domain.QPassage;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -88,25 +89,35 @@ public class PassageQueryRepository {
     }
 
     // 내가 남긴 대목(FR-...): 소유 기준은 흔적을 남긴 사용자다(최초 생성자가 아니어도 병합된 대목에 흔적을 남겼으면 포함).
-    // createdAt/정렬 기준은 대목 자체가 아니라 "내가 그 대목에 흔적을 남긴 시점"이어야 사용자 관점에서 의미가 있으므로
-    // opinion.createdAt의 최댓값을 쓴다(같은 대목에 흔적을 여러 번 남긴 경우 가장 최근 흔적 기준, 대목 단위 중복 제거).
+    // 정렬 기준은 대목 자체가 아니라 "내가 그 대목에 흔적을 남긴 시점"이어야 사용자 관점에서 의미가 있다.
+    // 같은 대목에 흔적을 여러 번 남긴 경우 카드가 이동해야 할 흔적(opinionId)이 하나로 정해져야 하므로,
+    // GROUP BY 집계 대신 "이 사용자가 이 대목에 남긴 흔적 중 더 나중 것이 없다"는 NOT EXISTS로 대목당
+    // 정확히 한 행(가장 최근 흔적)만 남긴다.
     public Page<MyPassageProjection> findMyPassages(Long userId, Long bookId, boolean spoilerOnly, Pageable pageable) {
         QOpinion opinion = QOpinion.opinion;
+        QOpinion laterOpinion = new QOpinion("laterOpinion");
         QPassage passage = QPassage.passage;
 
         BooleanExpression bookFilter = bookId != null ? passage.book.id.eq(bookId) : null;
         BooleanExpression spoilerFilter = spoilerOnly ? passage.isSpoiler.isTrue() : null;
+        BooleanExpression isLatestOpinionForPassage = JPAExpressions.selectOne()
+                .from(laterOpinion)
+                .where(laterOpinion.passage.eq(opinion.passage),
+                        laterOpinion.user.eq(opinion.user),
+                        laterOpinion.deletedAt.isNull(),
+                        laterOpinion.createdAt.gt(opinion.createdAt)
+                                .or(laterOpinion.createdAt.eq(opinion.createdAt).and(laterOpinion.id.gt(opinion.id))))
+                .notExists();
 
         List<MyPassageProjection> content = queryFactory
                 .select(Projections.constructor(MyPassageProjection.class,
-                        passage.id, passage.book.id, passage.pageNumber, passage.quotedText,
-                        passage.isSpoiler, opinion.createdAt.max()))
+                        passage.id, passage.book.id, opinion.id, passage.pageNumber, passage.quotedText,
+                        passage.isSpoiler, opinion.createdAt))
                 .from(opinion)
                 .join(opinion.passage, passage)
                 .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
-                        bookFilter, spoilerFilter)
-                .groupBy(passage.id, passage.book.id, passage.pageNumber, passage.quotedText, passage.isSpoiler)
-                .orderBy(opinion.createdAt.max().desc(), passage.id.desc())
+                        bookFilter, spoilerFilter, isLatestOpinionForPassage)
+                .orderBy(opinion.createdAt.desc(), passage.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -124,12 +135,12 @@ public class PassageQueryRepository {
 
     // 좋아요·스포일러 관리 화면 공용 "전체 책 보기" 드롭다운: 내가 스포일러로 남긴 대목이 있는 도서 목록.
     // 소유 기준은 findMyPassages와 동일하게 흔적을 남긴 사용자(opinion.user) 기준.
-    public List<BookOptionProjection> findSpoilerBookOptions(Long userId) {
+    public Page<BookOptionProjection> findSpoilerBookOptions(Long userId, Pageable pageable) {
         QOpinion opinion = QOpinion.opinion;
         QPassage passage = QPassage.passage;
         QBook book = QBook.book;
 
-        return queryFactory
+        List<BookOptionProjection> content = queryFactory
                 .select(Projections.constructor(BookOptionProjection.class, book.id, book.title))
                 .from(opinion)
                 .join(opinion.passage, passage)
@@ -138,6 +149,19 @@ public class PassageQueryRepository {
                         passage.isSpoiler.isTrue())
                 .groupBy(book.id, book.title)
                 .orderBy(opinion.createdAt.max().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        Long total = queryFactory
+                .select(book.countDistinct())
+                .from(opinion)
+                .join(opinion.passage, passage)
+                .join(passage.book, book)
+                .where(opinion.user.id.eq(userId), opinion.deletedAt.isNull(), passage.deletedAt.isNull(),
+                        passage.isSpoiler.isTrue())
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/user/application/UserMapper.java
@@ -15,7 +15,6 @@ import com.nexters.palang.domain.user.presentation.dto.MyOpinionResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyPassageListResponse;
 import com.nexters.palang.domain.user.presentation.dto.MyPassageResponse;
 import com.nexters.palang.global.common.response.PageInfo;
-import java.util.List;
 import org.springframework.data.domain.Page;
 
 public final class UserMapper {
@@ -58,14 +57,15 @@ public final class UserMapper {
         return new BookOptionResponse(projection.bookId(), projection.title());
     }
 
-    public static FilterBooksResponse toFilterBooksResponse(List<BookOptionProjection> projections) {
-        return new FilterBooksResponse(projections.stream().map(UserMapper::toBookOptionResponse).toList());
+    public static FilterBooksResponse toFilterBooksResponse(Page<BookOptionProjection> projections) {
+        return new FilterBooksResponse(
+                projections.map(UserMapper::toBookOptionResponse).getContent(), PageInfo.from(projections));
     }
 
     public static MyPassageResponse toMyPassageResponse(MyPassageProjection projection) {
         return new MyPassageResponse(
-                projection.passageId(), projection.bookId(), projection.pageNumber(), projection.quotedText(),
-                projection.isSpoiler(), projection.createdAt());
+                projection.passageId(), projection.bookId(), projection.opinionId(), projection.pageNumber(),
+                projection.quotedText(), projection.isSpoiler(), projection.createdAt());
     }
 
     public static MyPassageListResponse toMyPassageListResponse(Page<MyPassageProjection> projections) {

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -185,7 +185,8 @@ public interface UserApi {
 
     @Operation(summary = "도서 필터 목록", description = "좋아요 관리·스포일러 관리 화면의 \"전체 책 보기\" 드롭다운에 쓸 도서 목록입니다. "
             + "type=LIKE면 내가 좋아요를 누른 흔적이 있는 도서를, type=SPOILER면 내가 스포일러로 남긴 대목이 있는 도서를 "
-            + "최근 활동순으로 중복 없이 반환합니다. 여기서 고른 bookId를 흔적/좋아요/대목 목록 API의 bookId 파라미터로 전달합니다. "
+            + "최근 활동순으로 중복 없이 반환합니다. 다른 목록 API와 동일하게 page/size로 페이지네이션됩니다. "
+            + "여기서 고른 bookId를 흔적/좋아요/대목 목록 API의 bookId 파라미터로 전달합니다. "
             + "Authorization: Bearer {accessToken} 헤더로 인증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -199,7 +200,9 @@ public interface UserApi {
                                     + "\"status\":401,\"detail\":\"로그인이 필요합니다.\"}")))
     })
     ResponseEntity<DataResponse<FilterBooksResponse>> getFilterBooks(
-            @Parameter(description = "필터 종류 (LIKE: 좋아요 관리, SPOILER: 스포일러 대목 관리)", required = true) BookFilterType type
+            @Parameter(description = "필터 종류 (LIKE: 좋아요 관리, SPOILER: 스포일러 대목 관리)", required = true) BookFilterType type,
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") int size
     );
 
     @Operation(summary = "내 대목 목록", description = "내가 흔적을 남긴 대목을 최신순으로 조회합니다. "

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserController.java
@@ -19,8 +19,8 @@ import com.nexters.palang.domain.user.presentation.dto.UpdateNicknameRequest;
 import com.nexters.palang.global.common.response.DataResponse;
 import com.nexters.palang.global.security.CurrentUserProvider;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -122,11 +122,14 @@ public class UserController implements UserApi {
 
     @Override
     @GetMapping("/api/users/me/filter-books")
-    public ResponseEntity<DataResponse<FilterBooksResponse>> getFilterBooks(@RequestParam BookFilterType type) {
+    public ResponseEntity<DataResponse<FilterBooksResponse>> getFilterBooks(
+            @RequestParam BookFilterType type,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
-        List<BookOptionProjection> books = type == BookFilterType.SPOILER
-                ? passageService.getSpoilerBookOptions(currentUserId)
-                : opinionService.getLikedBookOptions(currentUserId);
+        Page<BookOptionProjection> books = type == BookFilterType.SPOILER
+                ? passageService.getSpoilerBookOptions(currentUserId, pageable(page, size))
+                : opinionService.getLikedBookOptions(currentUserId, pageable(page, size));
         return ResponseEntity.ok(DataResponse.from(UserMapper.toFilterBooksResponse(books)));
     }
 

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/FilterBooksResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/FilterBooksResponse.java
@@ -1,9 +1,11 @@
 package com.nexters.palang.domain.user.presentation.dto;
 
+import com.nexters.palang.global.common.response.PageInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record FilterBooksResponse(
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookOptionResponse> books
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<BookOptionResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageResponse.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/dto/MyPassageResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 public record MyPassageResponse(
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
         @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(example = "1", requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
         @Schema(example = "87", requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
         @Schema(example = "우리는 모두 이야기를 찾아 헤맨다.", requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
         @Schema(example = "false", requiredMode = Schema.RequiredMode.REQUIRED) boolean isSpoiler,

--- a/src/test/java/com/nexters/palang/domain/book/application/UserBookStatusServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/UserBookStatusServiceTest.java
@@ -76,7 +76,7 @@ class UserBookStatusServiceTest {
     void updateBookStatusUpdatesExistingStatus() {
         Book book = book(10L, 300);
         UserBookStatus existing = UserBookStatus.builder()
-                .user(user(1L)).book(book).status(ReadingStatus.PLANNED).currentPage(null).build();
+                .user(user(1L)).book(book).status(ReadingStatus.FINISHED).currentPage(null).build();
         given(bookRepository.findById(10L)).willReturn(Optional.of(book));
         given(userBookStatusRepository.findByUserIdAndBookId(1L, 10L)).willReturn(Optional.of(existing));
 
@@ -93,7 +93,7 @@ class UserBookStatusServiceTest {
     void updateBookStatusFallsBackToUpdateWhenConcurrentInsertViolatesUniqueConstraint() {
         Book book = book(10L, 300);
         UserBookStatus winnerOfRace = UserBookStatus.builder()
-                .user(user(1L)).book(book).status(ReadingStatus.PLANNED).currentPage(null).build();
+                .user(user(1L)).book(book).status(ReadingStatus.FINISHED).currentPage(null).build();
         given(bookRepository.findById(10L)).willReturn(Optional.of(book));
         given(userBookStatusRepository.findByUserIdAndBookId(1L, 10L))
                 .willReturn(Optional.empty(), Optional.of(winnerOfRace));

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/BookQueryRepositoryTest.java
@@ -9,6 +9,8 @@ import com.nexters.palang.domain.book.application.BookSearchProjection;
 import com.nexters.palang.domain.book.application.BookSearchSort;
 import com.nexters.palang.domain.book.application.OpinionCountScope;
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.ReadingStatus;
+import com.nexters.palang.domain.book.domain.UserBookStatus;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.user.domain.SnsProvider;
@@ -76,6 +78,14 @@ class BookQueryRepositoryTest {
                 .passage(passage)
                 .user(user)
                 .content("흔적 내용")
+                .build());
+    }
+
+    private UserBookStatus userBookStatus(User user, Book book, ReadingStatus status) {
+        return entityManager.persistAndFlush(UserBookStatus.builder()
+                .user(user)
+                .book(book)
+                .status(status)
                 .build());
     }
 
@@ -449,6 +459,38 @@ class BookQueryRepositoryTest {
 
         assertThat(results.getContent()).extracting(BookActivityProjection::bookId)
                 .containsExactly(newerBook.getId(), olderBook.getId());
+    }
+
+    @Test
+    @DisplayName("흔적은 없지만 읽기 상태만 설정한 도서도 내 서재에 포함한다")
+    void findMyLibraryBooksIncludesBookWithStatusOnly() {
+        User me = user("me-status1");
+        Book statusOnlyBook = book("읽기 상태만 설정한 책");
+        userBookStatus(me, statusOnlyBook, ReadingStatus.READING);
+
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.ALL);
+
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId)
+                .containsExactly(statusOnlyBook.getId());
+        assertThat(results.getContent().get(0).passageCount()).isEqualTo(0);
+        assertThat(results.getContent().get(0).opinionCount()).isEqualTo(0);
+        assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("같은 도서에 흔적과 읽기 상태가 모두 있어도 한 번만 포함한다")
+    void findMyLibraryBooksDeduplicatesBookWithBothOpinionAndStatus() {
+        User me = user("me-both");
+        Book book = book("흔적과 읽기 상태가 모두 있는 책");
+        opinion(passage(book, me, 1), me);
+        userBookStatus(me, book, ReadingStatus.FINISHED);
+
+        Page<BookActivityProjection> results = bookQueryRepository.findMyLibraryBooks(
+                me.getId(), PageRequest.of(0, 20), OpinionCountScope.ALL);
+
+        assertThat(results.getContent()).extracting(BookActivityProjection::bookId).containsExactly(book.getId());
+        assertThat(results.getTotalElements()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -467,10 +467,11 @@ class OpinionServiceTest {
     @Test
     @DisplayName("좋아요 도서 필터 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
     void getLikedBookOptionsReturnsResultFromQueryRepository() {
-        List<BookOptionProjection> expected = List.of(new BookOptionProjection(10L, "제목"));
-        given(opinionQueryRepository.findLikedBookOptions(1L)).willReturn(expected);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<BookOptionProjection> expected = new PageImpl<>(List.of(new BookOptionProjection(10L, "제목")));
+        given(opinionQueryRepository.findLikedBookOptions(1L, pageable)).willReturn(expected);
 
-        List<BookOptionProjection> results = opinionService.getLikedBookOptions(1L);
+        Page<BookOptionProjection> results = opinionService.getLikedBookOptions(1L, pageable);
 
         assertThat(results).isEqualTo(expected);
     }

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionQueryRepositoryTest.java
@@ -295,9 +295,11 @@ class OpinionQueryRepositoryTest {
         entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inTargetBook1).build());
         entityManager.persistAndFlush(OpinionLike.builder().user(me).opinion(inTargetBook2).build());
 
-        List<BookOptionProjection> results = opinionQueryRepository.findLikedBookOptions(me.getId());
+        Page<BookOptionProjection> results = opinionQueryRepository.findLikedBookOptions(
+                me.getId(), PageRequest.of(0, 20));
 
-        assertThat(results).extracting(BookOptionProjection::bookId)
+        assertThat(results.getContent()).extracting(BookOptionProjection::bookId)
                 .containsExactly(book.getId(), inOtherBook.getPassage().getBook().getId());
+        assertThat(results.getTotalElements()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/application/PassageServiceTest.java
@@ -30,7 +30,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -147,10 +150,11 @@ class PassageServiceTest {
     @Test
     @DisplayName("스포일러 도서 필터 목록을 조회하면 QueryRepository 결과를 그대로 반환한다")
     void getSpoilerBookOptionsReturnsResultFromQueryRepository() {
-        List<BookOptionProjection> expected = List.of(new BookOptionProjection(10L, "책 제목"));
-        given(passageQueryRepository.findSpoilerBookOptions(1L)).willReturn(expected);
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<BookOptionProjection> expected = new PageImpl<>(List.of(new BookOptionProjection(10L, "책 제목")));
+        given(passageQueryRepository.findSpoilerBookOptions(1L, pageable)).willReturn(expected);
 
-        List<BookOptionProjection> result = passageService.getSpoilerBookOptions(1L);
+        Page<BookOptionProjection> result = passageService.getSpoilerBookOptions(1L, pageable);
 
         assertThat(result).isEqualTo(expected);
     }

--- a/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/passage/infrastructure/PassageQueryRepositoryTest.java
@@ -343,13 +343,15 @@ class PassageQueryRepositoryTest {
         Book book = book("책");
         Passage passage = passage(book, writer, 5, "발췌 문장", "hash-1");
         entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적1").build());
-        entityManager.persistAndFlush(Opinion.builder().passage(passage).user(writer).content("흔적2").build());
+        Opinion latest = entityManager.persistAndFlush(
+                Opinion.builder().passage(passage).user(writer).content("흔적2").build());
 
         Page<MyPassageProjection> result = passageQueryRepository.findMyPassages(
                 writer.getId(), null, false, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).opinionId()).isEqualTo(latest.getId());
     }
 
     @Test
@@ -363,8 +365,9 @@ class PassageQueryRepositoryTest {
         entityManager.persistAndFlush(Opinion.builder().passage(spoiler).user(writer).content("흔적1").build());
         entityManager.persistAndFlush(Opinion.builder().passage(notSpoiler).user(writer).content("흔적2").build());
 
-        List<BookOptionProjection> results = passageQueryRepository.findSpoilerBookOptions(writer.getId());
+        Page<BookOptionProjection> results = passageQueryRepository.findSpoilerBookOptions(
+                writer.getId(), PageRequest.of(0, 20));
 
-        assertThat(results).extracting(BookOptionProjection::bookId).containsExactly(targetBook.getId());
+        assertThat(results.getContent()).extracting(BookOptionProjection::bookId).containsExactly(targetBook.getId());
     }
 }

--- a/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/user/presentation/UserControllerTest.java
@@ -353,8 +353,8 @@ class UserControllerTest {
     @DisplayName("좋아요 도서 필터 목록을 조회한다")
     void getFilterBooksForLike() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(opinionService.getLikedBookOptions(1L)).willReturn(
-                List.of(new BookOptionProjection(10L, "책 제목")));
+        given(opinionService.getLikedBookOptions(eq(1L), any())).willReturn(
+                new PageImpl<>(List.of(new BookOptionProjection(10L, "책 제목")), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/filter-books").param("type", "LIKE"))
                 .andExpect(status().isOk())
@@ -366,8 +366,8 @@ class UserControllerTest {
     @DisplayName("스포일러 도서 필터 목록을 조회한다")
     void getFilterBooksForSpoiler() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
-        given(passageService.getSpoilerBookOptions(1L)).willReturn(
-                List.of(new BookOptionProjection(20L, "다른 책")));
+        given(passageService.getSpoilerBookOptions(eq(1L), any())).willReturn(
+                new PageImpl<>(List.of(new BookOptionProjection(20L, "다른 책")), DEFAULT_PAGEABLE, 1));
 
         mockMvc.perform(get("/api/users/me/filter-books").param("type", "SPOILER"))
                 .andExpect(status().isOk())
@@ -388,7 +388,7 @@ class UserControllerTest {
     void getMyPassages() throws Exception {
         given(currentUserProvider.getCurrentUserId()).willReturn(1L);
         MyPassageProjection projection = new MyPassageProjection(
-                1L, 10L, 5, "발췌 문장", true, LocalDateTime.now());
+                1L, 10L, 100L, 5, "발췌 문장", true, LocalDateTime.now());
         given(passageService.getMyPassages(eq(1L), eq(10L), eq(true), any())).willReturn(
                 new PageImpl<>(List.of(projection), DEFAULT_PAGEABLE, 1));
 
@@ -398,6 +398,7 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.passages[0].passageId").value(1))
                 .andExpect(jsonPath("$.data.passages[0].bookId").value(10))
+                .andExpect(jsonPath("$.data.passages[0].opinionId").value(100))
                 .andExpect(jsonPath("$.data.passages[0].isSpoiler").value(true));
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #140

## 🚀 개요
> 좋아요 관리·스포일러 관리 화면 연동 중 새로 확인된 요청 1건과, 기획 확인이 끝난 미결 항목 3건을 반영합니다.

## 📄 작업 내용
- `GET /api/users/me/passages` 응답(`MyPassageResponse`)에 `opinionId` 추가 — 한 대목에 내 흔적이 여러 개면 가장 최근 흔적 하나를 반환 (`NOT EXISTS` 서브쿼리로 대목당 정확히 한 행만 선택)
- `GET /api/books/my-library` 수집 기준 확장 — 흔적이 없어도 읽기 상태(`UserBookStatus`)만 설정한 도서도 노출. 정렬은 "흔적 시각/상태 갱신 시각 중 더 최근"
- `ReadingStatus`에서 `PLANNED` 제거 (`READING`, `FINISHED`만 유지)
- `GET /api/users/me/filter-books`에 `page`/`size` 페이지네이션 추가 — 다른 목록 API와 동일한 컨벤션(기본 20, 최대 100)으로 통일해 "개수 상한" 요청 해결
- 스포일러 해제 `false → true` 재설정 허용 여부는 기존 구현(양방향 허용) 유지로 결론 — 코드 변경 없음

| Method | Path | 변경 |
|---|---|---|
| GET | `/api/users/me/passages` | 응답에 `opinionId` 필드 추가 |
| GET | `/api/books/my-library` | 수집 기준 확장(읽기 상태만 있어도 포함) |
| GET | `/api/users/me/filter-books` | `page`/`size` 파라미터 및 `pageInfo` 추가 |

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 557개 중 554개 통과. 나머지 3개(`AladinBookApiClientCacheTest`)는 로컬 Redis 미기동으로 인한 기존 환경 이슈이며, 이번 변경 이전 develop에서도 동일하게 실패함을 확인했습니다(무관).

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `BookQueryRepository#findMyLibraryBooks`를 GROUP BY 집계 쿼리 대신, 흔적/읽기상태 두 활동 집합을 각각 조회해 Java에서 병합·정렬·페이지네이션하는 방식으로 바꿨습니다. 두 활동의 "최근 시각" 컬럼이 서로 다른 테이블(opinion.createdAt / userBookStatus.updatedAt)에 있어 하나의 SQL로 합쳐 정렬하기 까다로워 택한 방식인데, 더 나은 방법이 있을지 의견 부탁드립니다.
- `PassageQueryRepository#findMyPassages`도 같은 이유로 GROUP BY 대신 NOT EXISTS(더 나중 흔적 없음) 패턴으로 바꿔 opinionId를 함께 뽑도록 했습니다. 쿼리 의도가 잘 읽히는지 확인 부탁드립니다.
- `filter-books`에 페이지네이션을 붙이면서 응답 필드명(`books` + `pageInfo`)은 그대로 유지했는데, 프론트 쪽에서 파싱 방식이 바뀌어야 하니 미리 공유 부탁드립니다.
