### PR TITLE
Feat/#155 관리자 페이지 - 테스트 유저 데이터 삭제 기능

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -42,3 +42,8 @@ IMAGE_UPLOAD_DIR=/app/uploads
 # api-dev.pallang.co.kr) 상대 경로를 반환하면 프론트가 자기 자신의 origin으로 잘못 요청해 404가 난다.
 # dev/prod 프로파일에 기본값이 있어 보통 비워둬도 되지만, 도메인이 바뀌면 여기서 덮어쓸 것.
 # STORAGE_PUBLIC_BASE_URL=https://api-dev.pallang.co.kr/images
+
+# ---- 관리자 페이지(/admin) 및 관리자 API 접근 권한 ----
+# 기존 로그인(JWT)의 userId 중 관리자 페이지에서 유저 삭제 등을 수행할 수 있는 계정만 콤마로 나열.
+# 예: ADMIN_USER_IDS=1,7
+ADMIN_USER_IDS=

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminAccessGuard.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminAccessGuard.java
@@ -1,0 +1,30 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import com.nexters.palang.global.security.CurrentUserProvider;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+// 인가는 서비스/컨트롤러 레이어의 CurrentUserProvider가 담당한다는 이 프로젝트의 컨벤션(SecurityConfig
+// 참고)을 그대로 따른다: 별도 관리자 로그인/역할 체계를 새로 만들지 않고, 기존 로그인 JWT의 userId가
+// admin.user-ids 화이트리스트에 있는지만 확인한다.
+@Component
+@RequiredArgsConstructor
+public class AdminAccessGuard {
+
+    private final CurrentUserProvider currentUserProvider;
+
+    @Value("${admin.user-ids:}")
+    private List<Long> adminUserIds;
+
+    public Long requireAdmin() {
+        Long userId = currentUserProvider.getCurrentUserId();
+        if (!adminUserIds.contains(userId)) {
+            throw new AdminException(AdminErrorCode.ADMIN_ACCESS_DENIED);
+        }
+        return userId;
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminUserMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminUserMapper.java
@@ -1,0 +1,24 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminUserListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUserSummaryResponse;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminUserMapper {
+
+    private AdminUserMapper() {
+    }
+
+    public static AdminUserSummaryResponse toSummary(AdminUserSearchResult result) {
+        var user = result.user();
+        return new AdminUserSummaryResponse(
+                user.getId(), user.getNickname(), user.getEmail(), user.getSnsProvider().name(),
+                user.isWithdrawn(), user.getCreatedAt(), result.hostedGroupCount());
+    }
+
+    public static AdminUserListResponse toListResponse(Page<AdminUserSearchResult> results) {
+        return new AdminUserListResponse(
+                results.map(AdminUserMapper::toSummary).getContent(), PageInfo.from(results));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminUserSearchResult.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminUserSearchResult.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.user.domain.User;
+
+public record AdminUserSearchResult(User user, long hostedGroupCount) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminUserService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminUserService.java
@@ -1,0 +1,167 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
+import com.nexters.palang.domain.block.infrastructure.UserBlockRepository;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.notification.infrastructure.DeviceTokenRepository;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.report.infrastructure.ReportRepository;
+import com.nexters.palang.domain.user.common.error.UserErrorCode;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// prod에 쌓인 테스트/QA 계정을 관리자 페이지에서 정리하기 위한 하드 삭제(issue #155). User.withdraw()
+// (회원탈퇴, 익명화만 하고 실제 행은 남기는 정책)와는 완전히 별개의 관리자 전용 경로이며, 일반 유저 플로우와
+// 섞이지 않는다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final PassageRepository passageRepository;
+    private final OpinionRepository opinionRepository;
+    private final CommentRepository commentRepository;
+    private final DecorationRepository decorationRepository;
+    private final OpinionLikeRepository opinionLikeRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final NotificationRepository notificationRepository;
+    private final ReportRepository reportRepository;
+    private final UserBlockRepository userBlockRepository;
+    private final UserBookStatusRepository userBookStatusRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Page<AdminUserSearchResult> searchUsers(String keyword, Pageable pageable) {
+        Page<User> users = userRepository.findByNicknameContainingOrEmailContaining(keyword, keyword, pageable);
+        return users.map(user -> new AdminUserSearchResult(user, groupRepository.countByHostId(user.getId())));
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        List<Long> soloHostedGroupIds = validateDeletableAndCollectSoloHostedGroups(userId);
+
+        Set<Long> passageIdsToDelete = collectPassageIdsToDelete(userId, soloHostedGroupIds);
+        Set<Long> opinionIdsToDelete = collectOpinionIdsToDelete(userId, passageIdsToDelete);
+
+        deleteOpinionSubContent(userId, opinionIdsToDelete);
+        if (!opinionIdsToDelete.isEmpty()) {
+            opinionRepository.deleteAllById(opinionIdsToDelete);
+        }
+        if (!passageIdsToDelete.isEmpty()) {
+            passageRepository.deleteAllById(passageIdsToDelete);
+        }
+
+        groupMemberRepository.deleteAllByUserId(userId);
+        if (!soloHostedGroupIds.isEmpty()) {
+            groupRepository.deleteAllById(soloHostedGroupIds);
+        }
+
+        deviceTokenRepository.deleteAllByUserId(userId);
+        notificationRepository.deleteAllByReceiverId(userId);
+        reportRepository.deleteAllByReporterId(userId);
+        userBlockRepository.deleteAllByBlockerIdOrBlockedId(userId, userId);
+        userBookStatusRepository.deleteAllByUserId(userId);
+        refreshTokenRepository.deleteAllByUserId(userId);
+
+        userRepository.delete(user);
+    }
+
+    // 다른 멤버가 있는 모임의 호스트면 삭제를 막는다(그 모임의 다른 멤버 데이터까지 함께 사라지므로).
+    // 통과하면, 혼자뿐인(=삭제해도 collateral이 없는) 호스트 모임 id 목록을 돌려준다.
+    private List<Long> validateDeletableAndCollectSoloHostedGroups(Long userId) {
+        List<Group> hostedGroups = groupRepository.findAllByHostId(userId);
+        List<Long> soloHostedGroupIds = new ArrayList<>();
+        List<String> blockingGroupNames = new ArrayList<>();
+        for (Group group : hostedGroups) {
+            if (groupMemberRepository.countByGroupId(group.getId()) > 1) {
+                blockingGroupNames.add(group.getName());
+            } else {
+                soloHostedGroupIds.add(group.getId());
+            }
+        }
+        if (!blockingGroupNames.isEmpty()) {
+            throw new AdminException(AdminErrorCode.USER_DELETE_BLOCKED_BY_HOSTED_GROUP,
+                    "다른 멤버가 있는 모임의 호스트여서 삭제할 수 없습니다: " + String.join(", ", blockingGroupNames));
+        }
+
+        List<Long> ownPassageIds = passageRepository.findAllByCreatorId(userId).stream().map(Passage::getId).toList();
+        if (!ownPassageIds.isEmpty()) {
+            List<Long> blockingPassageIds =
+                    opinionRepository.findPassageIdsWithOpinionsFromOtherUsers(ownPassageIds, userId);
+            if (!blockingPassageIds.isEmpty()) {
+                throw new AdminException(AdminErrorCode.USER_DELETE_BLOCKED_BY_PASSAGE,
+                        "다른 사용자의 의견이 달린 흔적을 작성해서 삭제할 수 없습니다 (흔적 id: "
+                                + blockingPassageIds.stream().map(String::valueOf).collect(Collectors.joining(", "))
+                                + ")");
+            }
+        }
+        return soloHostedGroupIds;
+    }
+
+    // 삭제 대상 대목 = 이 유저가 작성한 대목 전부 ∪ 이 유저 혼자만 있던 모임 소속 대목 전부.
+    private Set<Long> collectPassageIdsToDelete(Long userId, List<Long> soloHostedGroupIds) {
+        Set<Long> passageIds = new LinkedHashSet<>();
+        passageRepository.findAllByCreatorId(userId).forEach(p -> passageIds.add(p.getId()));
+        if (!soloHostedGroupIds.isEmpty()) {
+            passageRepository.findAllByGroupIdIn(soloHostedGroupIds).forEach(p -> passageIds.add(p.getId()));
+        }
+        return passageIds;
+    }
+
+    // 삭제 대상 의견 = 삭제될 대목에 달린 의견 전부(작성자 무관) ∪ 이 유저 본인이 남긴 의견 전부(대목 무관).
+    private Set<Long> collectOpinionIdsToDelete(Long userId, Set<Long> passageIdsToDelete) {
+        Set<Long> opinionIds = new LinkedHashSet<>();
+        if (!passageIdsToDelete.isEmpty()) {
+            opinionIds.addAll(opinionRepository.findIdsByPassageIdIn(List.copyOf(passageIdsToDelete)));
+        }
+        opinionIds.addAll(opinionRepository.findIdsByUserId(userId));
+        return opinionIds;
+    }
+
+    // 댓글은 자기참조 FK(parent_comment_id)가 있어 답글부터 지워야 한다. 이 유저의 (삭제 대상에 포함되지
+    // 않는) 댓글에 달린 답글을 먼저 지운 뒤, 삭제될 의견에 달린 댓글/데코/좋아요를 한 번에 지우고, 마지막으로
+    // 이 유저의 나머지 댓글/좋아요를 지운다. 다른 유저가 이 유저의 의견/댓글에 남긴 반응(댓글/좋아요/데코)도
+    // 함께 사라지는데, 이는 "본인 콘텐츠에 달린 반응"이라 모임 호스트/대목 소유 케이스와 달리 별도 차단
+      // 조건을 두지 않기로 했다(issue #155 참고 사항).
+    private void deleteOpinionSubContent(Long userId, Set<Long> opinionIdsToDelete) {
+        List<Long> ownCommentIds = commentRepository.findIdsByUserId(userId);
+        if (!ownCommentIds.isEmpty()) {
+            commentRepository.deleteAllByParentCommentIdIn(ownCommentIds);
+        }
+        if (!opinionIdsToDelete.isEmpty()) {
+            List<Long> opinionIdList = List.copyOf(opinionIdsToDelete);
+            commentRepository.deleteAllByOpinionIdIn(opinionIdList);
+            decorationRepository.deleteAllByOpinionIdIn(opinionIdList);
+            opinionLikeRepository.deleteAllByOpinionIdIn(opinionIdList);
+        }
+        commentRepository.deleteAllByUserId(userId);
+        opinionLikeRepository.deleteAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/common/error/AdminErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/admin/common/error/AdminErrorCode.java
@@ -1,0 +1,22 @@
+package com.nexters.palang.domain.admin.common.error;
+
+import com.nexters.palang.global.common.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AdminErrorCode implements BaseErrorCode {
+
+    ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ADMIN_403_1", "관리자 권한이 없습니다."),
+    USER_DELETE_BLOCKED_BY_HOSTED_GROUP(HttpStatus.CONFLICT, "ADMIN_409_1",
+            "다른 멤버가 있는 모임의 호스트여서 삭제할 수 없습니다."),
+    USER_DELETE_BLOCKED_BY_PASSAGE(HttpStatus.CONFLICT, "ADMIN_409_2",
+            "다른 사용자의 의견이 달린 흔적을 작성해서 삭제할 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/main/java/com/nexters/palang/domain/admin/common/error/AdminException.java
+++ b/src/main/java/com/nexters/palang/domain/admin/common/error/AdminException.java
@@ -1,0 +1,14 @@
+package com.nexters.palang.domain.admin.common.error;
+
+import com.nexters.palang.global.common.error.AppException;
+
+public class AdminException extends AppException {
+
+    public AdminException(AdminErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AdminException(AdminErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPageConfig.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPageConfig.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+// 정적 리소스 핸들러는 "/admin"·"/admin/"(트레일링 슬래시) 요청을 디렉터리 내 index.html로 자동
+// 연결해주지 않아 NoResourceFoundException(500)이 발생한다. 관리자가 외우기 쉬운 짧은 경로로도
+// 페이지에 들어올 수 있도록 정적 파일의 실제 경로로 리다이렉트한다.
+@Configuration
+public class AdminPageConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/admin", "/admin/index.html");
+        registry.addRedirectViewController("/admin/", "/admin/index.html");
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserApi.java
@@ -1,0 +1,50 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminUserListResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+// 관리자 페이지(/admin) 전용 API. 일반 API 문서와 섞이지 않도록 별도 태그로 분리한다.
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminUserApi {
+
+    @Operation(summary = "관리자 유저 검색", description = "닉네임 또는 이메일에 키워드가 포함된 유저를 검색합니다. "
+            + "관리자 화이트리스트(admin.user-ids)에 속한 계정의 JWT로만 호출할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/admin/users\",\"title\":\"ADMIN_403_1\","
+                                    + "\"status\":403,\"detail\":\"관리자 권한이 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<AdminUserListResponse>> searchUsers(
+            @Parameter(description = "닉네임/이메일 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 유저 삭제", description = "유저와 연관 데이터(모임/흔적/의견/댓글/좋아요/데코 등)를 "
+            + "하드 삭제합니다. 되돌릴 수 없습니다. 다른 멤버가 있는 모임의 호스트이거나, 다른 사용자의 의견이 "
+            + "달린 흔적을 작성한 경우 409로 차단됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음 (USER_404_1)"),
+            @ApiResponse(responseCode = "409", description = "다른 유저의 데이터와 얽혀 있어 삭제할 수 없음 "
+                    + "(ADMIN_409_1 / ADMIN_409_2)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/admin/users/42\",\"title\":\"ADMIN_409_1\","
+                                    + "\"status\":409,\"detail\":\"다른 멤버가 있는 모임의 호스트여서 삭제할 수 "
+                                    + "없습니다: 독서모임A\"}")))
+    })
+    ResponseEntity<DataResponse<Void>> deleteUser(Long userId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserController.java
@@ -1,0 +1,53 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminUserMapper;
+import com.nexters.palang.domain.admin.application.AdminUserSearchResult;
+import com.nexters.palang.domain.admin.application.AdminUserService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUserListResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminUserController implements AdminUserApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminUserService adminUserService;
+
+    @Override
+    @GetMapping("/api/admin/users")
+    public ResponseEntity<DataResponse<AdminUserListResponse>> searchUsers(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<AdminUserSearchResult> results = adminUserService.searchUsers(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminUserMapper.toListResponse(results)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/users/{userId}")
+    public ResponseEntity<DataResponse<Void>> deleteUser(@PathVariable Long userId) {
+        adminAccessGuard.requireAdmin();
+        adminUserService.deleteUser(userId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUserListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUserListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminUserListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminUserSummaryResponse> users,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUserSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUserSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AdminUserSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String nickname,
+        @Schema(nullable = true) String email,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String snsProvider,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean withdrawn,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED,
+                description = "이 유저가 호스트인 모임 수. 1개 이상이면 그 모임에 다른 멤버가 있는지에 따라 "
+                        + "삭제 요청이 차단(409)될 수 있다.")
+        long hostedGroupCount
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
+++ b/src/main/java/com/nexters/palang/domain/auth/infrastructure/RefreshTokenRepository.java
@@ -17,4 +17,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying
     @Query("update RefreshToken r set r.revoked = true where r.userId = :userId and r.revoked = false")
     void revokeAllByUserId(@Param("userId") Long userId);
+
+    // 관리자 유저 삭제(AdminUserService): revoke가 아니라 실제 행 삭제. users에 FK는 없지만
+    // (userId가 plain 컬럼) 유저를 완전히 지우는 마당에 세션 기록을 남겨둘 이유가 없다.
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepository.java
+++ b/src/main/java/com/nexters/palang/domain/block/infrastructure/UserBlockRepository.java
@@ -8,4 +8,7 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
     boolean existsByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
 
     void deleteByBlockerIdAndBlockedId(Long blockerId, Long blockedId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 관련된 차단 내역 전부(차단한 쪽/차단당한 쪽 모두).
+    void deleteAllByBlockerIdOrBlockedId(Long blockerId, Long blockedId);
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
@@ -11,4 +11,7 @@ public interface UserBookStatusRepository extends JpaRepository<UserBookStatus, 
     boolean existsByUserIdAndBookId(Long userId, Long bookId);
 
     void deleteByUserIdAndBookId(Long userId, Long bookId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저의 읽기 상태 전부.
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.comment.infrastructure;
 
 import com.nexters.palang.domain.comment.domain.Comment;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 트랜잭션 안에서 user를 미리 로딩해야 LazyInitializationException을 피할 수 있다.
     @Query("select c from Comment c join fetch c.user where c.id = :id")
     Optional<Comment> findByIdWithUser(@Param("id") Long id);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저 본인의 댓글/답글 id 전부(삭제 순서 계산용).
+    @Query("select c.id from Comment c where c.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
+
+    // 아래 세 메서드는 comments.parent_comment_id(자기참조 FK)를 위반하지 않도록 자식(답글)부터 지우기
+    // 위한 것이다. 삭제 순서: ①이 유저의 댓글에 달린 답글(작성자 무관) → ②삭제 대상 의견에 달린 댓글/답글
+    // 전부(한 쿼리 안에서 부모/자식이 함께 지워지므로 순서 문제가 없다) → ③이 유저의 나머지 댓글.
+    void deleteAllByParentCommentIdIn(List<Long> parentCommentIds);
+
+    void deleteAllByOpinionIdIn(List<Long> opinionIds);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/decoration/infrastructure/DecorationRepository.java
+++ b/src/main/java/com/nexters/palang/domain/decoration/infrastructure/DecorationRepository.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.decoration.infrastructure;
+
+import com.nexters.palang.domain.decoration.domain.Decoration;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DecorationRepository extends JpaRepository<Decoration, Long> {
+
+    // 관리자 유저 삭제(AdminUserService): 삭제 대상 의견에 달린 데코 전부.
+    void deleteAllByOpinionIdIn(List<Long> opinionIds);
+}

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
@@ -10,4 +10,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     long countByGroupId(Long groupId);
 
     void deleteAllByGroupId(Long groupId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저의 모든 모임 멤버십(본인이 호스트인 모임 포함)을 제거한다.
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -2,12 +2,20 @@ package com.nexters.palang.domain.group.infrastructure;
 
 import com.nexters.palang.domain.group.domain.Group;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 호스트인 모임을 전부 조회해, 다른 멤버가 있는
+    // 모임인지(삭제 차단) / 혼자뿐인 모임인지(함께 삭제 가능)를 판별하는 데 쓴다.
+    List<Group> findAllByHostId(Long hostId);
+
+    // 관리자 페이지 유저 목록에서 "호스트인 모임 수"를 보여주기 위한 참고용 카운트.
+    long countByHostId(Long hostId);
 
     // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다. book 제목/저자/표지를 응답에
     // 바로 내려줘야 해서(GroupMapper.toInvitationPreviewResponse) join fetch로 같이 읽는다 — book이

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/DeviceTokenRepository.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/DeviceTokenRepository.java
@@ -12,4 +12,7 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
     List<DeviceToken> findAllByUserId(Long userId);
 
     void deleteByTokenAndUserId(String token, Long userId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저의 디바이스 토큰 전부.
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepository.java
+++ b/src/main/java/com/nexters/palang/domain/notification/infrastructure/NotificationRepository.java
@@ -22,4 +22,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("update Notification n set n.read = true, n.readAt = current_timestamp "
             + "where n.receiver.id = :receiverId and n.read = false")
     int markAllAsRead(@Param("receiverId") Long receiverId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 수신자인 알림 전부. actorId(알림을 유발한 유저)가
+    // 이 유저를 가리키는 다른 사람의 알림은 FK 제약이 없어 그대로 남는다(알려진 한계, 이슈 #155 참고).
+    void deleteAllByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionLikeRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionLikeRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.opinion.domain.OpinionLike;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OpinionLikeRepository extends JpaRepository<OpinionLike, Long> {
@@ -8,4 +9,10 @@ public interface OpinionLikeRepository extends JpaRepository<OpinionLike, Long> 
     boolean existsByUserIdAndOpinionId(Long userId, Long opinionId);
 
     void deleteByUserIdAndOpinionId(Long userId, Long opinionId);
+
+    // 관리자 유저 삭제(AdminUserService): 삭제 대상 의견에 달린 좋아요 전부(누가 눌렀는지 무관).
+    void deleteAllByOpinionIdIn(List<Long> opinionIds);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 남긴 나머지 좋아요.
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -32,4 +32,20 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
     // 위 알림의 수신 대상 후보: 이 책에 살아있는 의견을 남긴 적 있는 사용자 목록(작성자 본인 제외는 호출부 책임).
     @Query("select distinct o.user.id from Opinion o where o.passage.book.id = :bookId and o.deletedAt is null")
     List<Long> findDistinctUserIdsByBookId(@Param("bookId") Long bookId);
+
+    // 관리자 유저 삭제(AdminUserService): 삭제 대상 대목들에 달린 의견 id 전부. 소프트 삭제 여부와 무관하게
+    // 물리적으로 존재하는 행을 전부 대상으로 해야 대목을 지울 때 FK 위반이 나지 않는다.
+    @Query("select o.id from Opinion o where o.passage.id in :passageIds")
+    List<Long> findIdsByPassageIdIn(@Param("passageIds") List<Long> passageIds);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저 본인이 남긴 의견 id 전부(대목 소속 모임과 무관).
+    @Query("select o.id from Opinion o where o.user.id = :userId")
+    List<Long> findIdsByUserId(@Param("userId") Long userId);
+
+    // 관리자 유저 삭제 차단 조건: 이 유저가 작성한 대목 중, 다른 사용자가 의견을 남긴 대목이 있는지 확인.
+    // 있으면 그 대목(과 대목에 달린 모든 의견/댓글/좋아요)을 지울 때 타인의 1차 콘텐츠까지 함께 사라지므로
+    // 삭제를 차단해야 한다.
+    @Query("select distinct o.passage.id from Opinion o where o.passage.id in :passageIds and o.user.id <> :userId")
+    List<Long> findPassageIdsWithOpinionsFromOtherUsers(
+            @Param("passageIds") List<Long> passageIds, @Param("userId") Long userId);
 }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.passage.infrastructure;
 
 import com.nexters.palang.domain.passage.domain.Passage;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,11 @@ public interface PassageRepository extends JpaRepository<Passage, Long> {
     // 흔적 목록 조회 시 대상 대목의 존재 여부뿐 아니라 group 소속을 확인해야 해서(모임원 검증) 엔티티
     // 자체를 조회한다.
     Optional<Passage> findByIdAndDeletedAtIsNull(Long id);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 작성자인 대목(소속 모임 무관) 전부.
+    // 소프트 삭제 여부와 무관하게 물리적으로 존재하는 행을 전부 대상으로 해야 FK 위반 없이 정리할 수 있다.
+    List<Passage> findAllByCreatorId(Long userId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 혼자 호스트인 모임들(soloHostedGroupIds)에 속한 대목 전부.
+    List<Passage> findAllByGroupIdIn(List<Long> groupIds);
 }

--- a/src/main/java/com/nexters/palang/domain/report/infrastructure/ReportRepository.java
+++ b/src/main/java/com/nexters/palang/domain/report/infrastructure/ReportRepository.java
@@ -7,4 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     boolean existsByReporterIdAndTargetTypeAndTargetId(Long reporterId, ReportTargetType targetType, Long targetId);
+
+    // 관리자 유저 삭제(AdminUserService): 이 유저가 신고자인 신고 내역 전부.
+    void deleteAllByReporterId(Long reporterId);
 }

--- a/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/nexters/palang/domain/user/infrastructure/UserRepository.java
@@ -3,6 +3,8 @@ package com.nexters.palang.domain.user.infrastructure;
 import com.nexters.palang.domain.user.domain.SnsProvider;
 import com.nexters.palang.domain.user.domain.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNicknameAndIdNot(String nickname, Long id);
 
     Optional<User> findBySnsProviderAndSnsId(SnsProvider snsProvider, String snsId);
+
+    // 관리자 페이지 유저 검색: 닉네임 또는 이메일에 키워드가 포함된 유저(관리자 화면이라 소프트 삭제
+    // 여부와 무관하게 전부 대상으로 한다).
+    Page<User> findByNicknameContainingOrEmailContaining(String nickname, String email, Pageable pageable);
 }

--- a/src/main/java/com/nexters/palang/global/common/error/AppException.java
+++ b/src/main/java/com/nexters/palang/global/common/error/AppException.java
@@ -6,9 +6,17 @@ import lombok.Getter;
 public class AppException extends RuntimeException {
 
     private final BaseErrorCode errorCode;
+    private final String detail;
 
     public AppException(BaseErrorCode errorCode) {
-        super(errorCode.getMessage());
+        this(errorCode, errorCode.getMessage());
+    }
+
+    // errorCode.getMessage()는 고정 문구라, 어떤 모임/대목 때문에 막혔는지처럼 요청마다 달라지는
+    // 안내가 필요한 경우(AdminException 등) 이 생성자로 detail을 따로 넘긴다.
+    public AppException(BaseErrorCode errorCode, String detail) {
+        super(detail);
         this.errorCode = errorCode;
+        this.detail = detail;
     }
 }

--- a/src/main/java/com/nexters/palang/global/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/nexters/palang/global/common/error/GlobalExceptionHandler.java
@@ -20,10 +20,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AppException.class)
     public ResponseEntity<ErrorResponse> handleAppException(AppException e, HttpServletRequest request) {
         BaseErrorCode errorCode = e.getErrorCode();
-        log.warn("AppException 발생: {}, 에러가 발생한 지점: {} {}", errorCode.getMessage(), request.getMethod(), request.getRequestURI());
-        
+        log.warn("AppException 발생: {}, 에러가 발생한 지점: {} {}", e.getDetail(), request.getMethod(), request.getRequestURI());
+
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(request.getRequestURI(), errorCode));
+                .body(ErrorResponse.of(request.getRequestURI(), errorCode, e.getDetail()));
     }
 
     // @Valid 검사 실패(필수 파라미터가 null 또는 공백) 인 경우 예외를 잡는 핸들러

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,3 +45,8 @@ firebase:
 notification:
   # "책에 새 의견 N개 이상" 알림 트리거 기준값.
   book-new-opinions-threshold: ${NOTIFICATION_BOOK_NEW_OPINIONS_THRESHOLD:5}
+
+# 관리자 페이지/API 접근 화이트리스트. 별도 관리자 계정 체계 없이, 기존 로그인 JWT의 userId가
+# 이 목록에 있어야 통과한다(AdminAccessGuard). 콤마로 구분된 userId 목록.
+admin:
+  user-ids: ${ADMIN_USER_IDS:}

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex, nofollow" />
+<title>Pallang 관리자 - 유저 정리</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f5f5f7;
+    --card: #ffffff;
+    --border: #e0e0e5;
+    --text: #1c1c1e;
+    --muted: #6b6b70;
+    --danger: #d73a4a;
+    --danger-dark: #b3212f;
+    --accent: #3366ff;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Pretendard, Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 24px;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  p.subtitle { color: var(--muted); margin: 0 0 20px; font-size: 13px; }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  input[type="text"], input[type="password"] {
+    flex: 1;
+    min-width: 200px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 14px;
+  }
+  button {
+    padding: 8px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--accent);
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  button.secondary { background: #fff; color: var(--text); }
+  button.danger { background: var(--danger); border-color: var(--danger); }
+  button.danger:hover { background: var(--danger-dark); }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 600; }
+  .badge {
+    display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px;
+    background: #eef0ff; color: var(--accent);
+  }
+  .badge.warn { background: #fff3e0; color: #b3620a; }
+  #status { font-size: 13px; margin-top: 8px; white-space: pre-wrap; }
+  #status.error { color: var(--danger); }
+  #status.ok { color: #1a7f37; }
+  .pager { display: flex; gap: 8px; align-items: center; margin-top: 12px; font-size: 13px; }
+</style>
+</head>
+<body>
+  <h1>Pallang 관리자 — 유저 정리</h1>
+  <p class="subtitle">테스트/QA 계정을 검색해서 삭제합니다. 관리자 화이트리스트(admin.user-ids)에 등록된 계정의
+    JWT access token으로만 동작합니다. 삭제는 되돌릴 수 없습니다.</p>
+
+  <div class="card">
+    <div class="row">
+      <input id="token" type="password" placeholder="Authorization: Bearer 없이 access token만 붙여넣으세요" />
+      <button id="saveToken" class="secondary">토큰 저장</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="row">
+      <input id="keyword" type="text" placeholder="닉네임 또는 이메일 검색어" />
+      <button id="searchBtn">검색</button>
+    </div>
+    <div id="status"></div>
+  </div>
+
+  <div class="card">
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th><th>닉네임</th><th>이메일</th><th>SNS</th><th>가입일</th><th>호스트 모임 수</th><th></th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div class="pager">
+      <button id="prevBtn" class="secondary">이전</button>
+      <span id="pageLabel"></span>
+      <button id="nextBtn" class="secondary">다음</button>
+    </div>
+  </div>
+
+<script>
+  const TOKEN_KEY = "pallang_admin_token";
+  const tokenInput = document.getElementById("token");
+  const rowsEl = document.getElementById("rows");
+  const statusEl = document.getElementById("status");
+  const pageLabel = document.getElementById("pageLabel");
+
+  let currentKeyword = "";
+  let currentPage = 0;
+  let lastPageInfo = null;
+
+  function loadToken() {
+    try {
+      return localStorage.getItem(TOKEN_KEY) || "";
+    } catch {
+      return "";
+    }
+  }
+
+  tokenInput.value = loadToken();
+
+  document.getElementById("saveToken").addEventListener("click", () => {
+    try {
+      localStorage.setItem(TOKEN_KEY, tokenInput.value.trim());
+      setStatus("토큰을 저장했습니다.", "ok");
+    } catch {
+      setStatus("이 브라우저에서는 토큰을 저장할 수 없습니다(시크릿 모드 등). 매번 다시 붙여넣어야 합니다.", "error");
+    }
+  });
+
+  function setStatus(message, kind) {
+    statusEl.textContent = message || "";
+    statusEl.className = kind || "";
+  }
+
+  async function callApi(path, options) {
+    const token = loadToken();
+    const response = await fetch(path, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: "Bearer " + token } : {}),
+        ...(options && options.headers ? options.headers : {}),
+      },
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      const detail = body && body.detail ? body.detail : response.status + " 오류";
+      throw new Error(detail);
+    }
+    return body;
+  }
+
+  async function search(page) {
+    if (!currentKeyword) {
+      setStatus("검색어를 입력하세요.", "error");
+      return;
+    }
+    setStatus("검색 중...");
+    try {
+      const result = await callApi(
+        "/api/admin/users?keyword=" + encodeURIComponent(currentKeyword) + "&page=" + page + "&size=20",
+        { method: "GET" },
+      );
+      currentPage = page;
+      lastPageInfo = result.data.pageInfo;
+      renderRows(result.data.users);
+      renderPager();
+      setStatus(result.data.users.length + "명 조회됨.", "ok");
+    } catch (e) {
+      setStatus(e.message, "error");
+    }
+  }
+
+  function renderRows(users) {
+    rowsEl.innerHTML = "";
+    for (const user of users) {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${user.userId}</td>
+        <td>${escapeHtml(user.nickname)}${user.withdrawn ? ' <span class="badge warn">탈퇴</span>' : ""}</td>
+        <td>${escapeHtml(user.email || "-")}</td>
+        <td><span class="badge">${escapeHtml(user.snsProvider)}</span></td>
+        <td>${escapeHtml((user.createdAt || "").replace("T", " ").slice(0, 16))}</td>
+        <td>${user.hostedGroupCount}</td>
+        <td></td>
+      `;
+      const deleteCell = tr.lastElementChild;
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "danger";
+      deleteBtn.textContent = "삭제";
+      deleteBtn.addEventListener("click", () => deleteUser(user, deleteBtn));
+      deleteCell.appendChild(deleteBtn);
+      rowsEl.appendChild(tr);
+    }
+  }
+
+  async function deleteUser(user, button) {
+    const confirmed = confirm(
+      `${user.nickname}(id: ${user.userId})을(를) 삭제할까요?\n연관된 모임/흔적/의견/댓글이 함께 사라지며 되돌릴 수 없습니다.`,
+    );
+    if (!confirmed) return;
+
+    button.disabled = true;
+    setStatus("삭제 중...");
+    try {
+      await callApi("/api/admin/users/" + user.userId, { method: "DELETE" });
+      setStatus(`${user.nickname}(id: ${user.userId}) 삭제 완료.`, "ok");
+      search(currentPage);
+    } catch (e) {
+      setStatus("삭제 실패: " + e.message, "error");
+      button.disabled = false;
+    }
+  }
+
+  function renderPager() {
+    if (!lastPageInfo) {
+      pageLabel.textContent = "";
+      return;
+    }
+    pageLabel.textContent = `${lastPageInfo.page + 1} / ${Math.max(lastPageInfo.totalPages, 1)}페이지 (총 ${lastPageInfo.totalElements}명)`;
+    document.getElementById("prevBtn").disabled = lastPageInfo.page <= 0;
+    document.getElementById("nextBtn").disabled = !lastPageInfo.hasNext;
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    }[c]));
+  }
+
+  document.getElementById("searchBtn").addEventListener("click", () => {
+    currentKeyword = document.getElementById("keyword").value.trim();
+    search(0);
+  });
+  document.getElementById("keyword").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") document.getElementById("searchBtn").click();
+  });
+  document.getElementById("prevBtn").addEventListener("click", () => {
+    if (currentPage > 0) search(currentPage - 1);
+  });
+  document.getElementById("nextBtn").addEventListener("click", () => {
+    if (lastPageInfo && lastPageInfo.hasNext) search(currentPage + 1);
+  });
+</script>
+</body>
+</html>

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminUserServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminUserServiceTest.java
@@ -1,0 +1,156 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import com.nexters.palang.domain.auth.infrastructure.RefreshTokenRepository;
+import com.nexters.palang.domain.block.infrastructure.UserBlockRepository;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.notification.infrastructure.DeviceTokenRepository;
+import com.nexters.palang.domain.notification.infrastructure.NotificationRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.report.infrastructure.ReportRepository;
+import com.nexters.palang.domain.user.common.error.UserException;
+import com.nexters.palang.domain.user.domain.User;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+    @Mock
+    private PassageRepository passageRepository;
+    @Mock
+    private OpinionRepository opinionRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private DecorationRepository decorationRepository;
+    @Mock
+    private OpinionLikeRepository opinionLikeRepository;
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private ReportRepository reportRepository;
+    @Mock
+    private UserBlockRepository userBlockRepository;
+    @Mock
+    private UserBookStatusRepository userBookStatusRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    private AdminUserService adminUserService;
+    private User target;
+
+    @BeforeEach
+    void setUp() {
+        adminUserService = new AdminUserService(
+                userRepository, groupRepository, groupMemberRepository, passageRepository, opinionRepository,
+                commentRepository, decorationRepository, opinionLikeRepository, deviceTokenRepository,
+                notificationRepository, reportRepository, userBlockRepository, userBookStatusRepository,
+                refreshTokenRepository);
+        target = user(10L);
+    }
+
+    private User user(Long id) {
+        User built = User.builder().nickname("테스트유저" + id).build();
+        ReflectionTestUtils.setField(built, "id", id);
+        return built;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저를 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenUserNotFound() {
+        given(userRepository.findById(target.getId())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminUserService.deleteUser(target.getId())).isInstanceOf(UserException.class);
+    }
+
+    @Test
+    @DisplayName("다른 멤버가 있는 모임의 호스트면 삭제가 차단된다")
+    void deleteFailsWhenHostingGroupWithOtherMembers() {
+        given(userRepository.findById(target.getId())).willReturn(Optional.of(target));
+        Group hostedGroup = mock(Group.class);
+        given(hostedGroup.getId()).willReturn(100L);
+        given(hostedGroup.getName()).willReturn("독서모임A");
+        given(groupRepository.findAllByHostId(target.getId())).willReturn(List.of(hostedGroup));
+        given(groupMemberRepository.countByGroupId(100L)).willReturn(2L);
+
+        assertThatThrownBy(() -> adminUserService.deleteUser(target.getId()))
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.USER_DELETE_BLOCKED_BY_HOSTED_GROUP);
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("다른 유저의 의견이 달린 흔적을 작성했으면 삭제가 차단된다")
+    void deleteFailsWhenPassageHasOthersOpinions() {
+        given(userRepository.findById(target.getId())).willReturn(Optional.of(target));
+        given(groupRepository.findAllByHostId(target.getId())).willReturn(List.of());
+
+        Passage ownPassage = mock(Passage.class);
+        given(ownPassage.getId()).willReturn(200L);
+        given(passageRepository.findAllByCreatorId(target.getId())).willReturn(List.of(ownPassage));
+        given(opinionRepository.findPassageIdsWithOpinionsFromOtherUsers(List.of(200L), target.getId()))
+                .willReturn(List.of(200L));
+
+        assertThatThrownBy(() -> adminUserService.deleteUser(target.getId()))
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.USER_DELETE_BLOCKED_BY_PASSAGE);
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("차단 조건이 없으면 유저와 연관 데이터가 삭제된다")
+    void deleteRemovesUserAndRelatedData() {
+        given(userRepository.findById(target.getId())).willReturn(Optional.of(target));
+        given(groupRepository.findAllByHostId(target.getId())).willReturn(List.of());
+        given(passageRepository.findAllByCreatorId(target.getId())).willReturn(List.of());
+        given(opinionRepository.findIdsByUserId(target.getId())).willReturn(List.of());
+        given(commentRepository.findIdsByUserId(target.getId())).willReturn(List.of());
+
+        adminUserService.deleteUser(target.getId());
+
+        verify(groupMemberRepository).deleteAllByUserId(target.getId());
+        verify(deviceTokenRepository).deleteAllByUserId(target.getId());
+        verify(notificationRepository).deleteAllByReceiverId(target.getId());
+        verify(reportRepository).deleteAllByReporterId(target.getId());
+        verify(userBlockRepository).deleteAllByBlockerIdOrBlockedId(target.getId(), target.getId());
+        verify(userBookStatusRepository).deleteAllByUserId(target.getId());
+        verify(refreshTokenRepository).deleteAllByUserId(target.getId());
+        verify(userRepository).delete(target);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #155

## 🚀 개요
> prod에 쌓인 테스트/QA 계정을 SQL을 직접 짜지 않고도 안전하게 정리할 수 있도록, 관리자 API와 서버에 그대로 번들되는 정적 관리자 페이지(`/admin`)를 추가합니다.

## 📄 작업 내용
- 인증: 별도 관리자 계정 체계를 새로 만들지 않고, 기존 로그인 JWT의 userId가 `admin.user-ids`(env: `ADMIN_USER_IDS`) 화이트리스트에 있는지만 확인 (`AdminAccessGuard`)
- API

  | Method | Path | 설명 |
  | --- | --- | --- |
  | GET | `/api/admin/users?keyword=&page=&size=` | 닉네임/이메일로 유저 검색 (호스트인 모임 수 포함) |
  | DELETE | `/api/admin/users/{userId}` | 유저 + 연관 데이터 하드 삭제 |

- 삭제 로직(`AdminUserService`)
  - 차단 조건(409): ① 다른 멤버가 있는 모임의 호스트인 경우 ② 다른 사용자의 의견이 달린 흔적을 작성한 경우 — 둘 다 "이 유저를 지우면 타인의 1차 콘텐츠까지 함께 사라지는" 케이스라 차단
  - 통과 시: 혼자 호스트인 모임 → 그 모임의 대목/의견/댓글/좋아요/데코까지 cascade 삭제, 이 유저 본인의 의견/댓글/좋아요(다른 모임 소속 포함)도 함께 삭제, 이후 device_tokens/notifications/reports/user_blocks/user_book_statuses/refresh_tokens/users 순으로 정리
  - FK(특히 comments의 자기참조 `parent_comment_id`) 위반이 나지 않도록 삭제 순서를 맞췄고, 이를 위해 여러 레포지토리에 `deleteAllBy*` 파생 쿼리 메서드를 추가했습니다.
  - 기존 `User.withdraw()`(회원탈퇴 시 익명화, 실제 행은 보존)와는 완전히 별개의 관리자 전용 하드 삭제 경로입니다.
- `AppException`이 고정 메시지 대신 요청별 동적 detail을 실을 수 있도록 확장했습니다(어떤 모임/흔적 때문에 차단됐는지 안내하기 위함). 기존 예외들은 영향 없습니다(단일 인자 생성자는 그대로 `errorCode.getMessage()`를 detail로 사용).
- `src/main/resources/static/admin/index.html`: 별도 프론트 배포 없이 서버 jar/도커 이미지에 그대로 포함되는 순수 HTML/JS 페이지. JWT access token을 붙여넣어 localStorage에 저장하고, 이후 요청에 `Authorization: Bearer`로 사용합니다.
- `deploy/.env.example`에 `ADMIN_USER_IDS` 항목 추가
- `AdminPageConfig`: 정적 리소스 핸들러가 `/admin`, `/admin/`(트레일링 슬래시) 요청을 `index.html`로 자동 연결해주지 않아 500이 나던 문제를 발견해 `/admin/index.html`로 리다이렉트하도록 수정했습니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` — 신규 `AdminUserServiceTest` 4개 포함 전체 통과 확인. 기존에 실패하던 3~4건(로컬 Redis 미기동으로 인한 `AladinBookApiClientCacheTest`, 간헐적인 `NotificationRepositoryTest` 타임스탬프 동순위 정렬)은 이 PR 변경 범위와 무관한 기존 이슈로, `git diff`로 관련 파일에 로직 변경이 없음을 확인했습니다.
- `local` 프로파일(내장 H2)로 실제 앱을 기동해 `dev-login`으로 관리자 유저를 만들고, curl로 `GET /api/admin/users`(검색/페이징) → `DELETE /api/admin/users/{id}`(삭제 후 목록에서 제거됨) 전체 플로우를 직접 확인했습니다. 이 과정에서 `/admin`, `/admin/` 500 버그를 발견해 함께 고쳤습니다(`/admin/index.html`은 원래 200 정상).
- 모임 호스트 차단(409)·타인 의견 있는 흔적 차단(409) 케이스는 로컬에 책/모임 시드 데이터가 없어 curl로는 직접 재현하지 않았고, `AdminUserServiceTest`의 단위 테스트로 검증했습니다.
- prod DB는 조회 전용으로만 SSH 접속해 스키마(FK 구조)를 확인하는 데 썼고, 실제 삭제 동작은 prod에 대고 돌려보지 않았습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 삭제 시 "본인 의견/댓글에 달린 타인의 반응(댓글/좋아요/데코)은 별도 차단 없이 함께 삭제"로 정했는데, 이 기준이 적절한지 확인 부탁드립니다. (모임 호스트/대목 작성자 케이스는 타인의 "1차 콘텐츠"라 차단하지만, 반응성 콘텐츠는 정도가 다르다고 판단했습니다 — 이슈 #155 참고 사항에도 명시)
- 관리자 인증을 화이트리스트 + 기존 JWT로 최소 구현했습니다. 정식 관리자 역할 체계가 필요해지면 추후 별도 이슈로 확장하는 게 맞다고 봅니다.
- `notifications.actor_id`처럼 FK가 없는 컬럼은 삭제 대상에서 의도적으로 제외했습니다(알려진 한계). 이 정도 수준의 정합성이면 충분한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자 전용 페이지(`/admin`)에서 닉네임·이메일로 사용자를 검색하고 페이지별로 확인할 수 있습니다.
  - 사용자 정보, 탈퇴 여부, 가입일, 호스트 모임 수를 확인할 수 있습니다.
  - 관리자 권한으로 사용자를 삭제할 수 있습니다.
  - 등록된 관리자만 페이지와 관리자 API에 접근할 수 있습니다.

- **버그 수정**
  - 다른 멤버나 사용자의 콘텐츠에 영향을 주는 사용자 삭제를 차단합니다.
  - 삭제 시 관련 토큰, 알림, 차단, 신고 및 활동 데이터를 정리합니다.
  - 실패 시 상세한 오류 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->