### PR TITLE
Chore/#145 CI Docker 빌드 이중 컴파일 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
           path: build/reports/tests/test
           retention-days: 5
 
+      # Docker의 builder 스테이지(Gradle 컴파일)를 CI에서 또 돌리면 위의 "Build and run tests"와
+      # 완전히 같은 컴파일이 중복 실행된다. 이미 만들어진 jar를 builder 스테이지 결과물 자리에
+      # 대신 채워 넣어(--build-context로 builder 스테이지 자체를 치환) 재컴파일을 건너뛴다.
+      # Dockerfile 구조는 그대로이므로 실제 배포 이미지를 빌드하는 cd.yml은 영향받지 않고 전체 빌드를 그대로 수행한다.
+      - name: Prepare pre-built jar for Docker builder-stage override
+        run: |
+          mkdir -p docker-builder-context/workspace/build/libs
+          cp build/libs/*.jar docker-builder-context/workspace/build/libs/
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -85,6 +94,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-contexts: |
+            builder=docker-builder-context
           push: false
           tags: pallang-ci-check:${{ github.sha }}
           cache-from: type=gha

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+docker-builder-context/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/


### PR DESCRIPTION
## 📌 관련 이슈
- Close #145

## 🚀 개요
CI의 "Verify Docker image builds" 스텝이 12분 36초로 CI 전체 시간의 대부분을 차지하던 문제를, Gradle 이중 컴파일을 제거해서 줄입니다.

## 📄 작업 내용
- `.github/workflows/ci.yml`: "Build and run tests"에서 이미 만든 jar를 `docker-builder-context/workspace/build/libs/`에 복사한 뒤, `docker/build-push-action`에 `build-contexts: builder=docker-builder-context`를 추가해 Docker `builder` 스테이지(Gradle 재컴파일)를 이 사전 빌드 jar로 대체
- `Dockerfile`은 변경하지 않음 — `cd.yml`의 실제 배포 이미지 빌드는 지금처럼 `builder`/`runtime` 풀 멀티스테이지 빌드를 그대로 수행
- `.gitignore`에 `docker-builder-context/` 추가

## 📸 스크린샷 / 테스트 결과 (선택)
- 로컬에서 `./gradlew bootJar -x test` 실행 결과 `build/libs/`에 jar가 정확히 1개(`palang-0.0.1-SNAPSHOT.jar`)만 생성되는 것을 확인 — `Dockerfile`의 `COPY --from=builder /workspace/build/libs/*.jar app.jar` 와일드카드-단일파일 매칭 전제가 깨지지 않음

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 이 PR의 CI 실행에서 "Verify Docker image builds" 스텝이 실제로 12분대에서 얼마나 줄었는지 확인 예정