### PR TITLE
Deploy/#150 Dev MySQL 컨테이너 로컬 포트 바인딩 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
       - --default-time-zone=+09:00
+    # SSH 터널 경유 GUI 클라이언트(DataGrip 등) 접속용. 루프백에만 바인딩해 외부 노출은 막는다.
+    ports:
+      - "127.0.0.1:3306:3306"
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #150

## 🚀 개요
Dev 서버 MySQL 컨테이너에 루프백 전용 포트 바인딩을 추가해, SSH 터널 경유로 DataGrip 등 GUI 클라이언트에서 접속할 수 있게 합니다.

## 📄 작업 내용
- `docker-compose.yml` mysql 서비스에 `ports: "127.0.0.1:3306:3306"` 추가 (127.0.0.1 루프백만 바인딩해 외부 노출 방지)
- named volume(`mysql-data:/var/lib/mysql`)은 기존에 이미 적용되어 있어 추가 조치 없음
- DB 스키마 변경 없음 (인프라 설정만 변경)

## 📸 스크린샷 / 테스트 결과 (선택)
- 코드 변경 범위가 compose 설정 1줄이라 `./gradlew test`는 별도로 돌리지 않았습니다. Dev 서버 반영 후 `docker compose up -d`로 재생성하고 SSH 터널 경유 접속 확인이 필요합니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [ ] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [ ] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 이슈에 적힌 선행 이슈(SSH 터널 `Connection refused`)가 아직 해결 전이라, 서버 내부 방화벽/sshd 점검이 먼저 되어야 이 변경의 효과를 확인할 수 있습니다.
- `'pallang'@'%'` 계정 및 권한이 터널 경유 원격 접속을 허용하는지는 Dev 서버에서 별도 확인이 필요합니다 (이 PR 범위 밖).