### PR TITLE
Feat/#139 비로그인 내 의견 미리보기 샘플 계정 실데이터 전환

### DIFF
--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -26,9 +26,9 @@ import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
 import com.nexters.palang.domain.user.common.error.UserErrorCode;
 import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.GuestSampleAccount;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -163,32 +163,16 @@ public class OpinionService {
         return existing;
     }
 
-    // 비로그인 사용자는 마이페이지 미리보기로 고정 샘플 흔적 3건을 본다 (기획 확정, 이슈 #120).
-    private static final String GUEST_SAMPLE_BOOK_TITLE = "빵충 사육 준수 사항";
-    private static final String GUEST_SAMPLE_AUTHOR = "김혜영 (지은이)";
-    private static final String GUEST_SAMPLE_COVER_IMAGE_URL =
-            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg";
-    private static final String GUEST_SAMPLE_QUOTED_TEXT = "이 모든 건 챗지피티 덕분이었다. 담당자가 준 자료를 복사해서 "
-            + "이 녀석에게 붙여넣기를 반복하니 한눈에 봐도 괜찮은 서류를 달칵 토해냈다. 세상에, AI가 사람을 구했어요.";
-    private static final LocalDateTime GUEST_SAMPLE_CREATED_AT = LocalDateTime.of(2026, 8, 1, 12, 0, 0);
-    private static final List<MyOpinionProjection> GUEST_SAMPLE_OPINIONS = List.of(
-            new MyOpinionProjection(1L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
-                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
-                    "애증의 관계", 5, GUEST_SAMPLE_CREATED_AT),
-            new MyOpinionProjection(2L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
-                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
-                    "정말… 사람 구했다", 3, GUEST_SAMPLE_CREATED_AT),
-            new MyOpinionProjection(3L, 18L, GUEST_SAMPLE_BOOK_TITLE, GUEST_SAMPLE_AUTHOR,
-                    GUEST_SAMPLE_COVER_IMAGE_URL, 1L, GUEST_SAMPLE_QUOTED_TEXT, 33,
-                    "지피티야 나랑 영원히 함께하자", 8, GUEST_SAMPLE_CREATED_AT)
-    );
-
+    // 비로그인 사용자는 마이페이지 미리보기로 샘플 계정(GuestSampleAccount)의 실제 흔적을 본다
+    // (기획 확정, 이슈 #120). 이 계정과 그 계정의 흔적/꾸밈은 OpinionGuestSampleSeedRunner가 앱 기동
+    // 시 미리 만들어둔다 — 하드코딩 대신 실데이터를 재사용해야 상세 화면의 Decoration(밑줄/동그라미 등)도
+    // 자연스럽게 함께 보인다. 씨딩 전이거나 실패한 환경(로컬 등)에서는 빈 목록을 반환한다.
     public Page<MyOpinionProjection> getMyOpinions(Long userId, Long bookId, Pageable pageable) {
         if (userId == null) {
-            List<MyOpinionProjection> guestSample = bookId == null || bookId.equals(18L)
-                    ? GUEST_SAMPLE_OPINIONS
-                    : List.of();
-            return new PageImpl<>(guestSample, pageable, guestSample.size());
+            return userRepository
+                    .findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID)
+                    .map(sampleUser -> opinionQueryRepository.findMyOpinions(sampleUser.getId(), bookId, pageable))
+                    .orElseGet(() -> new PageImpl<>(List.of(), pageable, 0));
         }
         return opinionQueryRepository.findMyOpinions(userId, bookId, pageable);
     }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunner.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunner.java
