### PR TITLE
Feat/#147 모임 목록 조회 응답에 isHost 필드 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupMapper.java
@@ -35,7 +35,7 @@ public final class GroupMapper {
         return new GroupSummaryResponse(
                 projection.groupId(), projection.name(), projection.bookId(), projection.bookTitle(),
                 projection.bookCoverImageUrl(), projection.memberCount(), projection.capacity(),
-                projection.startDate(), projection.endDate(), ended);
+                projection.startDate(), projection.endDate(), ended, projection.isHost());
     }
 
     public static GroupListResponse toListResponse(Page<GroupSummaryProjection> page) {

--- a/src/main/java/com/nexters/palang/domain/group/application/GroupSummaryProjection.java
+++ b/src/main/java/com/nexters/palang/domain/group/application/GroupSummaryProjection.java
@@ -12,6 +12,7 @@ public record GroupSummaryProjection(
         long memberCount,
         int capacity,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        boolean isHost
 ) {
 }

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepository.java
@@ -65,10 +65,12 @@ public class GroupQueryRepository {
         List<GroupSummaryProjection> content = groupIds.stream()
                 .map(groupsById::get)
                 .filter(Objects::nonNull)
+                // host는 fetch join 대상이 아니라 LAZY 프록시지만, id만 읽는 건 프록시 초기화 없이도
+                // 안전하다(식별자는 프록시 생성 시점에 이미 채워져 있음) — LazyInitializationException 걱정 없다.
                 .map(g -> new GroupSummaryProjection(
                         g.getId(), g.getName(), g.getBook().getId(), g.getBook().getTitle(),
                         g.getBook().getCoverImageUrl(), memberCountsByGroupId.getOrDefault(g.getId(), 0L),
-                        g.getCapacity(), g.getStartDate(), g.getEndDate()))
+                        g.getCapacity(), g.getStartDate(), g.getEndDate(), g.getHost().getId().equals(userId)))
                 .toList();
 
         long total = countMyGroups(userId);

--- a/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/group/presentation/dto/GroupSummaryResponse.java
@@ -15,6 +15,10 @@ public record GroupSummaryResponse(
         @Schema(example = "2026-09-20", requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
         @Schema(example = "false", description = "종료일이 지났는지 여부. 안내용 배지 표시에만 쓰이며, "
                 + "이 값이 true여도 모임 목록 노출/흔적·의견 작성 등은 계속 가능합니다.",
-                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean ended,
+        @Schema(example = "true", description = "현재 로그인한 유저가 이 모임의 모임장인지 여부. "
+                + "모임 카드의 '더보기' 메뉴에서 모임장 전용 항목(방 설정 변경 등) 노출 여부를 "
+                + "프론트에서 판단하는 데 사용합니다.",
+                requiredMode = Schema.RequiredMode.REQUIRED) boolean isHost
 ) {
 }

--- a/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/infrastructure/GroupQueryRepositoryTest.java
@@ -87,6 +87,8 @@ class GroupQueryRepositoryTest {
                 .containsExactly(myGroup2.getId(), myGroup1.getId());
         assertThat(result.getContent().get(0).memberCount()).isEqualTo(2L);
         assertThat(result.getContent().get(1).memberCount()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).isHost()).isFalse(); // myGroup2는 other가 host, me는 member
+        assertThat(result.getContent().get(1).isHost()).isTrue(); // myGroup1은 me가 host
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
+++ b/src/test/java/com/nexters/palang/domain/group/presentation/GroupControllerTest.java
@@ -16,6 +16,7 @@ import com.nexters.palang.domain.book.domain.BookSource;
 import com.nexters.palang.domain.group.application.GroupDetail;
 import com.nexters.palang.domain.group.application.GroupInvitationPreview;
 import com.nexters.palang.domain.group.application.GroupService;
+import com.nexters.palang.domain.group.application.GroupSummaryProjection;
 import com.nexters.palang.domain.group.common.error.GroupErrorCode;
 import com.nexters.palang.domain.group.common.error.GroupException;
 import com.nexters.palang.domain.group.domain.Group;
@@ -132,6 +133,25 @@ class GroupControllerTest {
         given(groupService.getMyGroups(eq(1L), any())).willReturn(new PageImpl<>(List.of(), DEFAULT_PAGEABLE, 0));
 
         mockMvc.perform(get("/api/groups")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("모임 목록 조회 응답에는 모임별 isHost 여부가 포함된다")
+    void getMyGroups_includesIsHostPerGroup() throws Exception {
+        given(currentUserProvider.getCurrentUserId()).willReturn(1L);
+        GroupSummaryProjection hostedGroup = new GroupSummaryProjection(
+                1L, "고전 뽀개기", 1L, "채식주의자", null, 1L, 4,
+                LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20), true);
+        GroupSummaryProjection joinedGroup = new GroupSummaryProjection(
+                2L, "주말 독서 모임", 2L, "소년이 온다", null, 2L, 4,
+                LocalDate.of(2026, 8, 20), LocalDate.of(2026, 9, 20), false);
+        given(groupService.getMyGroups(eq(1L), any()))
+                .willReturn(new PageImpl<>(List.of(hostedGroup, joinedGroup), DEFAULT_PAGEABLE, 2));
+
+        mockMvc.perform(get("/api/groups"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.groups[0].isHost").value(true))
+                .andExpect(jsonPath("$.data.groups[1].isHost").value(false));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- Close #147

## 🚀 개요
> #148(상세 조회 응답 `isHost` 추가, merged)의 후속 작업 

실제로 그룹 설정 변경 진입점이 상세 화면이 아니라 모임 목록 카드의 `...` → "더보기" 시트(초대 링크 보내기 / 방 설정 변경하기)라는 게 확인되어, 목록 조회 응답(`GroupSummaryResponse`)에도 `isHost`를 추가합니다. 프론트가 이 값으로 시트 안의 모임장 전용 항목 노출 여부를 판단할 수 있습니다.

## 📄 작업 내용
- `GroupSummaryResponse`/`GroupSummaryProjection`에 `isHost` 필드 추가 (`@Schema` 설명 포함)
- `GroupQueryRepository.findMyGroups`에서 `g.getHost().getId().equals(userId)`로 `isHost` 계산 (host는 fetch join 대상이 아닌 LAZY 프록시지만, id만 읽는 건 프록시 초기화 없이 안전 — 추가 쿼리/LazyInitializationException 없음)
- `GroupMapper.toSummaryResponse`가 projection의 `isHost`를 그대로 응답에 전달하도록 갱신
- `GroupControllerTest`/`GroupQueryRepositoryTest`: 모임별로 `isHost`가 다르게 나오는 케이스 신규 추가

| Method | Path | 설명 |
|---|---|---|
| GET | `/api/groups` | 모임별 응답에 `isHost` 필드 추가 |

## 📸 스크린샷 / 테스트 결과 (선택)
`./gradlew test --tests "com.nexters.palang.domain.group.presentation.GroupControllerTest" --tests "com.nexters.palang.domain.group.infrastructure.GroupQueryRepositoryTest"` 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
프론트 수정까지 확인 예정