### PR TITLE
Feat/#157 관리자 페이지 - 콘텐츠 관리 + 독립 로그인

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -43,7 +43,12 @@ IMAGE_UPLOAD_DIR=/app/uploads
 # dev/prod 프로파일에 기본값이 있어 보통 비워둬도 되지만, 도메인이 바뀌면 여기서 덮어쓸 것.
 # STORAGE_PUBLIC_BASE_URL=https://api-dev.pallang.co.kr/images
 
-# ---- 관리자 페이지(/admin) 및 관리자 API 접근 권한 ----
-# 기존 로그인(JWT)의 userId 중 관리자 페이지에서 유저 삭제 등을 수행할 수 있는 계정만 콤마로 나열.
-# 예: ADMIN_USER_IDS=1,7
-ADMIN_USER_IDS=
+# ---- 관리자 페이지(/admin) 전용 로그인 ----
+# 일반 유저 로그인과 완전히 분리된 별도 계정이다. 셋 다 비어있으면 관리자 로그인이 항상 실패한다
+# (안전한 기본값). ADMIN_JWT_SECRET은 32바이트 이상 임의의 긴 문자열로 설정할 것 — 일반 유저 JWT_SECRET과
+# 절대 같은 값을 쓰지 않는다(섞이면 한쪽 토큰으로 다른 쪽을 위조할 수 있는 경로가 생긴다).
+ADMIN_LOGIN_USERNAME=
+ADMIN_LOGIN_PASSWORD=
+ADMIN_JWT_SECRET=
+# 관리자 세션 유효시간(초). 기본 43200초(12시간).
+# ADMIN_SESSION_EXPIRATION_SECONDS=43200

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminAccessGuard.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminAccessGuard.java
@@ -2,29 +2,35 @@ package com.nexters.palang.domain.admin.application;
 
 import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
 import com.nexters.palang.domain.admin.common.error.AdminException;