@@ -1,0 +1,134 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.decoration.domain.Decoration;
+import com.nexters.palang.domain.decoration.domain.EffectType;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.passage.application.PassageNormalizer;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.GuestSampleAccount;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// 비로그인 "내 의견" 미리보기(이슈 #120)를 하드코딩 대신 실제 계정의 실제 흔적/꾸밈으로 보여주기 위해,
+// 앱 시작 시 한 번 샘플 계정과 그 계정의 흔적 2건(대목 2개)을 만들어둔다. 이 프로젝트엔 Flyway 등
+// 마이그레이션 도구가 없어 BookTitleNormalizationBackfillRunner와 같은 방식(기동 시 자동 실행)을 따른다.
+// 샘플 계정에 이미 흔적이 있으면(=이미 씨딩됨) 아무 일도 하지 않으므로 재배포/재기동해도 안전하다(멱등적).
+// bookId=18("빵충 사육 준수 사항")이 없는 환경(로컬/테스트 DB 등)에서는 조용히 건너뛴다 — 이 도서는
+// BookService.GUEST_SAMPLE_LIBRARY_BOOK에서도 이미 같은 방식으로 하드코딩되어 있는 전제다.
+@Slf4j
+@Component
+public class OpinionGuestSampleSeedRunner implements ApplicationRunner {
+
+    private static final Long SAMPLE_BOOK_ID = 18L;
+
+    private static final int SAMPLE_PAGE_33 = 33;
+    private static final String SAMPLE_QUOTE_33 = "이 모든 건 챗지피티 덕분이었다. 담당자가 준 자료를 복사해서 "
+            + "이 녀석에게 붙여넣기를 반복하니 한눈에 봐도 괜찮은 서류를 달칵 토해냈다. 세상에, AI가 사람을 구했어요.";
+    private static final String SAMPLE_OPINION_33 = "애증의 관계";
+    // "세상에, AI가 사람을 구했어요." 구간에 동그라미(빨간색) 표시.
+    private static final int CIRCLE_START = 77;
+    private static final int CIRCLE_END = 95;
+
+    private static final int SAMPLE_PAGE_70 = 70;
+    private static final String SAMPLE_QUOTE_70 = "빵충은 번데기로 변태하는 순간 영양 성분이 급격히 변질되며, 특유의 향과 식감이 사라져 "
+            + "상품 가치가 사라집니다. 또한 번데기에서는 다량의 온실가스가 배출되어 기후 변화에 악영향을 미칠 가능성이 발견되었습니다.";
+    private static final List<String> SAMPLE_OPINIONS_70 = List.of("응 ???", "위험한걸 왜 사육하는거임?");
+
+    private static final String DECORATION_COLOR = "#FF0000";
+
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+    private final PassageRepository passageRepository;
+    private final OpinionRepository opinionRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    @Autowired
+    public OpinionGuestSampleSeedRunner(
+            UserRepository userRepository,
+            BookRepository bookRepository,
+            PassageRepository passageRepository,
+            OpinionRepository opinionRepository,
+            PlatformTransactionManager transactionManager) {
+        this.userRepository = userRepository;
+        this.bookRepository = bookRepository;
+        this.passageRepository = passageRepository;
+        this.opinionRepository = opinionRepository;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        boolean seeded = Boolean.TRUE.equals(transactionTemplate.execute(status -> {
+            User sampleUser = userRepository
+                    .findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID)
+                    .orElseGet(this::createSampleUser);
+
+            if (opinionRepository.countByUserIdAndDeletedAtIsNull(sampleUser.getId()) > 0) {
+                return false;
+            }
+
+            Book book = bookRepository.findById(SAMPLE_BOOK_ID).orElse(null);
+            if (book == null) {
+                log.info("샘플 도서(id={})가 없어 비로그인 미리보기 흔적 씨딩을 건너뜁니다.", SAMPLE_BOOK_ID);
+                return false;
+            }
+
+            Passage passage33 = createPassage(book, sampleUser, SAMPLE_PAGE_33, SAMPLE_QUOTE_33);
+            Opinion opinion33 = Opinion.createWithDecorations(passage33, sampleUser, SAMPLE_OPINION_33,
+                    List.of(Decoration.builder()
+                            .startOffset(CIRCLE_START).endOffset(CIRCLE_END)
+                            .effectType(EffectType.CIRCLE).color(DECORATION_COLOR)
+                            .build()));
+            opinionRepository.save(opinion33);
+
+            Passage passage70 = createPassage(book, sampleUser, SAMPLE_PAGE_70, SAMPLE_QUOTE_70);
+            for (String content : SAMPLE_OPINIONS_70) {
+                Opinion opinion70 = Opinion.createWithDecorations(passage70, sampleUser, content,
+                        List.of(Decoration.builder()
+                                .startOffset(0).endOffset(SAMPLE_QUOTE_70.length())
+                                .effectType(EffectType.UNDERLINE).color(DECORATION_COLOR)
+                                .build()));
+                opinionRepository.save(opinion70);
+            }
+
+            return true;
+        }));
+
+        if (seeded) {
+            log.info("비로그인 미리보기용 샘플 계정/흔적 씨딩 완료");
+        }
+    }
+
+    private User createSampleUser() {
+        User user = User.builder()
+                .nickname(GuestSampleAccount.NICKNAME)
+                .snsProvider(GuestSampleAccount.SNS_PROVIDER)
+                .snsId(GuestSampleAccount.SNS_ID)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Passage createPassage(Book book, User creator, int pageNumber, String quotedText) {
+        Passage passage = Passage.builder()
+                .book(book)
+                .creator(creator)
+                .group(null)
+                .pageNumber(pageNumber)
+                .quotedText(quotedText)
+                .isSpoiler(false)
+                .normalizedHash(PassageNormalizer.normalizedHash(quotedText))
+                .build();
+        return passageRepository.save(passage);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/user/domain/GuestSampleAccount.java
+++ b/src/main/java/com/nexters/palang/domain/user/domain/GuestSampleAccount.java
@@ -1,0 +1,15 @@
+package com.nexters.palang.domain.user.domain;
+
+// 비로그인 사용자에게 보여줄 "내 의견" 미리보기(이슈 #120)는 하드코딩 값 대신 실제 계정의 실제
+// 흔적/꾸밈 데이터를 그대로 보여준다 — 그래야 상세 화면의 Decoration(밑줄/동그라미 등)까지 자연스럽게
+// 재사용된다. OpinionGuestSampleSeedRunner(생성)와 OpinionService(조회) 양쪽이 같은 식별자로 이
+// 계정을 찾아야 하므로 상수를 이 중립적인 위치(user.domain)에 모아둔다.
+public final class GuestSampleAccount {
+
+    public static final SnsProvider SNS_PROVIDER = SnsProvider.KAKAO;
+    public static final String SNS_ID = "guest-preview-sample-account";
+    public static final String NICKNAME = "미리보기 계정";
+
+    private GuestSampleAccount() {
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -30,6 +30,7 @@ import com.nexters.palang.domain.opinion.presentation.dto.UpdateOpinionRequest;
 import com.nexters.palang.domain.passage.common.error.PassageException;
 import com.nexters.palang.domain.passage.domain.Passage;
 import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.GuestSampleAccount;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import java.time.LocalDate;
@@ -429,22 +430,36 @@ class OpinionServiceTest {
     }
 
     @Test
-    @DisplayName("비로그인 사용자가 내가 남긴 흔적 목록을 조회하면 QueryRepository 대신 고정 샘플 3건을 반환한다")
-    void getMyOpinionsReturnsSampleWhenGuest() {
+    @DisplayName("비로그인 사용자가 내가 남긴 흔적 목록을 조회하면 샘플 계정의 실제 흔적을 QueryRepository로 조회해 반환한다")
+    void getMyOpinionsReturnsSampleAccountOpinionsWhenGuest() {
         Pageable pageable = PageRequest.of(0, 20);
+        User sampleUser = User.builder()
+                .nickname(GuestSampleAccount.NICKNAME)
+                .snsProvider(GuestSampleAccount.SNS_PROVIDER)
+                .snsId(GuestSampleAccount.SNS_ID)
+                .build();
+        ReflectionTestUtils.setField(sampleUser, "id", 999L);
+        Page<MyOpinionProjection> expected = new PageImpl<>(
+                List.of(new MyOpinionProjection(1L, 18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "cover", 100L, "발췌", 33,
+                        "애증의 관계", 0, LocalDateTime.now())),
+                pageable, 1);
+        given(userRepository.findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID))
+                .willReturn(Optional.of(sampleUser));
+        given(opinionQueryRepository.findMyOpinions(999L, null, pageable)).willReturn(expected);
 
         Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, null, pageable);
 
-        assertThat(results.getTotalElements()).isEqualTo(3);
-        assertThat(results.getContent()).allMatch(o -> o.bookId().equals(18L) && o.pageNumber() == 33);
+        assertThat(results).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("비로그인 사용자가 다른 책 bookId로 조회하면 샘플이 아닌 빈 목록을 반환한다")
-    void getMyOpinionsReturnsEmptyWhenGuestFiltersOtherBook() {
+    @DisplayName("비로그인 사용자인데 샘플 계정이 씨딩되지 않았다면 빈 목록을 반환한다")
+    void getMyOpinionsReturnsEmptyWhenGuestAndSampleAccountMissing() {
         Pageable pageable = PageRequest.of(0, 20);
+        given(userRepository.findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID))
+                .willReturn(Optional.empty());
 
-        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, 999L, pageable);
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, null, pageable);
 
         assertThat(results.getTotalElements()).isZero();
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #139

## 🚀 개요
- 비로그인 "내 의견 보기" 미리보기(#120)가 하드코딩된 가짜 3건을 반환하던 것을, 실제 계정(GuestSampleAccount)의 실제 흔적으로 전환합니다.

## 📄 작업 내용
- `OpinionService.getMyOpinions`: 비로그인 분기에서 하드코딩된 `GUEST_SAMPLE_OPINIONS`(3건) 제거, 샘플 계정 실데이터를 `OpinionQueryRepository.findMyOpinions`로 조회하도록 변경 → 내가 남긴 의견 1건("애증의 관계")만 노출되고, 다른 사람 의견 2건은 더 이상 나오지 않습니다.
- `GuestSampleAccount` 상수 클래스 추가: 씨딩 러너와 서비스가 동일 SNS 식별자로 같은 샘플 계정을 참조합니다.
- `OpinionGuestSampleSeedRunner` 추가: 앱 기동 시 1회, 멱등적으로 샘플 계정 + 대목 2건을 생성합니다.
  - 33p: 의견 1건("애증의 관계") + "세상에, AI가 사람을 구했어요." 구간에 CIRCLE(빨간색) 꾸밈
  - 70p(신규): 의견 2건("응 ???", "위험한걸 왜 사육하는거임?") + 인용문 전체에 UNDERLINE(빨간색) 꾸밈
  - Flyway 등 마이그레이션 도구가 없는 저장소 특성상 `BookTitleNormalizationBackfillRunner`와 동일한 패턴(ApplicationRunner)을 재사용했습니다.
- `OpinionServiceTest` 관련 테스트 수정.

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 실행: 555개 중 552개 통과. 나머지 3개(`AladinBookApiClientCacheTest`)는 로컬 Redis 미실행으로 인한 기존 무관 실패로, 이 브랜치와 무관하게 develop 기준에서도 동일하게 실패함을 확인했습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 샘플 계정의 흔적은 하드코딩이 아닌 실제 Opinion/Passage/Decoration이라, 같은 책(bookId=18) 33p/70p 대목을 보는 다른 로그인 사용자에게도 "흔적 목록"에 실제로 노출됩니다. 이 부분이 기획 의도와 맞는지 확인 부탁드립니다.
- Decoration 색상은 별도 ColorToken 없이 하드코딩된 hex(`#FF0000`)를 그대로 사용했습니다. 추후 컬러 토큰화 논의가 있다면 함께 반영이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 비로그인 사용자도 마이페이지에서 실제 샘플 계정 기반의 흔적을 확인할 수 있습니다.
  - 샘플 도서와 의견이 자동으로 준비되어 미리보기 콘텐츠가 제공됩니다.
- **버그 수정**
  - 고정된 예시 3건 대신 실제 저장된 데이터를 조회하도록 개선했습니다.
  - 샘플 계정이나 콘텐츠가 없을 경우 오류 대신 빈 목록을 표시합니다.
  - 로그인 사용자의 기존 흔적 조회 기능은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->