### PR TITLE
Fix/#159 관리자 페이지 로그인 403 - CORS 허용 목록 누락

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -58,8 +58,11 @@ storage:
   public-base-url: ${STORAGE_PUBLIC_BASE_URL:https://api-dev.pallang.co.kr/images}
 
 # 6. CORS 허용 origin (프론트엔드와 서브도메인이 달라 브라우저 기준 다른 origin으로 취급됨)
+# api-dev.pallang.co.kr 자신도 포함한다 — /admin 정적 페이지가 이 API 서버 자신에서 서빙되는데,
+# 브라우저가 같은 오리진 요청에도 Origin 헤더를 보내는 경우(POST 등)가 있어 이 목록에 없으면
+# Spring Security의 CorsFilter가 자기 자신에 대한 fetch까지 403으로 막아버린다.
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://api-dev.pallang.co.kr,https://dev.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -65,9 +65,11 @@ jwt:
   access-token-expiration-seconds: ${JWT_ACCESS_EXPIRATION_SECONDS:3600}
   refresh-token-expiration-seconds: ${JWT_REFRESH_EXPIRATION_SECONDS:1209600}
 
-# CORS 허용 origin (운영 도메인)
+# CORS 허용 origin (운영 도메인). api.pallang.co.kr 자신도 포함한다 — /admin 정적 페이지가
+# 이 API 서버 자신에서 서빙되는데, 브라우저가 같은 오리진 요청에도 Origin 헤더를 보내는 경우(POST 등)가
+# 있어 이 목록에 없으면 Spring Security의 CorsFilter가 자기 자신에 대한 fetch까지 403으로 막아버린다.
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://www.pallang.co.kr,https://pallang.co.kr}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:https://api.pallang.co.kr,https://www.pallang.co.kr,https://pallang.co.kr}
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ apple:
   private-key: ${APPLE_PRIVATE_KEY:}
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:8080,http://localhost:3000,http://localhost:3001,http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:3005,http://localhost:3006,http://localhost:3007,http://localhost:3008,http://localhost:3009,http://localhost:3010}
 
 jwt:
   secret: ${JWT_SECRET:local-dev-jwt-secret-key-please-change-this-01234567890123456789}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #159

## 🚀 개요
> `/admin` 페이지에서 로그인이 403으로 막히는 회귀를 고칩니다. CORS 허용 목록에 API 서버 자기 자신의 오리진이 빠져 있던 게 원인입니다.

## 📄 작업 내용
- `application-dev.yaml`: `cors.allowed-origins` 기본값에 `https://api-dev.pallang.co.kr` 추가
- `application-prod.yaml`: `cors.allowed-origins` 기본값에 `https://api.pallang.co.kr` 추가
- `application.yaml`(로컬): `cors.allowed-origins` 기본값에 `http://localhost:8080` 추가(로컬에서 브라우저로 `/admin`을 열 때도 같은 문제가 나므로)
- dev/prod의 `.env`(GitHub Environment secret `APP_ENV_FILE`)에는 `CORS_ALLOWED_ORIGINS`를 별도로 설정해두지 않아 YAML 기본값을 그대로 쓰고 있었습니다 — 이번 PR만 머지/배포하면 되고, secret을 따로 만질 필요는 없습니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- 원인 재현: dev에 `Origin: https://api-dev.pallang.co.kr` 헤더를 실어 `POST /api/admin/auth/login`을 호출하면 `"Invalid CORS request"` 403이 그대로 재현됩니다(curl은 기본적으로 Origin 헤더를 보내지 않아 이전 배포 전 검증에서는 발견하지 못했습니다).
- 로컬에 수정 사항을 적용해 같은 방식(`Origin: http://localhost:8080`)으로 재현해보니 더 이상 CORS로 막히지 않고 컨트롤러까지 도달해 정상적으로 `401 ADMIN_401_1`(로그인 실패, 테스트용 잘못된 자격 증명이라 기대한 응답)이 나오는 것을 확인했습니다.
- `./gradlew test` — 전체 통과(기존에 실패하던 3건은 로컬 Redis 미기동으로 인한 것으로 이 PR과 무관).

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- YAML 설정만으로 고쳤는데, `/admin`이 앞으로도 API 서버 자신에서 계속 서빙될 거라면 이 패턴(자기 자신 오리진을 CORS 목록에 넣는 것)이 맞는 방향인지, 아니면 `/api/admin/**`·`/admin/**` 경로는 아예 CORS 검사 자체에서 빼는 게 더 나을지 의견 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 개발·운영 환경에서 API 도메인에 대한 CORS 요청을 허용했습니다.
  * 로컬 개발 환경에서 `localhost:8080` 출처를 추가로 지원합니다.
  * 기존에 허용되던 도메인과 로컬 출처는 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->