### PR TITLE
Feat/#147 모임 상세 조회 응답에 isHost 필드 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
@@ -20,14 +20,14 @@ public final class GroupMapper {
     private GroupMapper() {
     }
 
-    public static GroupDetailResponse toDetailResponse(GroupDetail detail) {
+    public static GroupDetailResponse toDetailResponse(GroupDetail detail, Long currentUserId) {
         Group group = detail.group();
         Book book = group.getBook();
         User host = group.getHost();
         return new GroupDetailResponse(
                 group.getId(), group.getName(), book.getId(), book.getTitle(), book.getAuthor(), book.getCoverImageUrl(),
                 host.getId(), host.getNickname(), group.getCapacity(), detail.memberCount(),
-                group.getStartDate(), group.getEndDate(), group.isEnded());
+                group.getStartDate(), group.getEndDate(), group.isEnded(), host.getId().equals(currentUserId));
     }
 
     public static GroupSummaryResponse toSummaryResponse(GroupSummaryProjection projection) {

--- a/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/GroupController.java
@@ -43,7 +43,7 @@ public class GroupController implements GroupApi {
     public ResponseEntity<DataResponse<GroupDetailResponse>> createGroup(@Valid @RequestBody CreateGroupRequest request) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         GroupDetail detail = groupService.createGroup(currentUserId, request);
-        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail, currentUserId)));
     }
 
     @Override
@@ -61,7 +61,7 @@ public class GroupController implements GroupApi {
     public ResponseEntity<DataResponse<GroupDetailResponse>> getGroupDetail(@PathVariable Long groupId) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         GroupDetail detail = groupService.getGroupDetail(groupId, currentUserId);
-        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail, currentUserId)));
     }
 
     @Override
@@ -70,7 +70,7 @@ public class GroupController implements GroupApi {
             @PathVariable Long groupId, @RequestBody @Valid UpdateGroupRequest request) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         GroupDetail detail = groupService.updateGroup(groupId, currentUserId, request);
-        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail, currentUserId)));
     }
 
     @Override
@@ -121,7 +121,7 @@ public class GroupController implements GroupApi {
     public ResponseEntity<DataResponse<GroupDetailResponse>> joinGroup(@PathVariable String inviteCode) {
         Long currentUserId = currentUserProvider.getCurrentUserId();
         GroupDetail detail = groupService.joinGroup(inviteCode, currentUserId);
-        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail)));
+        return ResponseEntity.ok(DataResponse.from(GroupMapper.toDetailResponse(detail, currentUserId)));
     }
 
     private Pageable pageable(int page, int size) {

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupDetailResponse.java
@@ -18,6 +18,9 @@ public record GroupDetailResponse(
         @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
         @Schema(example = "false", description = "종료일이 지났는지 여부. 안내용 배지 표시에만 쓰이며, "
                 + "이 값이 true여도 모임 목록 노출/흔적·의견 작성 등은 계속 가능합니다.",
-                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended,
+        @Schema(example = "true", description = "현재 로그인한 유저가 이 모임의 모임장인지 여부. "
+                + "방 설정 변경 등 모임장 전용 화면 노출 여부를 프론트에서 판단하는 데 사용합니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean isHost
 ) {
 }

--- a/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
@@ -97,7 +97,8 @@ class GroupControllerTest {
                         .content(objectMapper.writeValueAsString(createRequest())))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.groupId").value(1))
-                .andExpect(jsonPath("$.data.memberCount").value(1));
+                .andExpect(jsonPath("$.data.memberCount").value(1))
+                .andExpect(jsonPath("$.data.isHost").value(true));
     }
 
     @Test
@@ -142,7 +143,20 @@ class GroupControllerTest {
 
         mockMvc.perform(get("/api/groups/1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.memberCount").value(2));
+                .andExpect(jsonPath("$.data.memberCount").value(2))
+                .andExpect(jsonPath("$.data.isHost").value(true));
+    }
+
+    @Test
+    @DisplayName("모임장이 아닌 모임원이 상세 조회하면 isHost는 false다")
+    void getGroupDetail_whenNotHost_thenIsHostFalse() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(2L);
+        Group group = group(1L, user(1L));
+        given(groupService.getGroupDetail(1L, 2L)).willReturn(new GroupDetail(group, 2L));
+
+        mockMvc.perform(get("/api/groups/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isHost").value(false));
     }
 
     @Test
@@ -179,7 +193,8 @@ class GroupControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateRequest())))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.name").value("주말 독서 모임"));
+                .andExpect(jsonPath("$.data.name").value("주말 독서 모임"))
+                .andExpect(jsonPath("$.data.isHost").value(true));
     }
 
     @Test
@@ -312,7 +327,8 @@ class GroupControllerTest {
 
         mockMvc.perform(post("/api/groups/invitations/" + group.getInviteCode() + "/join"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.memberCount").value(2));
+                .andExpect(jsonPath("$.data.memberCount").value(2))
+                .andExpect(jsonPath("$.data.isHost").value(false));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #147

## 🚀 개요
> 모임 상세 조회 API 응답에 현재 로그인 유저가 해당 모임의 모임장인지 여부(`isHost`)를 추가합니다. 프론트가 `hostUserId`와 자신의 uid를 직접 비교하지 않고도 "방 설정 변경" 등 모임장 전용 화면 접근 여부를 바로 판단할 수 있도록 하기 위함입니다. (실제 수정 API는 기존에도 `validateHost`로 정상 보호되고 있어 보안 이슈는 아니었습니다.)

## 📄 작업 내용
- `GroupDetailResponse`에 `isHost` 필드 추가 (`@Schema` 설명 포함)
- `GroupMapper.toDetailResponse`가 `currentUserId`를 받아 `host.getId().equals(currentUserId)`로 `isHost`를 계산하도록 시그니처 변경
- `GroupController`의 4개 호출부(`createGroup`, `getGroupDetail`, `updateGroup`, `joinGroup`) 모두 변경된 시그니처로 갱신
- `GroupControllerTest`: 기존 테스트에 `isHost` 검증 추가, 모임원이 조회할 때 `isHost: false`가 되는 케이스 신규 추가

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/groups/{groupId}` | 응답에 `isHost` 필드 추가 |
| POST | `/api/groups` | 응답에 `isHost` 필드 추가 (항상 true) |
| PATCH | `/api/groups/{groupId}` | 응답에 `isHost` 필드 추가 (항상 true) |
| POST | `/api/groups/invitations/{inviteCode}/join` | 응답에 `isHost` 필드 추가 |

## 📸 스크린샷 / 테스트 결과 (선택)
`./gradlew test --tests "com.nexters.palang.domain.group.presentation.GroupControllerTest" --tests "com.nexters.palang.domain.group.application.GroupServiceTest"` 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `isHost`를 상세 조회 응답에만 추가했는데, 목록 조회(`GroupSummaryResponse`)에도 필요한지는 후속 확인이 필요합니다 (모임 카드의 "더보기" 시트에서 모임장 전용 항목을 노출하는 흐름이라면 목록 응답에도 필요 — 별도 후속 작업으로 진행 예정).
- `createGroup`/`updateGroup`/`joinGroup` 응답에서는 `isHost`가 항상 고정값(true/false)으로 나오는데, 이 필드를 굳이 넣을 필요가 있는지 의견 부탁드립니다.
