### PR TITLE
Fix/#161 관리자 페이지 검색어 없으면 목록 안 보이는 문제

### DIFF
--- a/src/main/resources/static/admin/index.html
+++ b/src/main/resources/static/admin/index.html
@@ -405,6 +405,11 @@
     rowsEl.innerHTML = "";
     setStatus("");
     renderPager();
+    // 로그인된 상태에서 탭을 열면 바로 목록을 보여준다 — 검색어를 먼저 입력해야만 뭔가 보이는
+    // 상태로 두면 "데이터가 하나도 없다"처럼 보이기 쉽다.
+    if (loadToken()) {
+      search(tabState[key].page);
+    }
   }
 
   function renderTableHead() {
@@ -415,10 +420,8 @@
   async function search(page) {
     const tab = TABS[currentTabKey];
     const state = tabState[currentTabKey];
-    if (!state.keyword) {
-      setStatus("검색어를 입력하세요.", "error");
-      return;
-    }
+    // 검색어를 비워두면 서버가 전체 목록을 돌려준다(모든 admin 검색 API가 Containing 쿼리라 빈
+    // 문자열은 모든 값에 매치된다) — 굳이 아무 키워드나 입력해야만 목록을 볼 수 있게 막지 않는다.
     setStatus("검색 중...");
     try {
       const result = await callApi(


### PR DESCRIPTION
## 📌 관련 이슈
- Close #161

## 🚀 개요
> 관리자 페이지에서 검색어 없이 탭을 열면 데이터가 하나도 없는 것처럼 보이는 문제를 고칩니다. 실제로는 dev DB에 데이터가 있는데(유저 32명, 도서 57권 등), 프론트가 빈 검색어일 때 API 호출 자체를 막고 있었습니다.

## 📄 작업 내용
- `search()`에서 빈 검색어면 조기 반환하던 가드 제거 — 모든 관리자 검색 API가 `findByXxxContaining` 계열이라 빈 문자열도 전체 목록에 매치되므로 서버는 이미 지원하고 있었습니다.
- `switchTab()`에서 로그인된 상태면 탭을 열 때 자동으로 첫 페이지를 조회하도록 변경 — 검색어를 먼저 입력해야만 뭔가 보이던 걸, 로그인/탭 전환 직후 바로 목록이 보이게 했습니다.

## 📸 스크린샷 / 테스트 결과 (선택)
- `node --check`로 수정한 인라인 스크립트 문법 확인.
- 백엔드 변경이 없어 `./gradlew test`는 이전과 동일(신규 회귀 없음).

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 탭을 열 때마다 자동으로 API를 호출하게 했는데, 데이터가 아주 많아지면 매번 처음 20건을 불러오는 게 부담될 수 있습니다. 지금 규모에서는 문제없어 보이지만, 나중에 필요하면 탭별로 "마지막으로 본 결과"를 캐시하는 것도 고려할 만합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 세션이 있으면 탭 전환 시 해당 목록이 자동으로 표시됩니다.
  * 검색어를 입력하지 않아도 전체 목록을 조회할 수 있습니다.
  * 불필요한 검색어 입력 안내가 제거되어 목록 확인이 더 간편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->