-import com.nexters.palang.global.security.CurrentUserProvider;
-import java.util.List;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-// 인가는 서비스/컨트롤러 레이어의 CurrentUserProvider가 담당한다는 이 프로젝트의 컨벤션(SecurityConfig
-// 참고)을 그대로 따른다: 별도 관리자 로그인/역할 체계를 새로 만들지 않고, 기존 로그인 JWT의 userId가
-// admin.user-ids 화이트리스트에 있는지만 확인한다.
+// 관리자 페이지/API는 일반 유저 로그인(JWT+CurrentUserProvider)과 완전히 분리된 별도 로그인
+// (AdminLoginService, POST /api/admin/auth/login)을 쓴다. 이 가드는 Authorization 헤더의 토큰을
+// AdminJwtProvider로 직접 검증한다 — 특정 유저 계정에 종속되지 않는, 이 페이지만을 위한 자격 증명이다.
 @Component
 @RequiredArgsConstructor
 public class AdminAccessGuard {
 
-    private final CurrentUserProvider currentUserProvider;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
-    @Value("${admin.user-ids:}")
-    private List<Long> adminUserIds;
+    private final HttpServletRequest request;
+    private final AdminJwtProvider adminJwtProvider;
 
-    public Long requireAdmin() {
-        Long userId = currentUserProvider.getCurrentUserId();
-        if (!adminUserIds.contains(userId)) {
+    public void requireAdmin() {
+        String token = resolveToken();
+        if (token == null || !adminJwtProvider.isValid(token)) {
             throw new AdminException(AdminErrorCode.ADMIN_ACCESS_DENIED);
         }
-        return userId;
+    }
+
+    private String resolveToken() {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminBookMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminBookMapper.java
@@ -1,0 +1,23 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookSummaryResponse;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminBookMapper {
+
+    private AdminBookMapper() {
+    }
+
+    public static AdminBookSummaryResponse toSummary(Book book) {
+        return new AdminBookSummaryResponse(
+                book.getId(), book.getTitle(), book.getAuthor(), book.getPublisher(), book.getPageCount(),
+                book.getIsbn(), book.getCoverImageUrl(), book.getSource().name(), book.getCreatedAt());
+    }
+
+    public static AdminBookListResponse toListResponse(Page<Book> books) {
+        return new AdminBookListResponse(books.map(AdminBookMapper::toSummary).getContent(), PageInfo.from(books));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminBookService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminBookService.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.book.common.error.BookErrorCode;
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 페이지에서 책(Book)을 조회/수정/삭제하기 위한 서비스(issue #155 후속). BookService에는 애초에
+// 도서 수정/삭제 기능이 없다(등록만 가능). 책 삭제는 그 책을 쓰는 여러 유저의 모임/대목까지 통째로 지울 수
+// 있는 위험한 작업이라는 점을 감안해, 연관된 모임/대목/의견/댓글까지 전부 함께 정리한다(issue #155 참고
+// 사항: "모두 cascade 삭제"로 결정).
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminBookService {
+
+    private final BookRepository bookRepository;
+    private final PassageRepository passageRepository;
+    private final GroupRepository groupRepository;
+    private final UserBookStatusRepository userBookStatusRepository;
+    private final AdminCascadeDeleter cascadeDeleter;
+
+    public Page<Book> searchBooks(String keyword, Pageable pageable) {
+        return bookRepository.findByTitleContainingOrAuthorContaining(keyword, keyword, pageable);
+    }
+
+    @Transactional
+    public Book updateBook(
+            Long bookId, String title, String author, String publisher, int pageCount, String isbn, String coverImageUrl) {
+        Book book = getExistingBook(bookId);
+        book.update(title, author, publisher, pageCount, isbn, coverImageUrl);
+        return book;
+    }
+
+    // 이 책으로 만들어진 모임(과 그 안의 대목/의견/댓글/데코/좋아요, 모임원), 모임에 속하지 않은 대목까지
+    // 전부 하드 삭제한 뒤 책 자체를 지운다. 여러 유저의 데이터에 영향을 줄 수 있는 위험한 작업이다.
+    @Transactional
+    public void deleteBook(Long bookId) {
+        getExistingBook(bookId);
+
+        List<Long> groupIds = groupRepository.findAllByBookId(bookId).stream().map(Group::getId).toList();
+        cascadeDeleter.deleteGroups(groupIds);
+
+        // 모임에 속하지 않은(전역 공개) 대목을 포함해, 이 책에 남아있는 대목을 전부 정리한다.
+        // 모임 소속 대목은 위 deleteGroups에서 이미 지워졌으므로 findAllByBookId는 나머지만 돌려준다.
+        List<Long> remainingPassageIds = passageRepository.findAllByBookId(bookId).stream().map(Passage::getId).toList();
+        cascadeDeleter.deletePassages(remainingPassageIds);
+
+        userBookStatusRepository.deleteAllByBookId(bookId);
+        bookRepository.deleteById(bookId);
+    }
+
+    private Book getExistingBook(Long bookId) {
+        return bookRepository.findById(bookId)
+                .orElseThrow(() -> new BookException(BookErrorCode.BOOK_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminCascadeDeleter.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminCascadeDeleter.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+// AdminPassageService/AdminOpinionService/AdminGroupService/AdminBookService가 공통으로 쓰는 하드 삭제
+// cascade. AdminUserService.deleteUser의 삭제 순서(댓글/데코/좋아요 → 의견 → 대목 → 모임원 → 모임)를
+// "특정 유저"가 아니라 "특정 의견/대목/모임 id 집합"을 기준으로 재사용할 수 있게 일반화했다. 이 프로젝트엔
+// DB 레벨 ON DELETE CASCADE가 없어(ddl-auto: update, 마이그레이션 도구 없음) 항상 자식부터 순서대로 지워야
+// FK 위반이 나지 않는다.
+@Component
+@RequiredArgsConstructor
+public class AdminCascadeDeleter {
+
+    private final PassageRepository passageRepository;
+    private final OpinionRepository opinionRepository;
+    private final CommentRepository commentRepository;
+    private final DecorationRepository decorationRepository;
+    private final OpinionLikeRepository opinionLikeRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    // 의견(들)과 거기 달린 댓글/데코/좋아요를 전부 지운다. 한 의견에 달린 댓글은 부모/답글(자기참조 FK)
+    // 관계여도 opinion_id로 한 번에 지우면 같은 DELETE 문 안에서 함께 제거되어 순서 문제가 없다
+    // (AdminUserService에서 이미 검증된 방식).
+    public void deleteOpinions(Collection<Long> opinionIds) {
+        if (opinionIds.isEmpty()) {
+            return;
+        }
+        List<Long> ids = List.copyOf(opinionIds);
+        commentRepository.deleteAllByOpinionIdIn(ids);
+        decorationRepository.deleteAllByOpinionIdIn(ids);
+        opinionLikeRepository.deleteAllByOpinionIdIn(ids);
+        opinionRepository.deleteAllById(ids);
+    }
+
+    // 대목(들)과 그 위의 의견/댓글/데코/좋아요를 전부 지운다.
+    public void deletePassages(Collection<Long> passageIds) {
+        if (passageIds.isEmpty()) {
+            return;
+        }
+        List<Long> ids = List.copyOf(passageIds);
+        deleteOpinions(opinionRepository.findIdsByPassageIdIn(ids));
+        passageRepository.deleteAllById(ids);
+    }
+
+    // 모임(들)과 그 안의 대목/의견/댓글/데코/좋아요, 모임원까지 전부 지운다.
+    public void deleteGroups(Collection<Long> groupIds) {
+        if (groupIds.isEmpty()) {
+            return;
+        }
+        List<Long> ids = List.copyOf(groupIds);
+        List<Long> passageIds = passageRepository.findAllByGroupIdIn(ids).stream().map(Passage::getId).toList();
+        deletePassages(passageIds);
+        groupMemberRepository.deleteAllByGroupIdIn(ids);
+        groupRepository.deleteAllById(ids);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentMapper.java
@@ -1,0 +1,26 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentSummaryResponse;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminCommentMapper {
+
+    private AdminCommentMapper() {
+    }
+
+    // opinion/user/parentComment는 지연 로딩 연관관계다. AdminPassageMapper와 같은 이유로 open-in-view에 기대고 있다.
+    public static AdminCommentSummaryResponse toSummary(Comment comment) {
+        return new AdminCommentSummaryResponse(
+                comment.getId(), comment.getOpinion().getId(),
+                comment.getParentComment() != null ? comment.getParentComment().getId() : null,
+                comment.getUser().getId(), comment.getUser().getNickname(),
+                comment.getContent(), comment.isDeleted(), comment.getCreatedAt());
+    }
+
+    public static AdminCommentListResponse toListResponse(Page<Comment> comments) {
+        return new AdminCommentListResponse(comments.map(AdminCommentMapper::toSummary).getContent(), PageInfo.from(comments));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentService.java
@@ -1,0 +1,47 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.comment.common.CommentErrorCode;
+import com.nexters.palang.domain.comment.common.CommentException;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 페이지에서 댓글(Comment, 답글 포함)을 조회/수정/삭제하기 위한 서비스(issue #155 후속).
+// CommentService의 modifyComment/removeComment는 작성자 본인만 호출할 수 있어(validateOwner) 관리자
+// 용도로 재사용할 수 없다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public Page<Comment> searchComments(String keyword, Pageable pageable) {
+        return commentRepository.findByContentContaining(keyword, pageable);
+    }
+
+    @Transactional
+    public Comment updateComment(Long commentId, String content) {
+        Comment comment = getExistingComment(commentId);
+        comment.updateContent(content);
+        return comment;
+    }
+
+    // 원댓글이면 거기 달린 답글부터 지운다(자기참조 FK). 하드 삭제라 되돌릴 수 없다.
+    @Transactional
+    public void deleteComment(Long commentId) {
+        getExistingComment(commentId);
+        commentRepository.deleteAllByParentCommentIdIn(List.of(commentId));
+        commentRepository.deleteById(commentId);
+    }
+
+    private Comment getExistingComment(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupMapper.java
@@ -1,0 +1,26 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupSummaryResponse;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminGroupMapper {
+
+    private AdminGroupMapper() {
+    }
+
+    // book/host는 지연 로딩 연관관계다. AdminPassageMapper와 같은 이유로 open-in-view에 기대고 있다.
+    public static AdminGroupSummaryResponse toSummary(AdminGroupSearchResult result) {
+        Group group = result.group();
+        return new AdminGroupSummaryResponse(
+                group.getId(), group.getName(), group.getBook().getId(), group.getBook().getTitle(),
+                group.getHost().getId(), group.getHost().getNickname(),
+                group.getCapacity(), result.memberCount(), group.getStartDate(), group.getEndDate(), group.getCreatedAt());
+    }
+
+    public static AdminGroupListResponse toListResponse(Page<AdminGroupSearchResult> results) {
+        return new AdminGroupListResponse(results.map(AdminGroupMapper::toSummary).getContent(), PageInfo.from(results));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupSearchResult.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupSearchResult.java
@@ -1,0 +1,6 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.group.domain.Group;
+
+public record AdminGroupSearchResult(Group group, long memberCount) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupService.java
@@ -1,0 +1,55 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.group.common.error.GroupErrorCode;
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 페이지에서 모임(Group)을 조회/수정/삭제하기 위한 서비스(issue #155 후속). GroupService의
+// updateGroup/deleteGroup은 호스트 본인만 호출할 수 있고(validateHost), deleteGroup은 그 모임의
+// 대목/의견/댓글까지는 지우지 않아(멤버십만 정리) 관리자의 "완전히 정리" 요구에는 맞지 않는다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminGroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final AdminCascadeDeleter cascadeDeleter;
+
+    public Page<AdminGroupSearchResult> searchGroups(String keyword, Pageable pageable) {
+        Page<Group> groups = groupRepository.findByNameContaining(keyword, pageable);
+        return groups.map(group -> new AdminGroupSearchResult(group, groupMemberRepository.countByGroupId(group.getId())));
+    }
+
+    // Group.updateSettings는 GroupService.updateGroup(호스트 전용)에서 쓰는 것과 같은 엔티티 메서드다.
+    // 정원을 현재 참여 인원보다 적게 줄이려 하면 그대로 GroupException(CAPACITY_BELOW_MEMBER_COUNT, 409)이
+    // 던져진다. 책은 모임 생성 후 바꿀 수 없어(updatable=false) 여기서도 수정 대상이 아니다.
+    @Transactional
+    public AdminGroupSearchResult updateGroup(Long groupId, String name, int capacity, LocalDate startDate, LocalDate endDate) {
+        Group group = getExistingGroup(groupId);
+        long memberCount = groupMemberRepository.countByGroupId(groupId);
+        group.updateSettings(name, capacity, startDate, endDate, memberCount);
+        return new AdminGroupSearchResult(group, memberCount);
+    }
+
+    // 모임과 그 안의 대목/의견/댓글/데코/좋아요, 모임원까지 전부 하드 삭제한다. 되돌릴 수 없다.
+    @Transactional
+    public void deleteGroup(Long groupId) {
+        getExistingGroup(groupId);
+        cascadeDeleter.deleteGroups(List.of(groupId));
+    }
+
+    private Group getExistingGroup(Long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminJwtProvider.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminJwtProvider.java
@@ -1,0 +1,64 @@
+package com.nexters.palang.domain.admin.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+// 관리자 페이지 전용 세션 토큰. 일반 유저 로그인(JwtTokenProvider)과 완전히 분리된 별도 비밀키로
+// 서명한다 — 두 토큰 체계를 같은 키로 섞으면 유저 토큰으로 관리자 토큰을 위조하거나 그 반대가 가능해질
+// 수 있어서다. admin.jwt-secret이 설정되지 않으면(로컬 개발 편의를 위해 앱을 죽이는 대신) 기동마다
+// 바뀌는 임시 키를 생성해 사용한다 — 이 경우 아무도 유효한 토큰을 만들 수 없으므로 관리자 로그인은
+// 사실상 비활성 상태가 된다(admin.login-username/password 미설정과 동일하게 "안전하게 꺼진" 상태).
+@Slf4j
+@Component
+public class AdminJwtProvider {
+
+    private static final String ADMIN_SUBJECT = "admin";
+
+    private final SecretKey secretKey;
+    private final long expirationMillis;
+
+    public AdminJwtProvider(
+            @Value("${admin.jwt-secret:}") String secret,
+            @Value("${admin.session-expiration-seconds:43200}") long expirationSeconds) {
+        this.secretKey = secret.isBlank() ? randomKey() : Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMillis = expirationSeconds * 1000;
+        if (secret.isBlank()) {
+            log.warn("admin.jwt-secret가 설정되지 않아 기동마다 바뀌는 임시 키를 사용합니다. "
+                    + "관리자 로그인을 쓰려면 ADMIN_JWT_SECRET을 설정하세요.");
+        }
+    }
+
+    public String createToken() {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(ADMIN_SUBJECT)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationMillis))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean isValid(String token) {
+        try {
+            Claims claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+            return ADMIN_SUBJECT.equals(claims.getSubject());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static SecretKey randomKey() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Keys.hmacShaKeyFor(bytes);
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminLoginService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminLoginService.java
@@ -1,0 +1,46 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+// 관리자 페이지 전용 로그인. admin.login-username/password(둘 다 기본값 없음 — 설정 전까지는 어떤
+// 입력으로도 로그인이 성공할 수 없다)와 정확히 일치해야 토큰이 발급된다. 문자열 비교에 String.equals
+// 대신 MessageDigest.isEqual을 쓰는 이유: 이 엔드포인트는 인증 전 상태에서 인터넷에 노출되는
+// "관문"이라 타이밍 공격으로 비밀번호를 한 글자씩 추측당하는 걸 막기 위함이다.
+@Service
+public class AdminLoginService {
+
+    private final String configuredUsername;
+    private final String configuredPassword;
+    private final AdminJwtProvider adminJwtProvider;
+
+    public AdminLoginService(
+            @Value("${admin.login-username:}") String configuredUsername,
+            @Value("${admin.login-password:}") String configuredPassword,
+            AdminJwtProvider adminJwtProvider) {
+        this.configuredUsername = configuredUsername;
+        this.configuredPassword = configuredPassword;
+        this.adminJwtProvider = adminJwtProvider;
+    }
+
+    public String login(String username, String password) {
+        if (configuredUsername.isBlank() || configuredPassword.isBlank()
+                || !constantTimeEquals(configuredUsername, username)
+                || !constantTimeEquals(configuredPassword, password)) {
+            throw new AdminException(AdminErrorCode.ADMIN_LOGIN_FAILED);
+        }
+        return adminJwtProvider.createToken();
+    }
+
+    private boolean constantTimeEquals(String expected, String actual) {
+        if (actual == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.UTF_8), actual.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionMapper.java
@@ -1,0 +1,25 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionSummaryResponse;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminOpinionMapper {
+
+    private AdminOpinionMapper() {
+    }
+
+    // passage/user는 지연 로딩 연관관계다. AdminPassageMapper와 같은 이유로 open-in-view에 기대고 있다.
+    public static AdminOpinionSummaryResponse toSummary(Opinion opinion) {
+        return new AdminOpinionSummaryResponse(
+                opinion.getId(), opinion.getPassage().getId(), opinion.getPassage().getQuotedText(),
+                opinion.getUser().getId(), opinion.getUser().getNickname(),
+                opinion.getContent(), opinion.getLikeCount(), opinion.isDeleted(), opinion.getCreatedAt());
+    }
+
+    public static AdminOpinionListResponse toListResponse(Page<Opinion> opinions) {
+        return new AdminOpinionListResponse(opinions.map(AdminOpinionMapper::toSummary).getContent(), PageInfo.from(opinions));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionService.java
@@ -1,0 +1,57 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.opinion.common.error.OpinionErrorCode;
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 페이지에서 의견(Opinion)을 조회/수정/삭제하기 위한 서비스(issue #155 후속). OpinionService의
+// modifyOpinion/removeOpinion은 작성자 본인만 호출할 수 있어(validateOwner) 관리자 용도로 재사용할 수
+// 없다 — 소유권 검사를 우회하는 별도 경로가 필요하다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminOpinionService {
+
+    private final OpinionRepository opinionRepository;
+    private final PassageRepository passageRepository;
+    private final AdminCascadeDeleter cascadeDeleter;
+
+    public Page<Opinion> searchOpinions(String keyword, Pageable pageable) {
+        return opinionRepository.findByContentContaining(keyword, pageable);
+    }
+
+    @Transactional
+    public Opinion updateOpinion(Long opinionId, String content) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        opinion.updateContent(content);
+        return opinion;
+    }
+
+    // 의견과 거기 달린 댓글/데코/좋아요를 하드 삭제한다. 그 대목에 남은 살아있는 의견이 더 없으면
+    // (OpinionService.removeOpinion과 동일한 규칙) 대목도 함께 소프트 삭제한다. 되돌릴 수 없다.
+    @Transactional
+    public void deleteOpinion(Long opinionId) {
+        Opinion opinion = getExistingOpinion(opinionId);
+        Long passageId = opinion.getPassage().getId();
+        boolean wasLastLiveOpinion = !opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(passageId, opinionId);
+
+        cascadeDeleter.deleteOpinions(List.of(opinionId));
+
+        if (wasLastLiveOpinion) {
+            passageRepository.findById(passageId).ifPresent(passage -> passage.delete());
+        }
+    }
+
+    private Opinion getExistingOpinion(Long opinionId) {
+        return opinionRepository.findById(opinionId)
+                .orElseThrow(() -> new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageMapper.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageMapper.java
@@ -1,0 +1,31 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageSummaryResponse;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.global.common.response.PageInfo;
+import org.springframework.data.domain.Page;
+
+public final class AdminPassageMapper {
+
+    private AdminPassageMapper() {
+    }
+
+    // book/creator/group은 지연 로딩 연관관계다. 이 프로젝트는 spring.jpa.open-in-view가 켜져 있어
+    // 컨트롤러 응답 직렬화 시점까지 세션이 열려 있으므로 지금은 동작하지만, open-in-view를 끄게 되면
+    // 이 매퍼가 호출되기 전에 서비스 트랜잭션 안에서 fetch join으로 미리 로딩하도록 바꿔야 한다.
+    public static AdminPassageSummaryResponse toSummary(Passage passage) {
+        return new AdminPassageSummaryResponse(
+                passage.getId(),
+                passage.getBook().getId(), passage.getBook().getTitle(),
+                passage.getGroup() != null ? passage.getGroup().getId() : null,
+                passage.getGroup() != null ? passage.getGroup().getName() : null,
+                passage.getCreator().getId(), passage.getCreator().getNickname(),
+                passage.getPageNumber(), passage.getQuotedText(), passage.isSpoiler(),
+                passage.isDeleted(), passage.getCreatedAt());
+    }
+
+    public static AdminPassageListResponse toListResponse(Page<Passage> passages) {
+        return new AdminPassageListResponse(passages.map(AdminPassageMapper::toSummary).getContent(), PageInfo.from(passages));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageService.java
@@ -1,0 +1,47 @@
+package com.nexters.palang.domain.admin.application;
+
+import com.nexters.palang.domain.passage.common.error.PassageErrorCode;
+import com.nexters.palang.domain.passage.common.error.PassageException;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 관리자 페이지에서 대목(Passage)을 조회/수정/삭제하기 위한 서비스(issue #155 후속). 소프트 삭제된
+// 대목도 정리 대상으로 볼 수 있어야 하므로 검색은 deletedAt과 무관하게 전부를 대상으로 한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPassageService {
+
+    private final PassageRepository passageRepository;
+    private final AdminCascadeDeleter cascadeDeleter;
+
+    public Page<Passage> searchPassages(String keyword, Pageable pageable) {
+        return passageRepository.findByQuotedTextContaining(keyword, pageable);
+    }
+
+    @Transactional
+    public Passage updatePassage(Long passageId, String quotedText, int pageNumber, boolean isSpoiler) {
+        Passage passage = getExistingPassage(passageId);
+        passage.updateContent(quotedText, pageNumber);
+        passage.changeSpoiler(isSpoiler);
+        return passage;
+    }
+
+    // 대목 자체와 거기 달린 의견/댓글/데코/좋아요까지 전부 하드 삭제한다. 되돌릴 수 없다.
+    @Transactional
+    public void deletePassage(Long passageId) {
+        getExistingPassage(passageId);
+        cascadeDeleter.deletePassages(List.of(passageId));
+    }
+
+    private Passage getExistingPassage(Long passageId) {
+        return passageRepository.findById(passageId)
+                .orElseThrow(() -> new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/common/error/AdminErrorCode.java
+++ b/src/main/java/com/nexters/palang/domain/admin/common/error/AdminErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AdminErrorCode implements BaseErrorCode {
 
     ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ADMIN_403_1", "관리자 권한이 없습니다."),
+    ADMIN_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "ADMIN_401_1", "아이디 또는 비밀번호가 올바르지 않습니다."),
     USER_DELETE_BLOCKED_BY_HOSTED_GROUP(HttpStatus.CONFLICT, "ADMIN_409_1",
             "다른 멤버가 있는 모임의 호스트여서 삭제할 수 없습니다."),
     USER_DELETE_BLOCKED_BY_PASSAGE(HttpStatus.CONFLICT, "ADMIN_409_2",

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminBookApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminBookApi.java
@@ -1,0 +1,45 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateBookRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminBookApi {
+
+    @Operation(summary = "관리자 도서 검색", description = "제목 또는 저자에 키워드가 포함된 도서를 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)")
+    })
+    ResponseEntity<DataResponse<AdminBookListResponse>> searchBooks(
+            @Parameter(description = "제목/저자 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 도서 수정", description = "제목/저자/출판사/쪽수/ISBN/표지 URL을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 도서를 찾을 수 없음 (BOOK_404_1)")
+    })
+    ResponseEntity<DataResponse<AdminBookSummaryResponse>> updateBook(Long bookId, AdminUpdateBookRequest request);
+
+    @Operation(summary = "관리자 도서 삭제", description = "이 책으로 만들어진 모임과 그 안의 대목/의견/댓글/"
+            + "데코/좋아요/모임원, 모임에 속하지 않은 대목까지 전부 하드 삭제한 뒤 책 자체를 지웁니다. "
+            + "여러 사용자의 데이터에 영향을 줄 수 있는 위험한 작업이며 되돌릴 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 도서를 찾을 수 없음 (BOOK_404_1)")
+    })
+    ResponseEntity<DataResponse<Void>> deleteBook(Long bookId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminBookController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminBookController.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminBookMapper;
+import com.nexters.palang.domain.admin.application.AdminBookService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminBookSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateBookRequest;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminBookController implements AdminBookApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminBookService adminBookService;
+
+    @Override
+    @GetMapping("/api/admin/books")
+    public ResponseEntity<DataResponse<AdminBookListResponse>> searchBooks(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<Book> results = adminBookService.searchBooks(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminBookMapper.toListResponse(results)));
+    }
+
+    @Override
+    @PatchMapping("/api/admin/books/{bookId}")
+    public ResponseEntity<DataResponse<AdminBookSummaryResponse>> updateBook(
+            @PathVariable Long bookId, @Valid @RequestBody AdminUpdateBookRequest request) {
+        adminAccessGuard.requireAdmin();
+        Book book = adminBookService.updateBook(bookId, request.title(), request.author(), request.publisher(),
+                request.pageCount(), request.isbn(), request.coverImageUrl());
+        return ResponseEntity.ok(DataResponse.from(AdminBookMapper.toSummary(book)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/books/{bookId}")
+    public ResponseEntity<DataResponse<Void>> deleteBook(@PathVariable Long bookId) {
+        adminAccessGuard.requireAdmin();
+        adminBookService.deleteBook(bookId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminCommentApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminCommentApi.java
@@ -1,0 +1,46 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateCommentRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminCommentApi {
+
+    @Operation(summary = "관리자 댓글 검색", description = "내용에 키워드가 포함된 댓글(답글 포함)을 검색합니다. "
+            + "소프트 삭제된 댓글도 함께 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)")
+    })
+    ResponseEntity<DataResponse<AdminCommentListResponse>> searchComments(
+            @Parameter(description = "내용 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 댓글 수정", description = "내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음 (COMMENT_404_1)")
+    })
+    ResponseEntity<DataResponse<AdminCommentSummaryResponse>> updateComment(
+            Long commentId, AdminUpdateCommentRequest request);
+
+    @Operation(summary = "관리자 댓글 삭제", description = "댓글을 하드 삭제합니다. 원댓글이면 거기 달린 "
+            + "답글도 함께 삭제됩니다. 되돌릴 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 댓글을 찾을 수 없음 (COMMENT_404_1)")
+    })
+    ResponseEntity<DataResponse<Void>> deleteComment(Long commentId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminCommentController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminCommentController.java
@@ -1,0 +1,67 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminCommentMapper;
+import com.nexters.palang.domain.admin.application.AdminCommentService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminCommentSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateCommentRequest;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminCommentController implements AdminCommentApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminCommentService adminCommentService;
+
+    @Override
+    @GetMapping("/api/admin/comments")
+    public ResponseEntity<DataResponse<AdminCommentListResponse>> searchComments(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<Comment> results = adminCommentService.searchComments(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminCommentMapper.toListResponse(results)));
+    }
+
+    @Override
+    @PatchMapping("/api/admin/comments/{commentId}")
+    public ResponseEntity<DataResponse<AdminCommentSummaryResponse>> updateComment(
+            @PathVariable Long commentId, @Valid @RequestBody AdminUpdateCommentRequest request) {
+        adminAccessGuard.requireAdmin();
+        Comment comment = adminCommentService.updateComment(commentId, request.content());
+        return ResponseEntity.ok(DataResponse.from(AdminCommentMapper.toSummary(comment)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/comments/{commentId}")
+    public ResponseEntity<DataResponse<Void>> deleteComment(@PathVariable Long commentId) {
+        adminAccessGuard.requireAdmin();
+        adminCommentService.deleteComment(commentId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminGroupApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminGroupApi.java
@@ -1,0 +1,49 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateGroupRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminGroupApi {
+
+    @Operation(summary = "관리자 모임 검색", description = "모임명에 키워드가 포함된 모임을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)")
+    })
+    ResponseEntity<DataResponse<AdminGroupListResponse>> searchGroups(
+            @Parameter(description = "모임명 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 모임 수정", description = "모임명/정원/시작일/종료일을 수정합니다. "
+            + "도서는 모임 생성 후 바꿀 수 없어 수정 대상이 아닙니다. 정원을 현재 참여 인원보다 적게 "
+            + "설정하면 409로 거절됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 정원/기간 (GROUP_400_1 / GROUP_400_2)"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)"),
+            @ApiResponse(responseCode = "409", description = "정원이 현재 참여 인원보다 적음 (GROUP_409_1)")
+    })
+    ResponseEntity<DataResponse<AdminGroupSummaryResponse>> updateGroup(
+            Long groupId, AdminUpdateGroupRequest request);
+
+    @Operation(summary = "관리자 모임 삭제", description = "모임과 그 안의 대목/의견/댓글/데코/좋아요, "
+            + "모임원까지 전부 하드 삭제합니다. 되돌릴 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없음 (GROUP_404_1)")
+    })
+    ResponseEntity<DataResponse<Void>> deleteGroup(Long groupId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminGroupController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminGroupController.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminGroupMapper;
+import com.nexters.palang.domain.admin.application.AdminGroupSearchResult;
+import com.nexters.palang.domain.admin.application.AdminGroupService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminGroupSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateGroupRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminGroupController implements AdminGroupApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminGroupService adminGroupService;
+
+    @Override
+    @GetMapping("/api/admin/groups")
+    public ResponseEntity<DataResponse<AdminGroupListResponse>> searchGroups(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<AdminGroupSearchResult> results = adminGroupService.searchGroups(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminGroupMapper.toListResponse(results)));
+    }
+
+    @Override
+    @PatchMapping("/api/admin/groups/{groupId}")
+    public ResponseEntity<DataResponse<AdminGroupSummaryResponse>> updateGroup(
+            @PathVariable Long groupId, @Valid @RequestBody AdminUpdateGroupRequest request) {
+        adminAccessGuard.requireAdmin();
+        AdminGroupSearchResult result = adminGroupService.updateGroup(
+                groupId, request.name(), request.capacity(), request.startDate(), request.endDate());
+        return ResponseEntity.ok(DataResponse.from(AdminGroupMapper.toSummary(result)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/groups/{groupId}")
+    public ResponseEntity<DataResponse<Void>> deleteGroup(@PathVariable Long groupId) {
+        adminAccessGuard.requireAdmin();
+        adminGroupService.deleteGroup(groupId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminLoginApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminLoginApi.java
@@ -1,0 +1,30 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminLoginRequest;
+import com.nexters.palang.domain.admin.presentation.dto.AdminLoginResponse;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminLoginApi {
+
+    @Operation(summary = "관리자 로그인", description = "일반 유저 로그인과 별개인 관리자 전용 로그인이다. "
+            + "admin.login-username/password(환경변수 ADMIN_LOGIN_USERNAME/ADMIN_LOGIN_PASSWORD)와 "
+            + "정확히 일치해야 하며, 발급된 토큰은 다른 관리자 API 호출 시 Authorization: Bearer로 사용한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "아이디/비밀번호 불일치 (ADMIN_401_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/admin/auth/login\",\"title\":\"ADMIN_401_1\","
+                                    + "\"status\":401,\"detail\":\"아이디 또는 비밀번호가 올바르지 않습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<AdminLoginResponse>> login(AdminLoginRequest request);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminLoginController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminLoginController.java
@@ -1,0 +1,26 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminLoginService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminLoginRequest;
+import com.nexters.palang.domain.admin.presentation.dto.AdminLoginResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminLoginController implements AdminLoginApi {
+
+    private final AdminLoginService adminLoginService;
+
+    @Override
+    @PostMapping("/api/admin/auth/login")
+    public ResponseEntity<DataResponse<AdminLoginResponse>> login(@Valid @RequestBody AdminLoginRequest request) {
+        String token = adminLoginService.login(request.username(), request.password());
+        return ResponseEntity.ok(DataResponse.from(new AdminLoginResponse(token)));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminOpinionApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminOpinionApi.java
@@ -1,0 +1,46 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateOpinionRequest;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminOpinionApi {
+
+    @Operation(summary = "관리자 의견 검색", description = "내용에 키워드가 포함된 의견을 검색합니다. "
+            + "소프트 삭제된 의견도 함께 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)")
+    })
+    ResponseEntity<DataResponse<AdminOpinionListResponse>> searchOpinions(
+            @Parameter(description = "내용 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 의견 수정", description = "내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 의견을 찾을 수 없음 (OPINION_404_1)")
+    })
+    ResponseEntity<DataResponse<AdminOpinionSummaryResponse>> updateOpinion(
+            Long opinionId, AdminUpdateOpinionRequest request);
+
+    @Operation(summary = "관리자 의견 삭제", description = "의견과 거기 달린 댓글/데코/좋아요까지 전부 "
+            + "하드 삭제합니다. 그 대목에 남은 의견이 없으면 대목도 함께 소프트 삭제됩니다. 되돌릴 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 의견을 찾을 수 없음 (OPINION_404_1)")
+    })
+    ResponseEntity<DataResponse<Void>> deleteOpinion(Long opinionId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminOpinionController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminOpinionController.java
@@ -1,0 +1,67 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminOpinionMapper;
+import com.nexters.palang.domain.admin.application.AdminOpinionService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminOpinionSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdateOpinionRequest;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminOpinionController implements AdminOpinionApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminOpinionService adminOpinionService;
+
+    @Override
+    @GetMapping("/api/admin/opinions")
+    public ResponseEntity<DataResponse<AdminOpinionListResponse>> searchOpinions(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<Opinion> results = adminOpinionService.searchOpinions(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminOpinionMapper.toListResponse(results)));
+    }
+
+    @Override
+    @PatchMapping("/api/admin/opinions/{opinionId}")
+    public ResponseEntity<DataResponse<AdminOpinionSummaryResponse>> updateOpinion(
+            @PathVariable Long opinionId, @Valid @RequestBody AdminUpdateOpinionRequest request) {
+        adminAccessGuard.requireAdmin();
+        Opinion opinion = adminOpinionService.updateOpinion(opinionId, request.content());
+        return ResponseEntity.ok(DataResponse.from(AdminOpinionMapper.toSummary(opinion)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/opinions/{opinionId}")
+    public ResponseEntity<DataResponse<Void>> deleteOpinion(@PathVariable Long opinionId) {
+        adminAccessGuard.requireAdmin();
+        adminOpinionService.deleteOpinion(opinionId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPassageApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPassageApi.java
@@ -1,0 +1,53 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdatePassageRequest;
+import com.nexters.palang.global.common.error.ErrorResponse;
+import com.nexters.palang.global.common.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin", description = "관리자 전용 API — 테스트 계정 정리 등")
+public interface AdminPassageApi {
+
+    @Operation(summary = "관리자 대목 검색", description = "인용문에 키워드가 포함된 대목을 검색합니다. "
+            + "소프트 삭제된 대목도 함께 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)")
+    })
+    ResponseEntity<DataResponse<AdminPassageListResponse>> searchPassages(
+            @Parameter(description = "인용문 검색어") String keyword,
+            @Parameter(hidden = true) int page,
+            @Parameter(hidden = true) int size
+    );
+
+    @Operation(summary = "관리자 대목 수정", description = "인용문/페이지 번호/스포일러 여부를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 대목을 찾을 수 없음 (PASSAGE_404_1)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class), examples = @ExampleObject(
+                            value = "{\"type\":\"/api/admin/passages/1\",\"title\":\"PASSAGE_404_1\","
+                                    + "\"status\":404,\"detail\":\"해당 대목을 찾을 수 없습니다.\"}")))
+    })
+    ResponseEntity<DataResponse<AdminPassageSummaryResponse>> updatePassage(
+            Long passageId, AdminUpdatePassageRequest request);
+
+    @Operation(summary = "관리자 대목 삭제", description = "대목과 거기 달린 의견/댓글/데코/좋아요까지 전부 "
+            + "하드 삭제합니다. 되돌릴 수 없습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)"),
+            @ApiResponse(responseCode = "404", description = "해당 대목을 찾을 수 없음 (PASSAGE_404_1)")
+    })
+    ResponseEntity<DataResponse<Void>> deletePassage(Long passageId);
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPassageController.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminPassageController.java
@@ -1,0 +1,68 @@
+package com.nexters.palang.domain.admin.presentation;
+
+import com.nexters.palang.domain.admin.application.AdminAccessGuard;
+import com.nexters.palang.domain.admin.application.AdminPassageMapper;
+import com.nexters.palang.domain.admin.application.AdminPassageService;
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageListResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminPassageSummaryResponse;
+import com.nexters.palang.domain.admin.presentation.dto.AdminUpdatePassageRequest;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.global.common.response.DataResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminPassageController implements AdminPassageApi {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AdminPassageService adminPassageService;
+
+    @Override
+    @GetMapping("/api/admin/passages")
+    public ResponseEntity<DataResponse<AdminPassageListResponse>> searchPassages(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) int size) {
+        adminAccessGuard.requireAdmin();
+        Page<Passage> results = adminPassageService.searchPassages(keyword, pageable(page, size));
+        return ResponseEntity.ok(DataResponse.from(AdminPassageMapper.toListResponse(results)));
+    }
+
+    @Override
+    @PatchMapping("/api/admin/passages/{passageId}")
+    public ResponseEntity<DataResponse<AdminPassageSummaryResponse>> updatePassage(
+            @PathVariable Long passageId, @Valid @RequestBody AdminUpdatePassageRequest request) {
+        adminAccessGuard.requireAdmin();
+        Passage passage = adminPassageService.updatePassage(
+                passageId, request.quotedText(), request.pageNumber(), request.isSpoiler());
+        return ResponseEntity.ok(DataResponse.from(AdminPassageMapper.toSummary(passage)));
+    }
+
+    @Override
+    @DeleteMapping("/api/admin/passages/{passageId}")
+    public ResponseEntity<DataResponse<Void>> deletePassage(@PathVariable Long passageId) {
+        adminAccessGuard.requireAdmin();
+        adminPassageService.deletePassage(passageId);
+        return ResponseEntity.ok(DataResponse.from(null));
+    }
+
+    private Pageable pageable(int page, int size) {
+        return PageRequest.of(Math.max(page, 0), Math.clamp(size, 1, MAX_SIZE));
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserApi.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/AdminUserApi.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 public interface AdminUserApi {
 
     @Operation(summary = "관리자 유저 검색", description = "닉네임 또는 이메일에 키워드가 포함된 유저를 검색합니다. "
-            + "관리자 화이트리스트(admin.user-ids)에 속한 계정의 JWT로만 호출할 수 있습니다.")
+            + "관리자 로그인(POST /api/admin/auth/login)으로 발급받은 토큰으로만 호출할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "403", description = "관리자 권한 없음 (ADMIN_403_1)",

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminBookListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminBookListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminBookListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminBookSummaryResponse> books,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminBookSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminBookSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AdminBookSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String title,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String author,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String publisher,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) int pageCount,
+        @Schema(nullable = true) String isbn,
+        @Schema(nullable = true) String coverImageUrl,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String source,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminCommentListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminCommentListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminCommentListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminCommentSummaryResponse> comments,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminCommentSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminCommentSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AdminCommentSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long commentId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(nullable = true, description = "답글이면 원댓글 id, 원댓글이면 null") Long parentCommentId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String userNickname,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String content,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean deleted,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminGroupListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminGroupListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminGroupListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminGroupSummaryResponse> groups,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminGroupSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminGroupSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record AdminGroupSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long groupId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String name,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long hostId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String hostNickname,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) int capacity,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) long memberCount,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDate startDate,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDate endDate,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminLoginRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminLoginRequest.java
@@ -1,0 +1,10 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @NotBlank(message = "아이디는 필수입니다.") @Schema(example = "pallang") String username,
+        @NotBlank(message = "비밀번호는 필수입니다.") @Schema(example = "********") String password
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminLoginResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminLoginResponse.java
@@ -1,0 +1,8 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminLoginResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String accessToken
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminOpinionListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminOpinionListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminOpinionListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminOpinionSummaryResponse> opinions,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminOpinionSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminOpinionSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AdminOpinionSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long opinionId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String passageQuotedText,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long userId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String userNickname,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String content,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) int likeCount,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean deleted,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminPassageListResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminPassageListResponse.java
@@ -1,0 +1,11 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.global.common.response.PageInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record AdminPassageListResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<AdminPassageSummaryResponse> passages,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminPassageSummaryResponse.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminPassageSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record AdminPassageSummaryResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long passageId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long bookId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String bookTitle,
+        @Schema(nullable = true, description = "모임 전용 대목이면 모임 id, 전역 공개 대목이면 null") Long groupId,
+        @Schema(nullable = true) String groupName,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Long creatorId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String creatorNickname,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) int pageNumber,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String quotedText,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean isSpoiler,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean deleted,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateBookRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateBookRequest.java
@@ -1,0 +1,15 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record AdminUpdateBookRequest(
+        @NotBlank(message = "제목은 필수입니다.") @Schema(example = "채식주의자") String title,
+        @NotBlank(message = "저자는 필수입니다.") @Schema(example = "한강") String author,
+        @NotBlank(message = "출판사는 필수입니다.") @Schema(example = "창비") String publisher,
+        @Positive(message = "쪽수는 1 이상이어야 합니다.") @Schema(example = "247") int pageCount,
+        @Schema(nullable = true, example = "9788936434120") String isbn,
+        @Schema(nullable = true, example = "https://example.com/cover.jpg") String coverImageUrl
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateCommentRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateCommentRequest.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.domain.comment.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminUpdateCommentRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = Comment.CONTENT_MAX_LENGTH, message = "내용은 최대 500자까지 가능합니다.")
+        @Schema(example = "수정된 댓글 내용") String content
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateGroupRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateGroupRequest.java
@@ -1,0 +1,27 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.domain.group.domain.Group;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record AdminUpdateGroupRequest(
+        @NotBlank(message = "모임명은 필수입니다.")
+        @Size(max = Group.NAME_MAX_LENGTH, message = "모임명은 최대 15자까지 가능합니다.")
+        @Schema(example = "고전 뽀개기") String name,
+
+        @Min(value = Group.MIN_CAPACITY, message = "인원은 최소 2명 이상이어야 합니다.")
+        @Max(value = Group.MAX_CAPACITY, message = "인원은 최대 10명까지 가능합니다.")
+        @Schema(example = "4") int capacity,
+
+        @NotNull(message = "시작일은 필수입니다.")
+        @Schema(example = "2026-08-20") LocalDate startDate,
+
+        @NotNull(message = "종료일은 필수입니다.")
+        @Schema(example = "2026-09-20") LocalDate endDate
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateOpinionRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdateOpinionRequest.java
@@ -1,0 +1,13 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminUpdateOpinionRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = Opinion.CONTENT_MAX_LENGTH, message = "내용은 최대 500자까지 가능합니다.")
+        @Schema(example = "수정된 의견 내용") String content
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdatePassageRequest.java
+++ b/src/main/java/com/nexters/palang/domain/admin/presentation/dto/AdminUpdatePassageRequest.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.admin.presentation.dto;
+
+import com.nexters.palang.domain.passage.domain.Passage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record AdminUpdatePassageRequest(
+        @NotBlank(message = "인용문은 필수입니다.")
+        @Size(max = Passage.QUOTED_TEXT_MAX_LENGTH, message = "인용문은 최대 150자까지 가능합니다.")
+        @Schema(example = "수정된 인용문") String quotedText,
+
+        @Positive(message = "페이지 번호는 1 이상이어야 합니다.")
+        @Schema(example = "42") int pageNumber,
+
+        @Schema(example = "false") boolean isSpoiler
+) {
+}

--- a/src/main/java/com/nexters/palang/domain/book/domain/Book.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/Book.java
@@ -80,6 +80,17 @@ public class Book extends BaseEntity {
         this.source = source != null ? source : BookSource.API;
     }
 
+    // 관리자 전용 수정(AdminBookService). 일반 유저 플로우에는 등록된 도서 정보를 고치는 기능이 없다
+    // (알라딘 API로 잘못 들어온 정보나 중복 도서 정리 목적). titleNormalized는 @PreUpdate에서 자동 갱신된다.
+    public void update(String title, String author, String publisher, int pageCount, String isbn, String coverImageUrl) {
+        this.title = title;
+        this.author = author;
+        this.publisher = publisher;
+        this.pageCount = pageCount;
+        this.isbn = isbn;
+        this.coverImageUrl = coverImageUrl;
+    }
+
     @PrePersist
     @PreUpdate
     private void normalizeTitle() {

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
@@ -2,6 +2,7 @@ package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     // 페이지네이션을 쓰면 이전 배치가 채워지며 IS NULL 조건에서 빠져나가 다음 행을 건너뛸 수 있어
     // id > :id 조건으로 이어서 조회해야 한다(pageable은 정렬/LIMIT 용도로만 사용, offset은 항상 0).
     List<Book> findByTitleNormalizedIsNullAndIdGreaterThanOrderByIdAsc(Long id, Pageable pageable);
+
+    // 관리자 도서 검색(AdminBookService): 제목 또는 저자에 키워드가 포함된 도서 전부.
+    Page<Book> findByTitleContainingOrAuthorContaining(String titleKeyword, String authorKeyword, Pageable pageable);
 }

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/UserBookStatusRepository.java
@@ -14,4 +14,7 @@ public interface UserBookStatusRepository extends JpaRepository<UserBookStatus, 
 
     // 관리자 유저 삭제(AdminUserService): 이 유저의 읽기 상태 전부.
     void deleteAllByUserId(Long userId);
+
+    // 관리자 도서 삭제(AdminBookService): 이 책에 대한 읽기 상태 전부.
+    void deleteAllByBookId(Long bookId);
 }

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
@@ -3,6 +3,8 @@ package com.nexters.palang.domain.comment.infrastructure;
 import com.nexters.palang.domain.comment.domain.Comment;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 트랜잭션 안에서 user를 미리 로딩해야 LazyInitializationException을 피할 수 있다.
     @Query("select c from Comment c join fetch c.user where c.id = :id")
     Optional<Comment> findByIdWithUser(@Param("id") Long id);
+
+    // 관리자 댓글 검색(AdminCommentService): 소프트 삭제 여부와 무관하게 내용에 키워드가 포함된 댓글 전부.
+    Page<Comment> findByContentContaining(String keyword, Pageable pageable);
 
     // 관리자 유저 삭제(AdminUserService): 이 유저 본인의 댓글/답글 id 전부(삭제 순서 계산용).
     @Query("select c.id from Comment c where c.user.id = :userId")

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupMemberRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.palang.domain.group.infrastructure;
 
 import com.nexters.palang.domain.group.domain.GroupMember;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
@@ -10,6 +11,9 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     long countByGroupId(Long groupId);
 
     void deleteAllByGroupId(Long groupId);
+
+    // 관리자 모임/도서 삭제(AdminGroupService/AdminBookService): 여러 모임의 멤버십을 한 번에 제거한다.
+    void deleteAllByGroupIdIn(List<Long> groupIds);
 
     // 관리자 유저 삭제(AdminUserService): 이 유저의 모든 모임 멤버십(본인이 호스트인 모임 포함)을 제거한다.
     void deleteAllByUserId(Long userId);

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -4,6 +4,8 @@ import com.nexters.palang.domain.group.domain.Group;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +18,12 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     // 관리자 페이지 유저 목록에서 "호스트인 모임 수"를 보여주기 위한 참고용 카운트.
     long countByHostId(Long hostId);
+
+    // 관리자 도서 삭제(AdminBookService): 이 책으로 만들어진 모임 전부.
+    List<Group> findAllByBookId(Long bookId);
+
+    // 관리자 모임 검색(AdminGroupService): 모임명에 키워드가 포함된 모임 전부.
+    Page<Group> findByNameContaining(String keyword, Pageable pageable);
 
     // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다. book 제목/저자/표지를 응답에
     // 바로 내려줘야 해서(GroupMapper.toInvitationPreviewResponse) join fetch로 같이 읽는다 — book이

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -3,6 +3,8 @@ package com.nexters.palang.domain.opinion.infrastructure;
 import com.nexters.palang.domain.opinion.domain.Opinion;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,9 @@ import org.springframework.data.repository.query.Param;
 public interface OpinionRepository extends JpaRepository<Opinion, Long> {
 
     long countByUserIdAndDeletedAtIsNull(Long userId);
+
+    // 관리자 의견 검색(AdminOpinionService): 소프트 삭제 여부와 무관하게 내용에 키워드가 포함된 의견 전부.
+    Page<Opinion> findByContentContaining(String keyword, Pageable pageable);
 
     // 흔적 삭제 시 그 대목에 남은 다른 살아있는 흔적이 있는지 확인하기 위함 (없으면 대목도 함께 삭제).
     boolean existsByPassageIdAndDeletedAtIsNullAndIdNot(Long passageId, Long id);

--- a/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
+++ b/src/main/java/com/nexters/palang/domain/passage/domain/Passage.java
@@ -95,6 +95,13 @@ public class Passage extends BaseEntity {
         this.isSpoiler = isSpoiler;
     }
 
+    // 관리자 전용 수정(AdminPassageService). 일반 유저 플로우에는 대목 내용을 고치는 기능이 없다
+    // (오탈자·부적절한 내용 정리 목적).
+    public void updateContent(String quotedText, int pageNumber) {
+        this.quotedText = quotedText;
+        this.pageNumber = pageNumber;
+    }
+
     public boolean isDeleted() {
         return this.deletedAt != null;
     }

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
@@ -3,6 +3,8 @@ package com.nexters.palang.domain.passage.infrastructure;
 import com.nexters.palang.domain.passage.domain.Passage;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PassageRepository extends JpaRepository<Passage, Long> {
@@ -15,6 +17,13 @@ public interface PassageRepository extends JpaRepository<Passage, Long> {
     // 소프트 삭제 여부와 무관하게 물리적으로 존재하는 행을 전부 대상으로 해야 FK 위반 없이 정리할 수 있다.
     List<Passage> findAllByCreatorId(Long userId);
 
-    // 관리자 유저 삭제(AdminUserService): 이 유저가 혼자 호스트인 모임들(soloHostedGroupIds)에 속한 대목 전부.
+    // 관리자 유저 삭제(AdminUserService)/관리자 모임·도서 삭제(AdminGroupService/AdminBookService):
+    // 이 모임(들)에 속한 대목 전부.
     List<Passage> findAllByGroupIdIn(List<Long> groupIds);
+
+    // 관리자 도서 삭제(AdminBookService): 이 책에 달린 대목 전부(소속 모임 무관).
+    List<Passage> findAllByBookId(Long bookId);
+
+    // 관리자 대목 검색(AdminPassageService): 소프트 삭제 여부와 무관하게 인용문에 키워드가 포함된 대목 전부.
+    Page<Passage> findByQuotedTextContaining(String keyword, Pageable pageable);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,11 @@ notification:
   # "책에 새 의견 N개 이상" 알림 트리거 기준값.
   book-new-opinions-threshold: ${NOTIFICATION_BOOK_NEW_OPINIONS_THRESHOLD:5}
 
-# 관리자 페이지/API 접근 화이트리스트. 별도 관리자 계정 체계 없이, 기존 로그인 JWT의 userId가
-# 이 목록에 있어야 통과한다(AdminAccessGuard). 콤마로 구분된 userId 목록.
+# 관리자 페이지(/admin) 전용 로그인. 일반 유저 로그인(JWT)과 완전히 분리된 별도 계정 체계다.
+# login-username/password 둘 다 기본값이 없어(빈 문자열) 설정 전까지는 로그인이 항상 실패한다.
+# jwt-secret도 설정하지 않으면 AdminJwtProvider가 기동마다 바뀌는 임시 키를 써서 안전하게 막아둔다.
 admin:
-  user-ids: ${ADMIN_USER_IDS:}
+  login-username: ${ADMIN_LOGIN_USERNAME:}
+  login-password: ${ADMIN_LOGIN_PASSWORD:}
+  jwt-secret: ${ADMIN_JWT_SECRET:}
+  session-expiration-seconds: ${ADMIN_SESSION_EXPIRATION_SECONDS:43200}

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -96,35 +96,43 @@
 </head>
 <body>
   <h1>Pallang 관리자</h1>
-  <p class="subtitle">테스트/QA 데이터를 검색해서 수정·삭제합니다. 관리자 화이트리스트(admin.user-ids)에 등록된 계정의
-    JWT access token으로만 동작합니다. 삭제는 되돌릴 수 없습니다.</p>
+  <p class="subtitle">테스트/QA 데이터를 검색해서 수정·삭제합니다. 일반 유저 로그인과는 별개인 관리자 전용 계정으로
+    로그인해야 합니다. 삭제는 되돌릴 수 없습니다.</p>
 
-  <div class="card">
+  <div class="card" id="loginCard">
     <div class="row">
-      <input id="token" type="password" placeholder="Authorization: Bearer 없이 access token만 붙여넣으세요" />
-      <button id="saveToken" class="secondary">토큰 저장</button>
+      <input id="loginUsername" type="text" placeholder="아이디" autocomplete="username" />
+      <input id="loginPassword" type="password" placeholder="비밀번호" autocomplete="current-password" />
+      <button id="loginBtn">로그인</button>
     </div>
+    <div id="loginStatus"></div>
   </div>
 
-  <div class="tabs" id="tabs"></div>
-
-  <div class="card">
-    <div class="row">
-      <input id="keyword" type="text" />
-      <button id="searchBtn">검색</button>
+  <div id="mainContent" style="display: none;">
+    <div class="row" style="justify-content: flex-end; margin-bottom: 8px;">
+      <button id="logoutBtn" class="secondary">로그아웃</button>
     </div>
-    <div id="status"></div>
-  </div>
 
-  <div class="card">
-    <table>
-      <thead id="thead"></thead>
-      <tbody id="rows"></tbody>
-    </table>
-    <div class="pager">
-      <button id="prevBtn" class="secondary">이전</button>
-      <span id="pageLabel"></span>
-      <button id="nextBtn" class="secondary">다음</button>
+    <div class="tabs" id="tabs"></div>
+
+    <div class="card">
+      <div class="row">
+        <input id="keyword" type="text" />
+        <button id="searchBtn">검색</button>
+      </div>
+      <div id="status"></div>
+    </div>
+
+    <div class="card">
+      <table>
+        <thead id="thead"></thead>
+        <tbody id="rows"></tbody>
+      </table>
+      <div class="pager">
+        <button id="prevBtn" class="secondary">이전</button>
+        <span id="pageLabel"></span>
+        <button id="nextBtn" class="secondary">다음</button>
+      </div>
     </div>
   </div>
 
@@ -260,8 +268,12 @@
     },
   };
 
-  const TOKEN_KEY = "pallang_admin_token";
-  const tokenInput = document.getElementById("token");
+  const TOKEN_KEY = "pallang_admin_session_token";
+  const loginCard = document.getElementById("loginCard");
+  const mainContent = document.getElementById("mainContent");
+  const loginUsernameInput = document.getElementById("loginUsername");
+  const loginPasswordInput = document.getElementById("loginPassword");
+  const loginStatusEl = document.getElementById("loginStatus");
   const keywordInput = document.getElementById("keyword");
   const theadEl = document.getElementById("thead");
   const rowsEl = document.getElementById("rows");
@@ -281,15 +293,68 @@
     }
   }
 
-  tokenInput.value = loadToken();
-
-  document.getElementById("saveToken").addEventListener("click", () => {
+  function saveToken(token) {
     try {
-      localStorage.setItem(TOKEN_KEY, tokenInput.value.trim());
-      setStatus("토큰을 저장했습니다.", "ok");
+      localStorage.setItem(TOKEN_KEY, token);
     } catch {
-      setStatus("이 브라우저에서는 토큰을 저장할 수 없습니다(시크릿 모드 등). 매번 다시 붙여넣어야 합니다.", "error");
+      // 시크릿 모드 등 저장이 안 되는 브라우저에서도 이번 세션 안에서는 그대로 동작하게 둔다.
     }
+  }
+
+  function clearToken() {
+    try {
+      localStorage.removeItem(TOKEN_KEY);
+    } catch {
+      // no-op
+    }
+  }
+
+  function showLoggedOut(message) {
+    loginCard.style.display = "";
+    mainContent.style.display = "none";
+    if (message) setLoginStatus(message, "error");
+  }
+
+  function showLoggedIn() {
+    loginCard.style.display = "none";
+    mainContent.style.display = "";
+  }
+
+  function setLoginStatus(message, kind) {
+    loginStatusEl.textContent = message || "";
+    loginStatusEl.className = kind || "";
+  }
+
+  document.getElementById("loginBtn").addEventListener("click", async () => {
+    const username = loginUsernameInput.value.trim();
+    const password = loginPasswordInput.value;
+    if (!username || !password) {
+      setLoginStatus("아이디와 비밀번호를 입력하세요.", "error");
+      return;
+    }
+    setLoginStatus("로그인 중...");
+    try {
+      const result = await callApi("/api/admin/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ username, password }),
+      }, /* skipAuth */ true);
+      saveToken(result.data.accessToken);
+      loginPasswordInput.value = "";
+      setLoginStatus("");
+      showLoggedIn();
+      switchTab(currentTabKey);
+    } catch (e) {
+      setLoginStatus("로그인 실패: " + e.message, "error");
+    }
+  });
+
+  loginPasswordInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") document.getElementById("loginBtn").click();
+  });
+
+  document.getElementById("logoutBtn").addEventListener("click", () => {
+    clearToken();
+    showLoggedOut();
   });
 
   function setStatus(message, kind) {
@@ -297,18 +362,22 @@
     statusEl.className = kind || "";
   }
 
-  async function callApi(path, options) {
+  async function callApi(path, options, skipAuth) {
     const token = loadToken();
     const response = await fetch(path, {
       ...options,
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: "Bearer " + token } : {}),
+        ...(!skipAuth && token ? { Authorization: "Bearer " + token } : {}),
         ...(options && options.headers ? options.headers : {}),
       },
     });
     const body = await response.json().catch(() => null);
     if (!response.ok) {
+      if (!skipAuth && (response.status === 401 || response.status === 403)) {
+        clearToken();
+        showLoggedOut("세션이 만료되었습니다. 다시 로그인해주세요.");
+      }
       const detail = body && body.detail ? body.detail : response.status + " 오류";
       throw new Error(detail);
     }
@@ -523,6 +592,13 @@
 
   renderTabs();
   switchTab(currentTabKey);
+  // 저장된 세션 토큰이 있으면 바로 메인 화면을 보여준다. 토큰이 실제로 만료/무효였다면 첫 API 호출이
+  // 401/403을 돌려주고 callApi가 자동으로 로그인 화면으로 되돌린다.
+  if (loadToken()) {
+    showLoggedIn();
+  } else {
+    showLoggedOut();
+  }
 </script>
 </body>
 </html>

--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex, nofollow" />
-<title>Pallang 관리자 - 유저 정리</title>
+<title>Pallang 관리자</title>
 <style>
   :root {
     color-scheme: light dark;
@@ -35,14 +35,18 @@
     margin-bottom: 16px;
   }
   .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-  input[type="text"], input[type="password"] {
+  input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea {
     flex: 1;
     min-width: 200px;
     padding: 8px 10px;
     border: 1px solid var(--border);
     border-radius: 8px;
     font-size: 14px;
+    font-family: inherit;
+    background: var(--card);
+    color: var(--text);
   }
+  textarea { min-height: 70px; resize: vertical; }
   button {
     padding: 8px 14px;
     border-radius: 8px;
@@ -57,8 +61,10 @@
   button.danger:hover { background: var(--danger-dark); }
   button:disabled { opacity: 0.5; cursor: not-allowed; }
   table { width: 100%; border-collapse: collapse; font-size: 13px; }
-  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
   th { color: var(--muted); font-weight: 600; }
+  td.actions { white-space: nowrap; }
+  td.actions button { margin-right: 4px; }
   .badge {
     display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px;
     background: #eef0ff; color: var(--accent);
@@ -68,11 +74,29 @@
   #status.error { color: var(--danger); }
   #status.ok { color: #1a7f37; }
   .pager { display: flex; gap: 8px; align-items: center; margin-top: 12px; font-size: 13px; }
+  .tabs { display: flex; gap: 4px; margin-bottom: 16px; flex-wrap: wrap; }
+  .tabs button { background: #fff; color: var(--text); }
+  .tabs button.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .modal-backdrop {
+    display: none; position: fixed; inset: 0; background: rgba(0, 0, 0, 0.4);
+    align-items: center; justify-content: center; z-index: 10;
+  }
+  .modal-backdrop.open { display: flex; }
+  .modal {
+    background: var(--card); border-radius: 12px; padding: 20px; width: 420px; max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 32px); overflow-y: auto;
+  }
+  .modal h2 { font-size: 16px; margin: 0 0 12px; }
+  .modal .field { margin-bottom: 10px; }
+  .modal .field label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+  .modal .field.checkbox { display: flex; align-items: center; gap: 6px; }
+  .modal .field.checkbox label { margin: 0; }
+  .modal .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 </style>
 </head>
 <body>
-  <h1>Pallang 관리자 — 유저 정리</h1>
-  <p class="subtitle">테스트/QA 계정을 검색해서 삭제합니다. 관리자 화이트리스트(admin.user-ids)에 등록된 계정의
+  <h1>Pallang 관리자</h1>
+  <p class="subtitle">테스트/QA 데이터를 검색해서 수정·삭제합니다. 관리자 화이트리스트(admin.user-ids)에 등록된 계정의
     JWT access token으로만 동작합니다. 삭제는 되돌릴 수 없습니다.</p>
 
   <div class="card">
@@ -82,9 +106,11 @@
     </div>
   </div>
 
+  <div class="tabs" id="tabs"></div>
+
   <div class="card">
     <div class="row">
-      <input id="keyword" type="text" placeholder="닉네임 또는 이메일 검색어" />
+      <input id="keyword" type="text" />
       <button id="searchBtn">검색</button>
     </div>
     <div id="status"></div>
@@ -92,11 +118,7 @@
 
   <div class="card">
     <table>
-      <thead>
-        <tr>
-          <th>ID</th><th>닉네임</th><th>이메일</th><th>SNS</th><th>가입일</th><th>호스트 모임 수</th><th></th>
-        </tr>
-      </thead>
+      <thead id="thead"></thead>
       <tbody id="rows"></tbody>
     </table>
     <div class="pager">
@@ -106,16 +128,150 @@
     </div>
   </div>
 
+  <div class="modal-backdrop" id="modalBackdrop">
+    <div class="modal">
+      <h2 id="modalTitle">수정</h2>
+      <div id="modalFields"></div>
+      <div class="actions">
+        <button id="modalCancel" class="secondary">취소</button>
+        <button id="modalSave">저장</button>
+      </div>
+    </div>
+  </div>
+
 <script>
+  // 탭마다 목록/수정/삭제 API 경로와 표에 보여줄 컬럼, 수정 폼에 쓸 필드를 정의한다. 탭을 늘릴 때는
+  // 이 설정 객체만 추가하면 되고, 검색·페이징·수정 모달·삭제 확인 로직은 공용으로 재사용된다.
+  const TABS = {
+    users: {
+      label: "유저", listUrl: "/api/admin/users", listKey: "users", idKey: "userId",
+      searchPlaceholder: "닉네임 또는 이메일 검색어",
+      columns: [
+        { label: "ID", render: r => r.userId },
+        { label: "닉네임", render: r => escapeHtml(r.nickname) + (r.withdrawn ? ' <span class="badge warn">탈퇴</span>' : "") },
+        { label: "이메일", render: r => escapeHtml(r.email || "-") },
+        { label: "SNS", render: r => `<span class="badge">${escapeHtml(r.snsProvider)}</span>` },
+        { label: "가입일", render: r => fmtDate(r.createdAt) },
+        { label: "호스트 모임 수", render: r => r.hostedGroupCount },
+      ],
+      deleteUrl: r => `/api/admin/users/${r.userId}`,
+      deleteConfirmText: r => `${r.nickname}(id: ${r.userId})을(를) 삭제할까요?\n연관된 모임/흔적/의견/댓글이 함께 사라지며 되돌릴 수 없습니다.`,
+    },
+    passages: {
+      label: "대목", listUrl: "/api/admin/passages", listKey: "passages", idKey: "passageId",
+      searchPlaceholder: "인용문 검색어",
+      columns: [
+        { label: "ID", render: r => r.passageId },
+        { label: "책", render: r => escapeHtml(r.bookTitle) },
+        { label: "모임", render: r => r.groupName ? escapeHtml(r.groupName) : "-" },
+        { label: "작성자", render: r => escapeHtml(r.creatorNickname) },
+        { label: "페이지", render: r => r.pageNumber },
+        { label: "인용문", render: r => escapeHtml(truncate(r.quotedText, 40)) },
+        { label: "상태", render: r => (r.deleted ? '<span class="badge warn">삭제됨</span> ' : "") + (r.isSpoiler ? '<span class="badge">스포일러</span>' : "") },
+      ],
+      editFields: [
+        { name: "quotedText", label: "인용문", type: "textarea", value: r => r.quotedText },
+        { name: "pageNumber", label: "페이지 번호", type: "number", value: r => r.pageNumber },
+        { name: "isSpoiler", label: "스포일러", type: "checkbox", value: r => r.isSpoiler },
+      ],
+      updateUrl: r => `/api/admin/passages/${r.passageId}`,
+      deleteUrl: r => `/api/admin/passages/${r.passageId}`,
+      deleteConfirmText: r => `대목(id: ${r.passageId})을(를) 삭제할까요?\n달린 의견/댓글/데코/좋아요까지 함께 사라지며 되돌릴 수 없습니다.`,
+    },
+    opinions: {
+      label: "의견", listUrl: "/api/admin/opinions", listKey: "opinions", idKey: "opinionId",
+      searchPlaceholder: "내용 검색어",
+      columns: [
+        { label: "ID", render: r => r.opinionId },
+        { label: "대목", render: r => escapeHtml(truncate(r.passageQuotedText, 20)) },
+        { label: "작성자", render: r => escapeHtml(r.userNickname) },
+        { label: "내용", render: r => escapeHtml(truncate(r.content, 40)) },
+        { label: "좋아요", render: r => r.likeCount },
+        { label: "상태", render: r => r.deleted ? '<span class="badge warn">삭제됨</span>' : "" },
+      ],
+      editFields: [
+        { name: "content", label: "내용", type: "textarea", value: r => r.content },
+      ],
+      updateUrl: r => `/api/admin/opinions/${r.opinionId}`,
+      deleteUrl: r => `/api/admin/opinions/${r.opinionId}`,
+      deleteConfirmText: r => `의견(id: ${r.opinionId})을(를) 삭제할까요?\n달린 댓글/데코/좋아요까지 함께 사라지며, 대목에 남은 의견이 없으면 대목도 함께 정리됩니다. 되돌릴 수 없습니다.`,
+    },
+    comments: {
+      label: "댓글", listUrl: "/api/admin/comments", listKey: "comments", idKey: "commentId",
+      searchPlaceholder: "내용 검색어",
+      columns: [
+        { label: "ID", render: r => r.commentId },
+        { label: "의견 ID", render: r => r.opinionId },
+        { label: "구분", render: r => r.parentCommentId ? `답글(→${r.parentCommentId})` : "원댓글" },
+        { label: "작성자", render: r => escapeHtml(r.userNickname) },
+        { label: "내용", render: r => escapeHtml(truncate(r.content, 40)) },
+        { label: "상태", render: r => r.deleted ? '<span class="badge warn">삭제됨</span>' : "" },
+      ],
+      editFields: [
+        { name: "content", label: "내용", type: "textarea", value: r => r.content },
+      ],
+      updateUrl: r => `/api/admin/comments/${r.commentId}`,
+      deleteUrl: r => `/api/admin/comments/${r.commentId}`,
+      deleteConfirmText: r => `댓글(id: ${r.commentId})을(를) 삭제할까요?\n원댓글이면 달린 답글도 함께 사라지며 되돌릴 수 없습니다.`,
+    },
+    groups: {
+      label: "모임", listUrl: "/api/admin/groups", listKey: "groups", idKey: "groupId",
+      searchPlaceholder: "모임명 검색어",
+      columns: [
+        { label: "ID", render: r => r.groupId },
+        { label: "모임명", render: r => escapeHtml(r.name) },
+        { label: "책", render: r => escapeHtml(r.bookTitle) },
+        { label: "호스트", render: r => escapeHtml(r.hostNickname) },
+        { label: "인원", render: r => `${r.memberCount}/${r.capacity}` },
+        { label: "기간", render: r => `${r.startDate} ~ ${r.endDate}` },
+      ],
+      editFields: [
+        { name: "name", label: "모임명", type: "text", value: r => r.name },
+        { name: "capacity", label: "정원(2~10)", type: "number", value: r => r.capacity },
+        { name: "startDate", label: "시작일", type: "date", value: r => r.startDate },
+        { name: "endDate", label: "종료일", type: "date", value: r => r.endDate },
+      ],
+      updateUrl: r => `/api/admin/groups/${r.groupId}`,
+      deleteUrl: r => `/api/admin/groups/${r.groupId}`,
+      deleteConfirmText: r => `모임(${r.name}, id: ${r.groupId})을(를) 삭제할까요?\n안의 대목/의견/댓글/모임원까지 함께 사라지며 되돌릴 수 없습니다.`,
+    },
+    books: {
+      label: "책", listUrl: "/api/admin/books", listKey: "books", idKey: "bookId",
+      searchPlaceholder: "제목 또는 저자 검색어",
+      columns: [
+        { label: "ID", render: r => r.bookId },
+        { label: "제목", render: r => escapeHtml(r.title) },
+        { label: "저자", render: r => escapeHtml(r.author) },
+        { label: "출판사", render: r => escapeHtml(r.publisher) },
+        { label: "쪽수", render: r => r.pageCount },
+        { label: "출처", render: r => `<span class="badge">${escapeHtml(r.source)}</span>` },
+      ],
+      editFields: [
+        { name: "title", label: "제목", type: "text", value: r => r.title },
+        { name: "author", label: "저자", type: "text", value: r => r.author },
+        { name: "publisher", label: "출판사", type: "text", value: r => r.publisher },
+        { name: "pageCount", label: "쪽수", type: "number", value: r => r.pageCount },
+        { name: "isbn", label: "ISBN", type: "text", value: r => r.isbn || "" },
+        { name: "coverImageUrl", label: "표지 URL", type: "text", value: r => r.coverImageUrl || "" },
+      ],
+      updateUrl: r => `/api/admin/books/${r.bookId}`,
+      deleteUrl: r => `/api/admin/books/${r.bookId}`,
+      deleteConfirmText: r => `책(${r.title}, id: ${r.bookId})을(를) 삭제할까요?\n이 책으로 만들어진 모임/대목/의견/댓글까지 전부 함께 사라지며 되돌릴 수 없습니다. 여러 사용자에게 영향을 줄 수 있는 위험한 작업입니다.`,
+    },
+  };
+
   const TOKEN_KEY = "pallang_admin_token";
   const tokenInput = document.getElementById("token");
+  const keywordInput = document.getElementById("keyword");
+  const theadEl = document.getElementById("thead");
   const rowsEl = document.getElementById("rows");
   const statusEl = document.getElementById("status");
   const pageLabel = document.getElementById("pageLabel");
+  const tabsEl = document.getElementById("tabs");
 
-  let currentKeyword = "";
-  let currentPage = 0;
-  let lastPageInfo = null;
+  let currentTabKey = "users";
+  // 탭별 검색어/페이지를 따로 기억해, 탭을 오갈 때 이전 검색 상태가 유지되게 한다.
+  const tabState = Object.fromEntries(Object.keys(TABS).map(key => [key, { keyword: "", page: 0, pageInfo: null }]));
 
   function loadToken() {
     try {
@@ -159,62 +315,92 @@
     return body;
   }
 
+  function renderTabs() {
+    tabsEl.innerHTML = "";
+    for (const [key, tab] of Object.entries(TABS)) {
+      const btn = document.createElement("button");
+      btn.textContent = tab.label;
+      btn.className = key === currentTabKey ? "active" : "secondary";
+      btn.addEventListener("click", () => switchTab(key));
+      tabsEl.appendChild(btn);
+    }
+  }
+
+  function switchTab(key) {
+    currentTabKey = key;
+    renderTabs();
+    const tab = TABS[key];
+    keywordInput.placeholder = tab.searchPlaceholder;
+    keywordInput.value = tabState[key].keyword;
+    renderTableHead();
+    rowsEl.innerHTML = "";
+    setStatus("");
+    renderPager();
+  }
+
+  function renderTableHead() {
+    const tab = TABS[currentTabKey];
+    theadEl.innerHTML = "<tr>" + tab.columns.map(c => `<th>${c.label}</th>`).join("") + "<th></th></tr>";
+  }
+
   async function search(page) {
-    if (!currentKeyword) {
+    const tab = TABS[currentTabKey];
+    const state = tabState[currentTabKey];
+    if (!state.keyword) {
       setStatus("검색어를 입력하세요.", "error");
       return;
     }
     setStatus("검색 중...");
     try {
       const result = await callApi(
-        "/api/admin/users?keyword=" + encodeURIComponent(currentKeyword) + "&page=" + page + "&size=20",
+        `${tab.listUrl}?keyword=${encodeURIComponent(state.keyword)}&page=${page}&size=20`,
         { method: "GET" },
       );
-      currentPage = page;
-      lastPageInfo = result.data.pageInfo;
-      renderRows(result.data.users);
+      state.page = page;
+      state.pageInfo = result.data.pageInfo;
+      const list = result.data[tab.listKey];
+      renderRows(list);
       renderPager();
-      setStatus(result.data.users.length + "명 조회됨.", "ok");
+      setStatus(list.length + "건 조회됨.", "ok");
     } catch (e) {
       setStatus(e.message, "error");
     }
   }
 
-  function renderRows(users) {
+  function renderRows(list) {
+    const tab = TABS[currentTabKey];
     rowsEl.innerHTML = "";
-    for (const user of users) {
+    for (const row of list) {
       const tr = document.createElement("tr");
-      tr.innerHTML = `
-        <td>${user.userId}</td>
-        <td>${escapeHtml(user.nickname)}${user.withdrawn ? ' <span class="badge warn">탈퇴</span>' : ""}</td>
-        <td>${escapeHtml(user.email || "-")}</td>
-        <td><span class="badge">${escapeHtml(user.snsProvider)}</span></td>
-        <td>${escapeHtml((user.createdAt || "").replace("T", " ").slice(0, 16))}</td>
-        <td>${user.hostedGroupCount}</td>
-        <td></td>
-      `;
-      const deleteCell = tr.lastElementChild;
+      tr.innerHTML = tab.columns.map(c => `<td>${c.render(row)}</td>`).join("") + '<td class="actions"></td>';
+      const actionsCell = tr.lastElementChild;
+      if (tab.editFields) {
+        const editBtn = document.createElement("button");
+        editBtn.className = "secondary";
+        editBtn.textContent = "수정";
+        editBtn.addEventListener("click", () => openEditModal(row));
+        actionsCell.appendChild(editBtn);
+      }
       const deleteBtn = document.createElement("button");
       deleteBtn.className = "danger";
       deleteBtn.textContent = "삭제";
-      deleteBtn.addEventListener("click", () => deleteUser(user, deleteBtn));
-      deleteCell.appendChild(deleteBtn);
+      deleteBtn.addEventListener("click", () => deleteRow(row, deleteBtn));
+      actionsCell.appendChild(deleteBtn);
       rowsEl.appendChild(tr);
     }
   }
 
-  async function deleteUser(user, button) {
-    const confirmed = confirm(
-      `${user.nickname}(id: ${user.userId})을(를) 삭제할까요?\n연관된 모임/흔적/의견/댓글이 함께 사라지며 되돌릴 수 없습니다.`,
-    );
+  async function deleteRow(row, button) {
+    const tab = TABS[currentTabKey];
+    const confirmed = confirm(tab.deleteConfirmText(row));
     if (!confirmed) return;
 
     button.disabled = true;
     setStatus("삭제 중...");
     try {
-      await callApi("/api/admin/users/" + user.userId, { method: "DELETE" });
-      setStatus(`${user.nickname}(id: ${user.userId}) 삭제 완료.`, "ok");
-      search(currentPage);
+      await callApi(tab.deleteUrl(row), { method: "DELETE" });
+      setStatus(`id: ${row[tab.idKey]} 삭제 완료.`, "ok");
+      search(tabState[currentTabKey].page);
     } catch (e) {
       setStatus("삭제 실패: " + e.message, "error");
       button.disabled = false;
@@ -222,13 +408,95 @@
   }
 
   function renderPager() {
-    if (!lastPageInfo) {
+    const pageInfo = tabState[currentTabKey].pageInfo;
+    if (!pageInfo) {
       pageLabel.textContent = "";
+      document.getElementById("prevBtn").disabled = true;
+      document.getElementById("nextBtn").disabled = true;
       return;
     }
-    pageLabel.textContent = `${lastPageInfo.page + 1} / ${Math.max(lastPageInfo.totalPages, 1)}페이지 (총 ${lastPageInfo.totalElements}명)`;
-    document.getElementById("prevBtn").disabled = lastPageInfo.page <= 0;
-    document.getElementById("nextBtn").disabled = !lastPageInfo.hasNext;
+    pageLabel.textContent = `${pageInfo.page + 1} / ${Math.max(pageInfo.totalPages, 1)}페이지 (총 ${pageInfo.totalElements}건)`;
+    document.getElementById("prevBtn").disabled = pageInfo.page <= 0;
+    document.getElementById("nextBtn").disabled = !pageInfo.hasNext;
+  }
+
+  // --- 수정 모달 ---
+  const modalBackdrop = document.getElementById("modalBackdrop");
+  const modalTitle = document.getElementById("modalTitle");
+  const modalFields = document.getElementById("modalFields");
+  let editingRow = null;
+
+  function openEditModal(row) {
+    const tab = TABS[currentTabKey];
+    editingRow = row;
+    modalTitle.textContent = `${tab.label} 수정 (id: ${row[tab.idKey]})`;
+    modalFields.innerHTML = "";
+    for (const field of tab.editFields) {
+      const wrapper = document.createElement("div");
+      const initial = field.value(row);
+      if (field.type === "checkbox") {
+        wrapper.className = "field checkbox";
+        wrapper.innerHTML = `<input type="checkbox" id="f_${field.name}" ${initial ? "checked" : ""} />
+          <label for="f_${field.name}">${field.label}</label>`;
+      } else if (field.type === "textarea") {
+        wrapper.className = "field";
+        wrapper.innerHTML = `<label for="f_${field.name}">${field.label}</label>
+          <textarea id="f_${field.name}">${escapeHtml(String(initial ?? ""))}</textarea>`;
+      } else {
+        wrapper.className = "field";
+        wrapper.innerHTML = `<label for="f_${field.name}">${field.label}</label>
+          <input type="${field.type}" id="f_${field.name}" value="${escapeHtml(String(initial ?? ""))}" />`;
+      }
+      modalFields.appendChild(wrapper);
+    }
+    modalBackdrop.classList.add("open");
+  }
+
+  function closeEditModal() {
+    modalBackdrop.classList.remove("open");
+    editingRow = null;
+  }
+
+  document.getElementById("modalCancel").addEventListener("click", closeEditModal);
+  modalBackdrop.addEventListener("click", (e) => {
+    if (e.target === modalBackdrop) closeEditModal();
+  });
+
+  document.getElementById("modalSave").addEventListener("click", async () => {
+    const tab = TABS[currentTabKey];
+    const row = editingRow;
+    if (!row) return;
+
+    const body = {};
+    for (const field of tab.editFields) {
+      const el = document.getElementById(`f_${field.name}`);
+      if (field.type === "checkbox") {
+        body[field.name] = el.checked;
+      } else if (field.type === "number") {
+        body[field.name] = Number(el.value);
+      } else {
+        body[field.name] = el.value;
+      }
+    }
+
+    setStatus("저장 중...");
+    try {
+      await callApi(tab.updateUrl(row), { method: "PATCH", body: JSON.stringify(body) });
+      setStatus(`id: ${row[tab.idKey]} 수정 완료.`, "ok");
+      closeEditModal();
+      search(tabState[currentTabKey].page);
+    } catch (e) {
+      setStatus("수정 실패: " + e.message, "error");
+    }
+  });
+
+  function truncate(value, maxLength) {
+    const text = String(value ?? "");
+    return text.length > maxLength ? text.slice(0, maxLength) + "…" : text;
+  }
+
+  function fmtDate(value) {
+    return escapeHtml((value || "").replace("T", " ").slice(0, 16));
   }
 
   function escapeHtml(value) {
@@ -238,18 +506,23 @@
   }
 
   document.getElementById("searchBtn").addEventListener("click", () => {
-    currentKeyword = document.getElementById("keyword").value.trim();
+    tabState[currentTabKey].keyword = keywordInput.value.trim();
     search(0);
   });
-  document.getElementById("keyword").addEventListener("keydown", (e) => {
+  keywordInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") document.getElementById("searchBtn").click();
   });
   document.getElementById("prevBtn").addEventListener("click", () => {
-    if (currentPage > 0) search(currentPage - 1);
+    const state = tabState[currentTabKey];
+    if (state.page > 0) search(state.page - 1);
   });
   document.getElementById("nextBtn").addEventListener("click", () => {
-    if (lastPageInfo && lastPageInfo.hasNext) search(currentPage + 1);
+    const state = tabState[currentTabKey];
+    if (state.pageInfo && state.pageInfo.hasNext) search(state.page + 1);
   });
+
+  renderTabs();
+  switchTab(currentTabKey);
 </script>
 </body>
 </html>

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminAccessGuardTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminAccessGuardTest.java
@@ -1,0 +1,65 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAccessGuardTest {
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private AdminJwtProvider adminJwtProvider;
+
+    @Test
+    @DisplayName("유효한 관리자 토큰이면 통과한다")
+    void passesWithValidToken() {
+        given(request.getHeader("Authorization")).willReturn("Bearer valid-token");
+        given(adminJwtProvider.isValid("valid-token")).willReturn(true);
+        AdminAccessGuard guard = new AdminAccessGuard(request, adminJwtProvider);
+
+        assertThatCode(guard::requireAdmin).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 거부한다")
+    void deniesWithoutHeader() {
+        given(request.getHeader("Authorization")).willReturn(null);
+        AdminAccessGuard guard = new AdminAccessGuard(request, adminJwtProvider);
+
+        assertThatThrownBy(guard::requireAdmin)
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.ADMIN_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효하지 않으면 거부한다")
+    void deniesWithInvalidToken() {
+        given(request.getHeader("Authorization")).willReturn("Bearer bad-token");
+        given(adminJwtProvider.isValid("bad-token")).willReturn(false);
+        AdminAccessGuard guard = new AdminAccessGuard(request, adminJwtProvider);
+
+        assertThatThrownBy(guard::requireAdmin)
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.ADMIN_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("일반 유저 JWT를 흉내낸 비-Bearer 헤더는 거부한다")
+    void deniesNonBearerHeader() {
+        given(request.getHeader("Authorization")).willReturn("Basic dXNlcjpwYXNz");
+        AdminAccessGuard guard = new AdminAccessGuard(request, adminJwtProvider);
+
+        assertThatThrownBy(guard::requireAdmin).isInstanceOf(AdminException.class);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminBookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminBookServiceTest.java
@@ -1,0 +1,75 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.book.common.error.BookException;
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.book.infrastructure.UserBookStatusRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminBookServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private PassageRepository passageRepository;
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private UserBookStatusRepository userBookStatusRepository;
+    @Mock
+    private AdminCascadeDeleter cascadeDeleter;
+
+    private AdminBookService adminBookService;
+
+    @BeforeEach
+    void setUp() {
+        adminBookService = new AdminBookService(
+                bookRepository, passageRepository, groupRepository, userBookStatusRepository, cascadeDeleter);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 책을 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenBookNotFound() {
+        given(bookRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminBookService.deleteBook(1L)).isInstanceOf(BookException.class);
+    }
+
+    @Test
+    @DisplayName("책을 삭제하면 이 책의 모임/대목을 먼저 지운 뒤 읽기 상태와 책 자체를 지운다")
+    void deleteBookCascadesGroupsAndPassagesThenBook() {
+        given(bookRepository.findById(1L)).willReturn(Optional.of(mock(Book.class)));
+
+        Group hostedGroup = mock(Group.class);
+        given(hostedGroup.getId()).willReturn(100L);
+        given(groupRepository.findAllByBookId(1L)).willReturn(List.of(hostedGroup));
+
+        Passage globalPassage = mock(Passage.class);
+        given(globalPassage.getId()).willReturn(200L);
+        given(passageRepository.findAllByBookId(1L)).willReturn(List.of(globalPassage));
+
+        adminBookService.deleteBook(1L);
+
+        verify(cascadeDeleter).deleteGroups(List.of(100L));
+        verify(cascadeDeleter).deletePassages(List.of(200L));
+        verify(userBookStatusRepository).deleteAllByBookId(1L);
+        verify(bookRepository).deleteById(1L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminCascadeDeleterTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminCascadeDeleterTest.java
@@ -1,0 +1,95 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import com.nexters.palang.domain.decoration.infrastructure.DecorationRepository;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionLikeRepository;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCascadeDeleterTest {
+
+    @Mock
+    private PassageRepository passageRepository;
+    @Mock
+    private OpinionRepository opinionRepository;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private DecorationRepository decorationRepository;
+    @Mock
+    private OpinionLikeRepository opinionLikeRepository;
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    private AdminCascadeDeleter cascadeDeleter;
+
+    @BeforeEach
+    void setUp() {
+        cascadeDeleter = new AdminCascadeDeleter(passageRepository, opinionRepository, commentRepository,
+                decorationRepository, opinionLikeRepository, groupRepository, groupMemberRepository);
+    }
+
+    @Test
+    @DisplayName("의견 삭제는 댓글/데코/좋아요를 먼저 지운 뒤 의견 자체를 지운다")
+    void deleteOpinionsRemovesSubContentFirst() {
+        cascadeDeleter.deleteOpinions(List.of(1L, 2L));
+
+        verify(commentRepository).deleteAllByOpinionIdIn(List.of(1L, 2L));
+        verify(decorationRepository).deleteAllByOpinionIdIn(List.of(1L, 2L));
+        verify(opinionLikeRepository).deleteAllByOpinionIdIn(List.of(1L, 2L));
+        verify(opinionRepository).deleteAllById(List.of(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("빈 id 목록이면 아무 것도 지우지 않는다")
+    void deleteOpinionsNoOpWhenEmpty() {
+        cascadeDeleter.deleteOpinions(List.of());
+
+        verify(opinionRepository, never()).deleteAllById(org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    @DisplayName("대목 삭제는 그 위 의견들을 먼저 지운 뒤 대목 자체를 지운다")
+    void deletePassagesRemovesOpinionsFirst() {
+        given(opinionRepository.findIdsByPassageIdIn(List.of(10L))).willReturn(List.of(1L));
+
+        cascadeDeleter.deletePassages(List.of(10L));
+
+        verify(opinionRepository).deleteAllById(List.of(1L));
+        verify(passageRepository).deleteAllById(List.of(10L));
+    }
+
+    @Test
+    @DisplayName("모임 삭제는 그 안의 대목들을 먼저 지운 뒤 모임원과 모임을 지운다")
+    void deleteGroupsRemovesPassagesThenMembersThenGroup() {
+        Passage passage = mock(Passage.class);
+        given(passage.getId()).willReturn(10L);
+        given(passageRepository.findAllByGroupIdIn(List.of(100L))).willReturn(List.of(passage));
+        given(opinionRepository.findIdsByPassageIdIn(List.of(10L))).willReturn(List.of());
+
+        cascadeDeleter.deleteGroups(List.of(100L));
+
+        verify(passageRepository).deleteAllById(List.of(10L));
+        verify(groupMemberRepository).deleteAllByGroupIdIn(List.of(100L));
+        verify(groupRepository).deleteAllById(List.of(100L));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminCommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminCommentServiceTest.java
@@ -1,0 +1,54 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.comment.common.CommentException;
+import com.nexters.palang.domain.comment.domain.Comment;
+import com.nexters.palang.domain.comment.infrastructure.CommentRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    private AdminCommentService adminCommentService;
+
+    @BeforeEach
+    void setUp() {
+        adminCommentService = new AdminCommentService(commentRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글을 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenCommentNotFound() {
+        given(commentRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminCommentService.deleteComment(1L)).isInstanceOf(CommentException.class);
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제하면 답글을 먼저 지운 뒤 본인을 지운다")
+    void deleteCommentRemovesRepliesBeforeItself() {
+        given(commentRepository.findById(1L)).willReturn(Optional.of(mock(Comment.class)));
+
+        adminCommentService.deleteComment(1L);
+
+        InOrder inOrder = Mockito.inOrder(commentRepository);
+        inOrder.verify(commentRepository).deleteAllByParentCommentIdIn(List.of(1L));
+        inOrder.verify(commentRepository).deleteById(1L);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminGroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminGroupServiceTest.java
@@ -1,0 +1,81 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.group.common.error.GroupException;
+import com.nexters.palang.domain.group.domain.Group;
+import com.nexters.palang.domain.group.infrastructure.GroupMemberRepository;
+import com.nexters.palang.domain.group.infrastructure.GroupRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminGroupServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+    @Mock
+    private AdminCascadeDeleter cascadeDeleter;
+
+    private AdminGroupService adminGroupService;
+
+    @BeforeEach
+    void setUp() {
+        adminGroupService = new AdminGroupService(groupRepository, groupMemberRepository, cascadeDeleter);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임을 수정하려 하면 예외가 발생한다")
+    void updateFailsWhenGroupNotFound() {
+        given(groupRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminGroupService.updateGroup(1L, "이름", 4, LocalDate.now(), LocalDate.now().plusDays(1)))
+                .isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임을 수정하면 현재 참여 인원을 기준으로 설정이 바뀐다")
+    void updateGroupDelegatesToEntity() {
+        Group group = mock(Group.class);
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
+        LocalDate start = LocalDate.of(2026, 1, 1);
+        LocalDate end = LocalDate.of(2026, 2, 1);
+
+        AdminGroupSearchResult result = adminGroupService.updateGroup(1L, "새 이름", 5, start, end);
+
+        verify(group).updateSettings("새 이름", 5, start, end, 3L);
+        assertThat(result.memberCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임을 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenGroupNotFound() {
+        given(groupRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminGroupService.deleteGroup(1L)).isInstanceOf(GroupException.class);
+    }
+
+    @Test
+    @DisplayName("모임을 삭제하면 cascade 삭제기가 호출된다")
+    void deleteGroupDelegatesToCascadeDeleter() {
+        given(groupRepository.findById(1L)).willReturn(Optional.of(mock(Group.class)));
+
+        adminGroupService.deleteGroup(1L);
+
+        verify(cascadeDeleter).deleteGroups(List.of(1L));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminJwtProviderTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminJwtProviderTest.java
@@ -1,0 +1,61 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminJwtProviderTest {
+
+    @Test
+    @DisplayName("발급한 토큰은 스스로 검증에 성공한다")
+    void issuedTokenIsValid() {
+        AdminJwtProvider provider = new AdminJwtProvider("test-admin-secret-at-least-32-bytes-long", 3600);
+
+        String token = provider.createToken();
+
+        assertThat(provider.isValid(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 비밀키로 서명된 토큰은 검증에 실패한다")
+    void tokenSignedWithDifferentSecretIsInvalid() {
+        AdminJwtProvider issuer = new AdminJwtProvider("secret-a-at-least-32-bytes-long-000000", 3600);
+        AdminJwtProvider verifier = new AdminJwtProvider("secret-b-at-least-32-bytes-long-000000", 3600);
+
+        String token = issuer.createToken();
+
+        assertThat(verifier.isValid(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 검증에 실패한다")
+    void expiredTokenIsInvalid() throws InterruptedException {
+        AdminJwtProvider provider = new AdminJwtProvider("test-admin-secret-at-least-32-bytes-long", 0);
+
+        String token = provider.createToken();
+        Thread.sleep(10);
+
+        assertThat(provider.isValid(token)).isFalse();
+    }
+
+    @Test
+    @DisplayName("비밀키를 설정하지 않으면 기동마다 임의의 키로 대체된다")
+    void fallsBackToRandomKeyWhenSecretMissing() {
+        AdminJwtProvider a = new AdminJwtProvider("", 3600);
+        AdminJwtProvider b = new AdminJwtProvider("", 3600);
+
+        String tokenFromA = a.createToken();
+
+        assertThat(a.isValid(tokenFromA)).isTrue();
+        assertThat(b.isValid(tokenFromA)).isFalse();
+    }
+
+    @Test
+    @DisplayName("엉뚱한 문자열은 토큰으로 인정되지 않는다")
+    void garbageStringIsInvalid() {
+        AdminJwtProvider provider = new AdminJwtProvider("test-admin-secret-at-least-32-bytes-long", 3600);
+
+        assertThat(provider.isValid("not-a-jwt")).isFalse();
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminLoginServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminLoginServiceTest.java
@@ -1,0 +1,61 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.nexters.palang.domain.admin.common.error.AdminErrorCode;
+import com.nexters.palang.domain.admin.common.error.AdminException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminLoginServiceTest {
+
+    @Mock
+    private AdminJwtProvider adminJwtProvider;
+
+    @Test
+    @DisplayName("아이디/비밀번호가 일치하면 토큰을 발급한다")
+    void loginSucceedsWithMatchingCredentials() {
+        AdminLoginService service = new AdminLoginService("pallang", "pallang123!", adminJwtProvider);
+        given(adminJwtProvider.createToken()).willReturn("issued-token");
+
+        String token = service.login("pallang", "pallang123!");
+
+        assertThat(token).isEqualTo("issued-token");
+    }
+
+    @Test
+    @DisplayName("비밀번호가 다르면 로그인에 실패한다")
+    void loginFailsWithWrongPassword() {
+        AdminLoginService service = new AdminLoginService("pallang", "pallang123!", adminJwtProvider);
+
+        assertThatThrownBy(() -> service.login("pallang", "wrong"))
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.ADMIN_LOGIN_FAILED);
+    }
+
+    @Test
+    @DisplayName("아이디가 다르면 로그인에 실패한다")
+    void loginFailsWithWrongUsername() {
+        AdminLoginService service = new AdminLoginService("pallang", "pallang123!", adminJwtProvider);
+
+        assertThatThrownBy(() -> service.login("someone-else", "pallang123!"))
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.ADMIN_LOGIN_FAILED);
+    }
+
+    @Test
+    @DisplayName("설정된 아이디/비밀번호가 비어있으면 어떤 입력으로도 로그인할 수 없다")
+    void loginAlwaysFailsWhenNotConfigured() {
+        AdminLoginService service = new AdminLoginService("", "", adminJwtProvider);
+
+        assertThatThrownBy(() -> service.login("pallang", "pallang123!"))
+                .isInstanceOf(AdminException.class)
+                .hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.ADMIN_LOGIN_FAILED);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminOpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminOpinionServiceTest.java
@@ -1,0 +1,82 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.opinion.common.error.OpinionException;
+import com.nexters.palang.domain.opinion.domain.Opinion;
+import com.nexters.palang.domain.opinion.infrastructure.OpinionRepository;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminOpinionServiceTest {
+
+    @Mock
+    private OpinionRepository opinionRepository;
+    @Mock
+    private PassageRepository passageRepository;
+    @Mock
+    private AdminCascadeDeleter cascadeDeleter;
+
+    private AdminOpinionService adminOpinionService;
+
+    @BeforeEach
+    void setUp() {
+        adminOpinionService = new AdminOpinionService(opinionRepository, passageRepository, cascadeDeleter);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 의견을 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenOpinionNotFound() {
+        given(opinionRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminOpinionService.deleteOpinion(1L)).isInstanceOf(OpinionException.class);
+    }
+
+    @Test
+    @DisplayName("대목에 남은 다른 의견이 없으면 의견 삭제 시 대목도 함께 소프트 삭제된다")
+    void deleteOpinionSoftDeletesPassageWhenLast() {
+        Passage passage = mock(Passage.class);
+        given(passage.getId()).willReturn(100L);
+        Opinion opinion = mock(Opinion.class);
+        given(opinion.getPassage()).willReturn(passage);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(false);
+        given(passageRepository.findById(100L)).willReturn(Optional.of(passage));
+
+        adminOpinionService.deleteOpinion(1L);
+
+        verify(cascadeDeleter).deleteOpinions(List.of(1L));
+        verify(passage).delete();
+    }
+
+    @Test
+    @DisplayName("대목에 다른 살아있는 의견이 남아있으면 대목은 삭제되지 않는다")
+    void deleteOpinionKeepsPassageWhenOthersRemain() {
+        Passage passage = mock(Passage.class);
+        given(passage.getId()).willReturn(100L);
+        Opinion opinion = mock(Opinion.class);
+        given(opinion.getPassage()).willReturn(passage);
+        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(true);
+
+        adminOpinionService.deleteOpinion(1L);
+
+        verify(cascadeDeleter).deleteOpinions(List.of(1L));
+        verify(passage, never()).delete();
+        verify(passageRepository, never()).findById(eq(100L));
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminPassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminPassageServiceTest.java
@@ -1,0 +1,76 @@
+package com.nexters.palang.domain.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.nexters.palang.domain.passage.common.error.PassageException;
+import com.nexters.palang.domain.passage.domain.Passage;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AdminPassageServiceTest {
+
+    @Mock
+    private PassageRepository passageRepository;
+    @Mock
+    private AdminCascadeDeleter cascadeDeleter;
+
+    private AdminPassageService adminPassageService;
+
+    @BeforeEach
+    void setUp() {
+        adminPassageService = new AdminPassageService(passageRepository, cascadeDeleter);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대목을 수정하려 하면 예외가 발생한다")
+    void updateFailsWhenPassageNotFound() {
+        given(passageRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminPassageService.updatePassage(1L, "내용", 10, false))
+                .isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("대목을 수정하면 인용문/페이지/스포일러 여부가 바뀐다")
+    void updatePassageChangesContent() {
+        Passage passage = mock(Passage.class);
+        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+
+        Passage result = adminPassageService.updatePassage(1L, "새 인용문", 20, true);
+
+        verify(passage).updateContent("새 인용문", 20);
+        verify(passage).changeSpoiler(true);
+        assertThat(result).isSameAs(passage);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 대목을 삭제하려 하면 예외가 발생한다")
+    void deleteFailsWhenPassageNotFound() {
+        given(passageRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminPassageService.deletePassage(1L)).isInstanceOf(PassageException.class);
+    }
+
+    @Test
+    @DisplayName("대목을 삭제하면 cascade 삭제기가 호출된다")
+    void deletePassageDelegatesToCascadeDeleter() {
+        given(passageRepository.findById(1L)).willReturn(Optional.of(mock(Passage.class)));
+
+        adminPassageService.deletePassage(1L);
+
+        verify(cascadeDeleter).deletePassages(List.of(1L));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #157

## 🚀 개요
> #155에서 만든 관리자 페이지(`/admin`)가 유저 삭제만 가능했던 것을, 대목(Passage)·의견(Opinion)·댓글(Comment)·모임(Group)·도서(Book)까지 조회·수정·삭제할 수 있게 넓힙니다. 또한 관리자 인증 방식을 "기존 유저 JWT + userId 화이트리스트"에서, 일반 유저 계정과 완전히 분리된 **관리자 전용 아이디/비밀번호 로그인**으로 바꿉니다(리뷰 중 요청 반영).

## 📄 작업 내용

### 관리자 로그인 방식 변경
- `POST /api/admin/auth/login`(username, password) — 성공 시 관리자 전용 JWT 발급. `admin.login-username`/`admin.login-password`(env: `ADMIN_LOGIN_USERNAME`/`ADMIN_LOGIN_PASSWORD`)와 정확히 일치해야 하며, 비교는 타이밍 공격을 막기 위해 `MessageDigest.isEqual`로 한다.
- 관리자 JWT는 일반 유저 JWT와 **완전히 다른 비밀키**(`admin.jwt-secret`, env: `ADMIN_JWT_SECRET`)로 서명한다 — 두 토큰 체계가 섞이면 한쪽 토큰으로 다른 쪽을 위조할 수 있는 경로가 생기기 때문. 세 값(`ADMIN_LOGIN_USERNAME`/`PASSWORD`/`ADMIN_JWT_SECRET`) 중 하나라도 비어있으면 로그인이 항상 실패하는 안전한 기본값으로 설계했다(`AdminJwtProvider`가 비밀키 미설정 시 기동마다 바뀌는 임시 키로 대체).
- `AdminAccessGuard`가 더 이상 `CurrentUserProvider`(일반 유저 로그인)를 거치지 않고, `Authorization` 헤더의 토큰을 `AdminJwtProvider`로 직접 검증하도록 변경. 기존 `admin.user-ids` 화이트리스트는 제거.
- `/admin` 페이지에 로그인 폼(아이디/비밀번호) 추가, 로그인 성공 시 토큰을 저장하고 메인 화면으로 전환. API가 401/403을 돌려주면(세션 만료 등) 자동으로 로그인 화면으로 되돌아간다.

### 대목/의견/댓글/모임/도서 관리 기능
- API (전부 새 `AdminAccessGuard`로 관리자 로그인 토큰 검증)

  | Method | Path | 설명 |
  | --- | --- | --- |
  | GET | `/api/admin/passages?keyword=&page=&size=` | 인용문 검색(소프트 삭제 포함) |
  | PATCH | `/api/admin/passages/{id}` | 인용문/페이지 번호/스포일러 여부 수정 |
  | DELETE | `/api/admin/passages/{id}` | 대목 + 의견/댓글/데코/좋아요 하드 삭제 |
  | GET | `/api/admin/opinions?keyword=&page=&size=` | 내용 검색(소프트 삭제 포함) |
  | PATCH | `/api/admin/opinions/{id}` | 내용 수정 |
  | DELETE | `/api/admin/opinions/{id}` | 의견 + 댓글/데코/좋아요 하드 삭제 (대목에 남은 의견이 없으면 대목도 소프트 삭제) |
  | GET | `/api/admin/comments?keyword=&page=&size=` | 내용 검색(소프트 삭제 포함, 답글 포함) |
  | PATCH | `/api/admin/comments/{id}` | 내용 수정 |
  | DELETE | `/api/admin/comments/{id}` | 댓글 하드 삭제(원댓글이면 답글도 함께) |
  | GET | `/api/admin/groups?keyword=&page=&size=` | 모임명 검색 |
  | PATCH | `/api/admin/groups/{id}` | 모임명/정원/기간 수정 (기존 `Group.updateSettings` 재사용, 도서는 수정 불가) |
  | DELETE | `/api/admin/groups/{id}` | 모임 + 대목/의견/댓글/데코/좋아요/모임원 하드 삭제 |
  | GET | `/api/admin/books?keyword=&page=&size=` | 제목/저자 검색 |
  | PATCH | `/api/admin/books/{id}` | 제목/저자/출판사/쪽수/ISBN/표지 URL 수정 |
  | DELETE | `/api/admin/books/{id}` | 이 책의 모임/대목/의견/댓글까지 전부 cascade 하드 삭제 |

- `AdminCascadeDeleter`: 의견→댓글/데코/좋아요, 대목→의견 이하, 모임→대목 이하로 이어지는 하드 삭제 cascade를 공용 컴포넌트로 뽑아, Passage/Opinion/Group/Book 4개 관리자 서비스가 함께 재사용합니다. (#155의 `AdminUserService`는 유저별 예외 케이스가 있어 그대로 두고 건드리지 않았습니다.)
- 삭제 방식 결정: 대목/의견/댓글은 원래 소프트 삭제를 쓰지만, 관리자 삭제는 "테스트 데이터를 실제로 지우는 것"이 목적이라 **하드 삭제**로 했습니다. 도서 삭제는 여러 유저의 모임/대목을 통째로 지울 수 있는 위험한 작업이지만, "차단"이 아니라 **전부 cascade 삭제**로 결정했습니다(#157 참고 사항).
- `Passage.updateContent(quotedText, pageNumber)` / `Book.update(...)` 엔티티 메서드 신규 추가(둘 다 기존 유저 플로우엔 수정 기능이 없었음). `Group`/`Opinion`/`Comment`는 기존 `updateSettings`/`updateContent` 메서드를 그대로 재사용했습니다.
- 각 레포지토리에 검색용(`findByXxxContaining`)·cascade용(`findAllByBookId`, `deleteAllByGroupIdIn` 등) 파생 쿼리 메서드 추가.
- `src/main/resources/static/admin/index.html`: 유저/대목/의견/댓글/모임/도서 탭을 추가했습니다. 탭마다 목록/수정/삭제 API 경로와 표 컬럼, 수정 폼 필드를 설정 객체로 정의하고, 검색·페이징·수정 모달·삭제 확인 로직은 공용 코드로 재사용합니다(도메인 5개를 위해 거의 같은 JS를 5번 복붙하지 않도록).

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` — 신규 단위 테스트(대목/의견/댓글/모임/도서 서비스 + `AdminCascadeDeleter` + 관리자 로그인/토큰/가드, 총 29개) 포함 전체 통과. 기존에 실패하던 3건(로컬 Redis 미기동으로 인한 `AladinBookApiClientCacheTest`)은 이 PR과 무관합니다.
- `local` 프로파일(내장 H2)로 실제 앱을 기동해 다음을 전부 실제 서버에 대고 확인했습니다.
  - `POST /api/admin/auth/login` — 틀린 비밀번호는 401, 올바른 아이디/비밀번호는 200 + 토큰 발급
  - 발급받은 관리자 토큰으로는 `/api/admin/users` 등이 정상 동작, 반대로 **일반 유저 로그인(dev-login) JWT로는 같은 요청이 403으로 거부**되는지 확인(두 토큰 체계가 완전히 분리됐는지 검증)
  - 도서/모임/대목/의견/댓글을 실제로 생성한 뒤, 5개 도메인의 검색(키워드/페이징) API가 지연 로딩 연관관계(책 제목/모임명/작성자 닉네임 등)까지 포함해 정상 응답하는지 확인
  - 5개 도메인의 수정(PATCH) API가 실제로 값을 바꾸는지 확인
  - 댓글 단건 삭제, 대목 단건 삭제 확인
  - **의견이 대목의 마지막 의견일 때 삭제하면 대목이 자동으로 소프트 삭제되는지** 확인(가장 까다로운 분기)
  - **도서 삭제 시 그 책의 모임 → 대목 → 의견까지 FK 위반 없이 전부 cascade 삭제되는지** 확인
  - `/admin` 페이지에 로그인 폼이 정상 렌더링되고, 새로 추가한 인라인 스크립트가 문법 오류 없이 로드되는지 확인(`node --check`)
- 이번에도 브라우저로 직접 클릭해보며 로그인/수정 모달 UI를 눈으로 확인하지는 못했습니다(이 세션에서 브라우저 자동화 권한이 막혀 있음) — API 레벨 동작은 위처럼 실제 서버로 검증했습니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 관리자 로그인을 "일반 유저 JWT 재사용 + userId 화이트리스트"에서 "완전히 독립된 아이디/비밀번호 로그인"으로 바꿨습니다. 계정 체계가 하나 더 생기는 트레이드오프가 있지만, 관리자 페이지가 특정 개발자 계정에 종속되지 않고 더 명확하게 분리된다는 장점이 있다고 판단했습니다. 비밀번호 재설정/분실 시 흐름은 아직 없고(env 값을 직접 바꿔서 재배포), 필요해지면 별도 이슈로 다루면 될 것 같습니다.
- 도서 삭제를 "차단" 대신 "전부 cascade"로 결정한 게 맞는지 다시 한번 확인 부탁드립니다 — 다른 유저의 모임/대목까지 흔적도 없이 사라지는 가장 파급력이 큰 작업입니다. `AdminBookApi`의 설명과 관리자 페이지 삭제 확인 문구에 위험성을 명시해뒀습니다.
- 대목/의견/댓글 관리자 삭제를 소프트 삭제가 아니라 하드 삭제로 한 게 이 도메인들의 기존 설계(소프트 삭제로 이력을 남김)와 어긋나 보일 수 있는데, "테스트 데이터 정리"라는 목적에는 하드 삭제가 맞다고 판단했습니다. 다른 의견 있으시면 알려주세요.
- `/admin/index.html`을 설정 객체 기반 공용 UI로 새로 짰습니다. 코드량은 줄었지만 필드 타입(text/textarea/number/checkbox/date)이 앞으로 더 다양해지면 이 구조가 얼마나 버틸지는 지켜봐야 할 것 같습니다.
