### PR TITLE
Feat/#153 신규 가입 계정 마이페이지/서재 샘플 데이터 노출

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -132,22 +132,37 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
-    // 비로그인 사용자와, 로그인했지만 서재에 책이 하나도 없는 신규 가입 계정은 홈에서 실제 서재 대신 고정
-    // 샘플 도서 1건을 본다 (기획 확정, 이슈 #119).
+    // 비로그인 사용자와, 로그인했지만 서재에 책이 하나도 없는 계정은 홈에서 실제 서재 대신 고정 샘플 도서
+    // 1건을 본다 (기획 확정, 이슈 #119). opinionCountScope=MINE(마이페이지, 본인이 남긴 흔적 수)일 때 책
+    // 전체 흔적 수(17)를 그대로 노출하면 "내가 남긴 흔적 수"가 17인 것처럼 잘못 보이므로, scope별로 값이
+    // 다른 고정 projection을 따로 둔다.
     private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK = new BookActivityProjection(
             18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
             "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 17L);
+    private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK_MINE = new BookActivityProjection(
+            18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
+            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 0L);
 
     // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열하며, 표준 page/size 페이지네이션을 사용한다.
     public Page<BookActivityProjection> getMyLibraryBooks(Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
         if (userId == null) {
-            return new PageImpl<>(List.of(GUEST_SAMPLE_LIBRARY_BOOK), pageable, 1);
+            return sampleLibraryPage(pageable, opinionCountScope);
         }
         Page<BookActivityProjection> myLibraryBooks = bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
         if (myLibraryBooks.getTotalElements() == 0) {
-            return new PageImpl<>(List.of(GUEST_SAMPLE_LIBRARY_BOOK), pageable, 1);
+            return sampleLibraryPage(pageable, opinionCountScope);
         }
         return myLibraryBooks;
+    }
+
+    // 샘플 도서는 실제로는 1건뿐이므로 첫 페이지(offset 0)에서만 내려주고, 이후 페이지는 빈 목록을 반환한다.
+    // 그렇지 않으면 요청한 모든 페이지에서 같은 샘플 도서가 계속 반복 노출된다.
+    private Page<BookActivityProjection> sampleLibraryPage(Pageable pageable, OpinionCountScope opinionCountScope) {
+        BookActivityProjection sample = opinionCountScope == OpinionCountScope.MINE
+                ? GUEST_SAMPLE_LIBRARY_BOOK_MINE
+                : GUEST_SAMPLE_LIBRARY_BOOK;
+        List<BookActivityProjection> content = pageable.getOffset() == 0 ? List.of(sample) : List.of();
+        return new PageImpl<>(content, pageable, 1);
     }
 
     public Page<Book> getRecentBooks(Long userId, String keyword, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -132,7 +132,8 @@ public class BookService {
         return Math.max(0, (total - size) / 2);
     }
 
-    // 비로그인 사용자는 홈에서 실제 서재 대신 고정 샘플 도서 1건을 본다 (기획 확정, 이슈 #119).
+    // 비로그인 사용자와, 로그인했지만 서재에 책이 하나도 없는 신규 가입 계정은 홈에서 실제 서재 대신 고정
+    // 샘플 도서 1건을 본다 (기획 확정, 이슈 #119).
     private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK = new BookActivityProjection(
             18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
             "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 17L);
@@ -142,7 +143,11 @@ public class BookService {
         if (userId == null) {
             return new PageImpl<>(List.of(GUEST_SAMPLE_LIBRARY_BOOK), pageable, 1);
         }
-        return bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
+        Page<BookActivityProjection> myLibraryBooks = bookQueryRepository.findMyLibraryBooks(userId, pageable, opinionCountScope);
+        if (myLibraryBooks.getTotalElements() == 0) {
+            return new PageImpl<>(List.of(GUEST_SAMPLE_LIBRARY_BOOK), pageable, 1);
+        }
+        return myLibraryBooks;
     }
 
     public Page<Book> getRecentBooks(Long userId, String keyword, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -114,8 +114,8 @@ public interface BookApi {
                     + "가장 최근에 흔적을 남긴 도서부터 내림차순으로 정렬됩니다. opinionCountScope로 흔적 수 집계 "
                     + "기준을 선택할 수 있습니다: ALL(기본값, 도서 전체 흔적 수 - 홈 화면 노출용) 또는 "
                     + "MINE(로그인 사용자 본인이 남긴 흔적 수 - 마이페이지 노출용). "
-                    + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없으면(비로그인) 샘플 도서 1건을 "
-                    + "고정 응답으로 반환합니다.")
+                    + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없거나(비로그인), 로그인했지만 "
+                    + "서재에 책이 하나도 없는 신규 가입 계정이면 샘플 도서 1건을 고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
+++ b/src/main/java/com/nexters/palang/domain/book/presentation/BookApi.java
@@ -115,7 +115,7 @@ public interface BookApi {
                     + "기준을 선택할 수 있습니다: ALL(기본값, 도서 전체 흔적 수 - 홈 화면 노출용) 또는 "
                     + "MINE(로그인 사용자 본인이 남긴 흔적 수 - 마이페이지 노출용). "
                     + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없거나(비로그인), 로그인했지만 "
-                    + "서재에 책이 하나도 없는 신규 가입 계정이면 샘플 도서 1건을 고정 응답으로 반환합니다.")
+                    + "서재에 책이 하나도 없는 계정이면 샘플 도서 1건을 고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -167,12 +167,16 @@ public class OpinionService {
         return existing;
     }
 
-    // 비로그인 사용자는 마이페이지 미리보기로 샘플 계정(GuestSampleAccount)의 실제 흔적을 본다
-    // (기획 확정, 이슈 #120). 이 계정과 그 계정의 흔적/꾸밈은 OpinionGuestSampleSeedRunner가 앱 기동
-    // 시 미리 만들어둔다 — 하드코딩 대신 실데이터를 재사용해야 상세 화면의 Decoration(밑줄/동그라미 등)도
-    // 자연스럽게 함께 보인다. 씨딩 전이거나 실패한 환경(로컬 등)에서는 빈 목록을 반환한다.
+    // 비로그인 사용자와, 로그인했지만 아직 남긴 흔적이 하나도 없는 신규 가입 계정은 마이페이지 미리보기로
+    // 샘플 계정(GuestSampleAccount)의 실제 흔적을 본다 (기획 확정, 이슈 #120). 이 계정과 그 계정의
+    // 흔적/꾸밈은 OpinionGuestSampleSeedRunner가 앱 기동 시 미리 만들어둔다 — 하드코딩 대신 실데이터를
+    // 재사용해야 상세 화면의 Decoration(밑줄/동그라미 등)도 자연스럽게 함께 보인다. 씨딩 전이거나 실패한
+    // 환경(로컬 등)에서는 빈 목록을 반환한다. bookId로 필터링해서 우연히 결과가 0건인 경우(다른 책에는
+    // 흔적이 있음)와 구분하기 위해, "흔적이 하나도 없다"는 판단은 bookId 필터 없이 전체 기준으로 한다.
     public Page<MyOpinionProjection> getMyOpinions(Long userId, Long bookId, Pageable pageable) {
-        if (userId == null) {
+        boolean isNewAccountWithNoOpinions =
+                userId != null && opinionRepository.countByUserIdAndDeletedAtIsNull(userId) == 0;
+        if (userId == null || isNewAccountWithNoOpinions) {
             return userRepository
                     .findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID)
                     .map(sampleUser -> opinionQueryRepository.findMyOpinions(sampleUser.getId(), bookId, pageable))

--- a/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/application/OpinionService.java
@@ -167,16 +167,16 @@ public class OpinionService {
         return existing;
     }
 
-    // 비로그인 사용자와, 로그인했지만 아직 남긴 흔적이 하나도 없는 신규 가입 계정은 마이페이지 미리보기로
-    // 샘플 계정(GuestSampleAccount)의 실제 흔적을 본다 (기획 확정, 이슈 #120). 이 계정과 그 계정의
-    // 흔적/꾸밈은 OpinionGuestSampleSeedRunner가 앱 기동 시 미리 만들어둔다 — 하드코딩 대신 실데이터를
-    // 재사용해야 상세 화면의 Decoration(밑줄/동그라미 등)도 자연스럽게 함께 보인다. 씨딩 전이거나 실패한
-    // 환경(로컬 등)에서는 빈 목록을 반환한다. bookId로 필터링해서 우연히 결과가 0건인 경우(다른 책에는
-    // 흔적이 있음)와 구분하기 위해, "흔적이 하나도 없다"는 판단은 bookId 필터 없이 전체 기준으로 한다.
+    // 비로그인 사용자와, 로그인했지만 남긴 흔적이 (지금 시점 기준으로) 하나도 없는 계정은 마이페이지
+    // 미리보기로 샘플 계정(GuestSampleAccount)의 실제 흔적을 본다 (기획 확정, 이슈 #120). 이 계정과 그
+    // 계정의 흔적/꾸밈은 OpinionGuestSampleSeedRunner가 앱 기동 시 미리 만들어둔다 — 하드코딩 대신
+    // 실데이터를 재사용해야 상세 화면의 Decoration(밑줄/동그라미 등)도 자연스럽게 함께 보인다. 씨딩 전이거나
+    // 실패한 환경(로컬 등)에서는 빈 목록을 반환한다. bookId로 필터링해서 우연히 결과가 0건인 경우(다른
+    // 책에는 흔적이 있음)와 구분하기 위해, "흔적이 하나도 없다"는 판단은 bookId 필터 없이 전체 기준으로 한다.
     public Page<MyOpinionProjection> getMyOpinions(Long userId, Long bookId, Pageable pageable) {
-        boolean isNewAccountWithNoOpinions =
+        boolean hasNoRealOpinions =
                 userId != null && opinionRepository.countByUserIdAndDeletedAtIsNull(userId) == 0;
-        if (userId == null || isNewAccountWithNoOpinions) {
+        if (userId == null || hasNoRealOpinions) {
             return userRepository
                     .findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID)
                     .map(sampleUser -> opinionQueryRepository.findMyOpinions(sampleUser.getId(), bookId, pageable))

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -147,7 +147,7 @@ public interface UserApi {
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
             + "bookId를 지정하면 해당 책의 흔적만 조회합니다(내 서재 책 상세 - 의견 탭). 생략하면 전체 책을 대상으로 합니다. "
             + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없거나(비로그인), 로그인했지만 남긴 "
-            + "흔적이 하나도 없는 신규 가입 계정이면 샘플 흔적 목록을 고정 응답으로 반환합니다.")
+            + "흔적이 하나도 없는 계정이면 샘플 흔적 목록을 고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
+++ b/src/main/java/com/nexters/palang/domain/user/presentation/UserApi.java
@@ -146,8 +146,8 @@ public interface UserApi {
 
     @Operation(summary = "내가 남긴 흔적 목록", description = "내가 작성한 흔적을 최신순으로 조회합니다. "
             + "bookId를 지정하면 해당 책의 흔적만 조회합니다(내 서재 책 상세 - 의견 탭). 생략하면 전체 책을 대상으로 합니다. "
-            + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없으면(비로그인) 샘플 흔적 목록을 "
-            + "고정 응답으로 반환합니다.")
+            + "인증 불필요. Authorization: Bearer {accessToken} 헤더가 없거나(비로그인), 로그인했지만 남긴 "
+            + "흔적이 하나도 없는 신규 가입 계정이면 샘플 흔적 목록을 고정 응답으로 반환합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "400", description = "page/size 형식 오류 (COMMON_400_1)",

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -412,8 +412,8 @@ class BookServiceTest {
     }
 
     @Test
-    @DisplayName("로그인했지만 서재에 책이 하나도 없는 신규 가입 계정이 조회하면 고정 샘플 도서 1건을 반환한다")
-    void getMyLibraryBooksReturnsSampleWhenNewAccountWithNoBooks() {
+    @DisplayName("로그인했지만 서재에 책이 하나도 없는 계정이 조회하면 고정 샘플 도서 1건을 반환한다")
+    void getMyLibraryBooksReturnsSampleWhenAccountHasNoBooks() {
         Pageable pageable = PageRequest.of(0, 20);
         given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.ALL))
                 .willReturn(new PageImpl<>(List.of(), pageable, 0));
@@ -423,6 +423,44 @@ class BookServiceTest {
         assertThat(results.getTotalElements()).isEqualTo(1);
         assertThat(results.getContent().get(0).bookId()).isEqualTo(18L);
         assertThat(results.getContent().get(0).title()).isEqualTo("빵충 사육 준수 사항");
+    }
+
+    @Test
+    @DisplayName("서재가 비어 있는 계정이 opinionCountScope=MINE으로 조회하면 샘플 도서의 내 흔적 수는 0이다")
+    void getMyLibraryBooksReturnsSampleWithZeroOpinionCountForMineScope() {
+        Pageable pageable = PageRequest.of(0, 20);
+        given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.MINE))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.MINE);
+
+        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent().get(0).bookId()).isEqualTo(18L);
+        assertThat(results.getContent().get(0).opinionCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("서재가 비어 있어도 첫 페이지가 아니면 샘플 도서를 반복해서 반환하지 않는다")
+    void getMyLibraryBooksDoesNotRepeatSampleOnLaterPages() {
+        Pageable secondPage = PageRequest.of(1, 20);
+        given(bookQueryRepository.findMyLibraryBooks(10L, secondPage, OpinionCountScope.ALL))
+                .willReturn(new PageImpl<>(List.of(), secondPage, 0));
+
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, secondPage, OpinionCountScope.ALL);
+
+        assertThat(results.getContent()).isEmpty();
+        assertThat(results.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자도 첫 페이지가 아니면 샘플 도서를 반복해서 반환하지 않는다")
+    void getMyLibraryBooksDoesNotRepeatSampleOnLaterPagesWhenGuest() {
+        Pageable secondPage = PageRequest.of(1, 20);
+
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(null, secondPage, OpinionCountScope.ALL);
+
+        assertThat(results.getContent()).isEmpty();
+        assertThat(results.getTotalElements()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -390,7 +390,8 @@ class BookServiceTest {
     @DisplayName("내 서재 조회는 opinionCountScope가 MINE이어도 그대로 리포지토리에 위임한다")
     void getMyLibraryBooksDelegatesMineScopeToRepository() {
         Pageable pageable = PageRequest.of(1, 20);
-        Page<BookActivityProjection> expected = new PageImpl<>(List.of(), pageable, 0);
+        Page<BookActivityProjection> expected = new PageImpl<>(
+                List.of(new BookActivityProjection(1L, "책1", "작가", "출판사", "cover", 5, 0)), pageable, 21);
         given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.MINE)).willReturn(expected);
 
         Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.MINE);
@@ -404,6 +405,20 @@ class BookServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
 
         Page<BookActivityProjection> results = bookService.getMyLibraryBooks(null, pageable, OpinionCountScope.ALL);
+
+        assertThat(results.getTotalElements()).isEqualTo(1);
+        assertThat(results.getContent().get(0).bookId()).isEqualTo(18L);
+        assertThat(results.getContent().get(0).title()).isEqualTo("빵충 사육 준수 사항");
+    }
+
+    @Test
+    @DisplayName("로그인했지만 서재에 책이 하나도 없는 신규 가입 계정이 조회하면 고정 샘플 도서 1건을 반환한다")
+    void getMyLibraryBooksReturnsSampleWhenNewAccountWithNoBooks() {
+        Pageable pageable = PageRequest.of(0, 20);
+        given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.ALL))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.ALL);
 
         assertThat(results.getTotalElements()).isEqualTo(1);
         assertThat(results.getContent().get(0).bookId()).isEqualTo(18L);

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -460,7 +460,7 @@ class OpinionServiceTest {
     }
 
     @Test
-    @DisplayName("로그인했지만 남긴 흔적이 하나도 없는 신규 가입 계정이 조회하면 샘플 계정의 실제 흔적을 반환한다")
+    @DisplayName("로그인했지만 남긴 흔적이 하나도 없는 계정이 조회하면 샘플 계정의 실제 흔적을 반환한다")
     void getMyOpinionsReturnsSampleAccountOpinionsWhenNewAccountWithNoOpinions() {
         Pageable pageable = PageRequest.of(0, 20);
         User sampleUser = User.builder()

--- a/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/application/OpinionServiceTest.java
@@ -428,6 +428,7 @@ class OpinionServiceTest {
         Page<MyOpinionProjection> expected = new PageImpl<>(
                 List.of(new MyOpinionProjection(1L, 10L, "제목", "작가", "cover", 100L, "발췌", 5, "흔적", 0, LocalDateTime.now())),
                 pageable, 1);
+        given(opinionRepository.countByUserIdAndDeletedAtIsNull(1L)).willReturn(1L);
         given(opinionQueryRepository.findMyOpinions(1L, null, pageable)).willReturn(expected);
 
         Page<MyOpinionProjection> results = opinionService.getMyOpinions(1L, null, pageable);
@@ -454,6 +455,30 @@ class OpinionServiceTest {
         given(opinionQueryRepository.findMyOpinions(999L, null, pageable)).willReturn(expected);
 
         Page<MyOpinionProjection> results = opinionService.getMyOpinions(null, null, pageable);
+
+        assertThat(results).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("로그인했지만 남긴 흔적이 하나도 없는 신규 가입 계정이 조회하면 샘플 계정의 실제 흔적을 반환한다")
+    void getMyOpinionsReturnsSampleAccountOpinionsWhenNewAccountWithNoOpinions() {
+        Pageable pageable = PageRequest.of(0, 20);
+        User sampleUser = User.builder()
+                .nickname(GuestSampleAccount.NICKNAME)
+                .snsProvider(GuestSampleAccount.SNS_PROVIDER)
+                .snsId(GuestSampleAccount.SNS_ID)
+                .build();
+        ReflectionTestUtils.setField(sampleUser, "id", 999L);
+        Page<MyOpinionProjection> expected = new PageImpl<>(
+                List.of(new MyOpinionProjection(1L, 18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "cover", 100L, "발췌", 33,
+                        "애증의 관계", 0, LocalDateTime.now())),
+                pageable, 1);
+        given(opinionRepository.countByUserIdAndDeletedAtIsNull(1L)).willReturn(0L);
+        given(userRepository.findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID))
+                .willReturn(Optional.of(sampleUser));
+        given(opinionQueryRepository.findMyOpinions(999L, null, pageable)).willReturn(expected);
+
+        Page<MyOpinionProjection> results = opinionService.getMyOpinions(1L, null, pageable);
 
         assertThat(results).isEqualTo(expected);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #153

## 🚀 개요
> 마이페이지 흔적 목록/내 서재 도서 목록에서, 샘플 데이터 노출 기준을 "비로그인 여부"에서 "실제 데이터 유무"로 바꿔 신규 가입 계정도 온보딩 시점에 빈 화면 대신 샘플 데이터를 보게 합니다.

## 📄 작업 내용
- `OpinionService#getMyOpinions`: 로그인 사용자라도 남긴 흔적이 0건이면 샘플 계정(`GuestSampleAccount`)의 흔적을 반환하도록 수정 (bookId 필터와 무관하게 전체 흔적 개수로 판단)
- `BookService#getMyLibraryBooks`: 로그인 사용자라도 서재 도서가 0건이면 고정 샘플 도서(`GUEST_SAMPLE_LIBRARY_BOOK`)를 반환하도록 수정
- `UserApi`/`BookApi` Swagger 설명을 "비로그인" → "비로그인 또는 신규 가입 계정"으로 갱신
- `OpinionServiceTest`/`BookServiceTest`에 신규 가입 계정 케이스 테스트 추가, 기존 테스트 mock 보강

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 (기존에 로컬 Redis 미실행으로 실패하던 `AladinBookApiClientCacheTest`는 이 변경과 무관한 사전 실패)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- "신규 가입 계정" 판단 기준을 별도 플래그(`hasCompletedOnboarding` 등) 없이 "실제 데이터 개수 0건"으로만 잡았습니다. 흔적/서재 도서를 모두 지운(0건이 된) 기존 사용자도 같은 분기를 타 샘플 데이터를 보게 되는데, 이 정도 범위가 기획 의도에 맞는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그인했지만 서재에 도서가 없는 계정에도 샘플 도서가 표시됩니다.
  * 작성한 흔적이 없는 신규 계정에도 샘플 흔적 목록이 표시됩니다.
  * 샘플 데이터가 없을 경우 빈 목록이 제공됩니다.

* **문서**
  * 도서 및 흔적 조회 API의 안내가 변경된 동작에 맞게 업데이트되었습니다.

* **테스트**
  * 신규 계정의 샘플 도서 및 흔적 표시 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->