### PR TITLE
Fix/#143 Group 응답 매핑 시 발생하는 LazyInitializationException 수정

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupService.java
@@ -14,6 +14,8 @@ import com.nexters.palang.domain.group.infrastructure.GroupQueryRepository;
 import com.nexters.palang.domain.group.infrastructure.GroupRepository;
 import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
 import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
 import com.nexters.palang.domain.user.domain.User;
 import com.nexters.palang.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +42,11 @@ public class GroupService {
     public GroupDetail createGroup(Long hostUserId, CreateGroupRequest request) {
         Book book = bookRepository.findById(request.bookId())
                 .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
-        User host = userRepository.getReferenceById(hostUserId);
+        // 응답(GroupDetail → toDetailResponse)에서 host.getNickname()을 읽으므로 프록시만 채우는
+        // getReferenceById 대신 실제로 초기화된 엔티티를 가져온다. currentUserId는 인증된 사용자지만
+        // 탈퇴 등 경합을 고려해 존재 검증도 함께 한다.
+        User host = userRepository.findById(hostUserId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         Group group = Group.create(
                 request.name(), book, host, request.capacity(), request.startDate(), request.endDate());
@@ -55,7 +61,8 @@ public class GroupService {
     }
 
     public GroupDetail getGroupDetail(Long groupId, Long userId) {
-        Group group = getExistingGroup(groupId);
+        Group group = groupRepository.findByIdWithBookAndHost(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
         validateMember(groupId, userId);
         return new GroupDetail(group, groupMemberRepository.countByGroupId(groupId));
     }

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -9,22 +9,31 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
-    // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다.
+    // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다. book 제목/저자/표지를 응답에
+    // 바로 내려줘야 해서(GroupMapper.toInvitationPreviewResponse) join fetch로 같이 읽는다 — book이
+    // LAZY인 채로 남으면 open-in-view: false 환경에서 컨트롤러 단 접근 시 LazyInitializationException.
+    @Query("select g from Group g join fetch g.book where g.inviteCode = :inviteCode")
     Optional<Group> findByInviteCode(String inviteCode);
+
+    // 모임 상세 조회 전용. GroupMapper.toDetailResponse가 book/host 필드를 컨트롤러 단에서 읽으므로
+    // (findByInviteCode와 같은 이유) join fetch로 함께 로딩한다.
+    @Query("select g from Group g join fetch g.book join fetch g.host where g.id = :groupId")
+    Optional<Group> findByIdWithBookAndHost(Long groupId);
 
     // 가입(join) 전용. 정원 초과 여부를 확인하고 GroupMember를 추가하는 사이 다른 트랜잭션이 끼어들어
     // 정원을 넘기는 것(TOCTOU)을 막기 위해 Group row에 비관적 락을 건다. 같은 모임에 대한 동시 가입
     // 요청은 이 락으로 직렬화되고, 락을 먼저 잡은 트랜잭션이 커밋(또는 롤백)해야 다음 요청이 최신
-    // 참여 인원 수를 보고 진행한다.
+    // 참여 인원 수를 보고 진행한다. 응답에 필요한 book/host도 함께 join fetch한다.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select g from Group g where g.inviteCode = :inviteCode")
+    @Query("select g from Group g join fetch g.book join fetch g.host where g.inviteCode = :inviteCode")
     Optional<Group> findByInviteCodeForUpdate(String inviteCode);
 
     // 방 설정 변경(정원 변경) 전용. findByInviteCodeForUpdate와 같은 Group row 잠금을 공유해야
     // 두 경로가 서로를 배제한다 — 그렇지 않으면 host가 정원을 줄이는 사이 다른 사용자가 가입해
     // "참여 인원 > 정원"인 모임이 만들어질 수 있다(TOCTOU). 다른 PK로 조회해도 잠그는 row가 같으면
-    // DB가 알아서 직렬화하므로, findByInviteCodeForUpdate와 조회 키가 달라도 안전하다.
+    // DB가 알아서 직렬화하므로, findByInviteCodeForUpdate와 조회 키가 달라도 안전하다. 응답에 필요한
+    // book/host도 함께 join fetch한다.
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select g from Group g where g.id = :groupId")
+    @Query("select g from Group g join fetch g.book join fetch g.host where g.id = :groupId")
     Optional<Group> findByIdForUpdate(Long groupId);
 }

--- a/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/application/GroupServiceTest.java
@@ -92,7 +92,7 @@ class GroupServiceTest {
     @DisplayName("모임을 생성하면 host가 모임원으로 함께 저장된다")
     void createGroupSucceeds() {
         given(bookRepository.findById(book.getId())).willReturn(Optional.of(book));
-        given(userRepository.getReferenceById(host.getId())).willReturn(host);
+        given(userRepository.findById(host.getId())).willReturn(Optional.of(host));
 
         GroupDetail detail = groupService.createGroup(host.getId(), createRequest());
 
@@ -115,7 +115,7 @@ class GroupServiceTest {
     @Test
     @DisplayName("존재하지 않는 모임을 조회하면 예외가 발생한다")
     void getGroupDetailFailsWhenNotFound() {
-        given(groupRepository.findById(999L)).willReturn(Optional.empty());
+        given(groupRepository.findByIdWithBookAndHost(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> groupService.getGroupDetail(999L, host.getId())).isInstanceOf(GroupException.class);
     }
@@ -124,7 +124,7 @@ class GroupServiceTest {
     @DisplayName("모임원이 아니면 모임 상세를 조회할 수 없다")
     void getGroupDetailFailsWhenNotMember() {
         Group group = group(1L, host);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findByIdWithBookAndHost(1L)).willReturn(Optional.of(group));
         given(groupMemberRepository.existsByGroupIdAndUserId(1L, other.getId())).willReturn(false);
 
         assertThatThrownBy(() -> groupService.getGroupDetail(1L, other.getId())).isInstanceOf(GroupException.class);
@@ -134,7 +134,7 @@ class GroupServiceTest {
     @DisplayName("모임원이면 모임 상세와 참여 인원 수를 함께 조회한다")
     void getGroupDetailSucceeds() {
         Group group = group(1L, host);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findByIdWithBookAndHost(1L)).willReturn(Optional.of(group));
         given(groupMemberRepository.existsByGroupIdAndUserId(1L, host.getId())).willReturn(true);
         given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
 

--- a/src/test/java/com/nexters/palang/domain/group/presentation/GroupLazyLoadingIntegrationTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/presentation/GroupLazyLoadingIntegrationTest.java
@@ -1,0 +1,162 @@
+package com.nexters.palang.domain.group.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.domain.GroupMember;
+import com.nexters.palang.domain.group.domain.GroupMemberRole;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.group.presentation.dto.CreateGroupRequest;
+import com.nexters.palang.domain.group.presentation.dto.UpdateGroupRequest;
+import com.nexters.palang.domain.user.domain.SnsProvider;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.security.jwt.JwtTokenProvider;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+// open-in-view: false 환경에서 GroupMapper가 Group.book/host(둘 다 LAZY)를 컨트롤러 단에서 참조해
+// LazyInitializationException(500)이 나는지 실제 트랜잭션 경계를 넘는 end-to-end 테스트로 검증한다.
+// (CommentLazyLoadingIntegrationTest와 같은 패턴 — GroupRepository의 join fetch 쿼리
+// (findByIdWithBookAndHost/findByIdForUpdate/findByInviteCodeForUpdate/findByInviteCode)가 없으면
+// 이 테스트들이 실패한다.)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class GroupLazyLoadingIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private GroupMemberRepository groupMemberRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private Long bookId;
+    private Long hostId;
+    private Long otherId;
+
+    @BeforeEach
+    void setUp() {
+        Book book = bookRepository.save(Book.builder()
+                .title("프랑켄슈타인").author("메리 셸리").publisher("문학동네").pageCount(300).build());
+        User host = userRepository.save(User.builder()
+                .nickname("모임장").snsProvider(SnsProvider.KAKAO).snsId("host-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+        User other = userRepository.save(User.builder()
+                .nickname("참여자").snsProvider(SnsProvider.KAKAO).snsId("other-1")
+                .termsAgreedAt(LocalDateTime.now()).build());
+
+        bookId = book.getId();
+        hostId = host.getId();
+        otherId = other.getId();
+    }
+
+    private String bearerToken(Long userId) {
+        return "Bearer " + jwtTokenProvider.createAccessToken(userId);
+    }
+
+    private Group createGroupDirectly() {
+        Book book = bookRepository.findById(bookId).orElseThrow();
+        User host = userRepository.findById(hostId).orElseThrow();
+        Group group = groupRepository.save(Group.create(
+                "고전 뽀개기", book, host, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20)));
+        groupMemberRepository.save(GroupMember.of(group, host, GroupMemberRole.HOST));
+        return group;
+    }
+
+    @Test
+    @DisplayName("모임을 생성하면 host 닉네임과 책 제목이 포함된 응답이 정상적으로 내려온다")
+    void createGroupReturnsHostNicknameAndBookTitle() throws Exception {
+        CreateGroupRequest request = new CreateGroupRequest(
+                "고전 뽀개기", bookId, 4, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20));
+
+        mockMvc.perform(post("/api/groups")
+                        .header("Authorization", bearerToken(hostId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hostNickname").value("모임장"))
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"));
+    }
+
+    @Test
+    @DisplayName("모임 상세를 조회하면 host 닉네임과 책 제목이 포함된 응답이 정상적으로 내려온다")
+    void getGroupDetailReturnsHostNicknameAndBookTitle() throws Exception {
+        Group group = createGroupDirectly();
+
+        mockMvc.perform(get("/api/groups/{groupId}", group.getId())
+                        .header("Authorization", bearerToken(hostId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hostNickname").value("모임장"))
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"));
+    }
+
+    @Test
+    @DisplayName("방 설정을 변경하면 host 닉네임과 책 제목이 포함된 응답이 정상적으로 내려온다")
+    void updateGroupReturnsHostNicknameAndBookTitle() throws Exception {
+        Group group = createGroupDirectly();
+        UpdateGroupRequest request = new UpdateGroupRequest(
+                "주말 독서 모임", 6, LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 27));
+
+        mockMvc.perform(patch("/api/groups/{groupId}", group.getId())
+                        .header("Authorization", bearerToken(hostId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hostNickname").value("모임장"))
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"));
+    }
+
+    @Test
+    @DisplayName("초대 링크로 가입하면 host 닉네임과 책 제목이 포함된 응답이 정상적으로 내려온다")
+    void joinGroupReturnsHostNicknameAndBookTitle() throws Exception {
+        Group group = createGroupDirectly();
+
+        mockMvc.perform(post("/api/groups/invitations/{inviteCode}/join", group.getInviteCode())
+                        .header("Authorization", bearerToken(otherId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hostNickname").value("모임장"))
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"));
+    }
+
+    @Test
+    @DisplayName("초대 링크를 미리보기하면 책 제목이 포함된 응답이 정상적으로 내려온다")
+    void previewInvitationReturnsBookTitle() throws Exception {
+        Group group = createGroupDirectly();
+
+        mockMvc.perform(get("/api/groups/invitations/{inviteCode}", group.getInviteCode()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookTitle").value("프랑켄슈타인"));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionLikeServiceTest.java
@@ -69,7 +69,8 @@ class OpinionLikeServiceTest {
     }
 
     private Opinion opinion(Long id, User owner) {
-        Opinion opinion = Opinion.builder().user(owner).content("흔적 내용").build();
+        Passage passage = Passage.builder().build();
+        Opinion opinion = Opinion.builder().user(owner).passage(passage).content("흔적 내용").build();
         ReflectionTestUtils.setField(opinion, "id", id);
         return opinion;
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #143

## 🚀 개요
모임 생성/상세조회/방 설정 변경/초대 가입/초대 미리보기 API가 응답을 만드는 과정에서
`LazyInitializationException`으로 500을 던지던 문제를 수정합니다. `Group.book`/`Group.host`가
`LAZY` 연관관계인데, `open-in-view: false` 환경에서 컨트롤러 단(트랜잭션 종료 후)의
`GroupMapper`가 이 필드를 읽어 발생하던 문제로, 관련 쿼리에 `join fetch`를 추가해 해결했습니다.

## 📄 작업 내용
- `GroupService.createGroup`: host 조회를 `getReferenceById`(프록시만 채움) 대신
  `findById`로 변경, 존재하지 않으면 `UserException(USER_NOT_FOUND)`
- `GroupRepository`: `findByInviteCode`, `findByIdForUpdate`, `findByInviteCodeForUpdate`에
  `join fetch g.book`(/`g.host`) 추가, 모임 상세 조회 전용 `findByIdWithBookAndHost` 신설
- `GroupService.getGroupDetail`이 새 `findByIdWithBookAndHost`를 사용하도록 변경
- `GroupLazyLoadingIntegrationTest` 신규 추가: `open-in-view: false` 환경에서 실제 트랜잭션
  경계를 넘는 end-to-end 테스트로 모임 생성/상세조회/방설정변경/가입/초대미리보기 5개 경로 모두
  검증 (`CommentLazyLoadingIntegrationTest`와 동일 패턴)
- `GroupServiceTest`: 변경된 리포지토리 메서드에 맞춰 스텁 수정

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew compileJava compileTestJava` 통과
- 로컬 MySQL로 `GroupServiceTest`, `GroupControllerTest`, `GroupLazyLoadingIntegrationTest`,
  `GroupTest` 전부 통과 확인
- 수정 전(`join fetch` 제거) 상태로 동일 테스트를 돌려 실제로 500이 재현되는 것까지 확인 후 수정 진행함
<img width="818" height="626" alt="image" src="https://github.com/user-attachments/assets/1d02e988-190c-4c3e-aa0d-cefb2908d7f6" />

> 실제 Swagger test 진행, 200 반환

## ✅ 체크리스트
- [ ] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `findByIdForUpdate`/`findByInviteCodeForUpdate`(비관적 락 쿼리)에 `join fetch`를 같이 걸어서,
  `SELECT ... FOR UPDATE`가 `book`/`host`(User) row까지 함께 잠그는 문제를 고려해야함.