### PR TITLE
Fix/#163 관리자 페이지 대목/의견/댓글/모임 조회 500 오류 수정

### DIFF
--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminCommentService.java
@@ -41,7 +41,7 @@ public class AdminCommentService {
     }
 
     private Comment getExistingComment(Long commentId) {
-        return commentRepository.findById(commentId)
+        return commentRepository.findWithAssociationsById(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminGroupService.java
@@ -49,7 +49,7 @@ public class AdminGroupService {
     }
 
     private Group getExistingGroup(Long groupId) {
-        return groupRepository.findById(groupId)
+        return groupRepository.findWithAssociationsById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminOpinionService.java
@@ -51,7 +51,7 @@ public class AdminOpinionService {
     }
 
     private Opinion getExistingOpinion(Long opinionId) {
-        return opinionRepository.findById(opinionId)
+        return opinionRepository.findWithAssociationsById(opinionId)
                 .orElseThrow(() -> new OpinionException(OpinionErrorCode.OPINION_NOT_FOUND));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageService.java
+++ b/src/main/java/com/nexters/palang/domain/admin/application/AdminPassageService.java
@@ -41,7 +41,7 @@ public class AdminPassageService {
     }
 
     private Passage getExistingPassage(Long passageId) {
-        return passageRepository.findById(passageId)
+        return passageRepository.findWithAssociationsById(passageId)
                 .orElseThrow(() -> new PassageException(PassageErrorCode.PASSAGE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
+++ b/src/main/java/com/nexters/palang/domain/comment/infrastructure/CommentRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +18,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByIdWithUser(@Param("id") Long id);
 
     // 관리자 댓글 검색(AdminCommentService): 소프트 삭제 여부와 무관하게 내용에 키워드가 포함된 댓글 전부.
+    // open-in-view: false 환경에서 AdminCommentMapper가 컨트롤러 단(트랜잭션 밖)에서 user.getNickname()을
+    // 참조하므로 EntityGraph로 미리 로딩해야 한다(opinion/parentComment는 getId()만 쓰여 프록시로 충분하다).
+    @EntityGraph(attributePaths = {"user"})
     Page<Comment> findByContentContaining(String keyword, Pageable pageable);
+
+    // 관리자 댓글 수정/삭제(AdminCommentService): 위와 같은 이유로, 단건 조회에도 user를 미리
+    // 로딩해둔다(수정 응답도 컨트롤러 단에서 같은 필드를 참조한다).
+    @EntityGraph(attributePaths = {"user"})
+    Optional<Comment> findWithAssociationsById(Long id);
 
     // 관리자 유저 삭제(AdminUserService): 이 유저 본인의 댓글/답글 id 전부(삭제 순서 계산용).
     @Query("select c.id from Comment c where c.user.id = :userId")

--- a/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/nexters/palang/domain/group/infrastructure/GroupRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -23,7 +24,15 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllByBookId(Long bookId);
 
     // 관리자 모임 검색(AdminGroupService): 모임명에 키워드가 포함된 모임 전부.
+    // open-in-view: false 환경에서 AdminGroupMapper가 컨트롤러 단(트랜잭션 밖)에서 book/host를
+    // 참조하므로, EntityGraph로 미리 로딩해두지 않으면 LazyInitializationException이 난다.
+    @EntityGraph(attributePaths = {"book", "host"})
     Page<Group> findByNameContaining(String keyword, Pageable pageable);
+
+    // 관리자 모임 수정/삭제(AdminGroupService): 위와 같은 이유로, 단건 조회에도 book/host를 미리
+    // 로딩해둔다(수정 응답도 컨트롤러 단에서 같은 필드를 참조한다).
+    @EntityGraph(attributePaths = {"book", "host"})
+    Optional<Group> findWithAssociationsById(Long id);
 
     // 초대 링크 미리보기 등 단순 조회용. 잠금이 필요 없는 경로에서 사용한다. book 제목/저자/표지를 응답에
     // 바로 내려줘야 해서(GroupMapper.toInvitationPreviewResponse) join fetch로 같이 읽는다 — book이

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,7 +15,15 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
     long countByUserIdAndDeletedAtIsNull(Long userId);
 
     // 관리자 의견 검색(AdminOpinionService): 소프트 삭제 여부와 무관하게 내용에 키워드가 포함된 의견 전부.
+    // open-in-view: false 환경에서 AdminOpinionMapper가 컨트롤러 단(트랜잭션 밖)에서 passage/user를
+    // 참조하므로, EntityGraph로 미리 로딩해두지 않으면 LazyInitializationException이 난다.
+    @EntityGraph(attributePaths = {"passage", "user"})
     Page<Opinion> findByContentContaining(String keyword, Pageable pageable);
+
+    // 관리자 의견 수정/삭제(AdminOpinionService): 위와 같은 이유로, 단건 조회에도 passage/user를
+    // 미리 로딩해둔다(수정 응답도 컨트롤러 단에서 같은 필드를 참조한다).
+    @EntityGraph(attributePaths = {"passage", "user"})
+    Optional<Opinion> findWithAssociationsById(Long id);
 
     // 흔적 삭제 시 그 대목에 남은 다른 살아있는 흔적이 있는지 확인하기 위함 (없으면 대목도 함께 삭제).
     boolean existsByPassageIdAndDeletedAtIsNullAndIdNot(Long passageId, Long id);

--- a/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
+++ b/src/main/java/com/nexters/palang/domain/passage/infrastructure/PassageRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PassageRepository extends JpaRepository<Passage, Long> {
@@ -25,5 +26,13 @@ public interface PassageRepository extends JpaRepository<Passage, Long> {
     List<Passage> findAllByBookId(Long bookId);
 
     // 관리자 대목 검색(AdminPassageService): 소프트 삭제 여부와 무관하게 인용문에 키워드가 포함된 대목 전부.
+    // open-in-view: false 환경에서 AdminPassageMapper가 컨트롤러 단(트랜잭션 밖)에서 book/creator/group을
+    // 참조하므로, EntityGraph로 미리 로딩해두지 않으면 LazyInitializationException이 난다.
+    @EntityGraph(attributePaths = {"book", "creator", "group"})
     Page<Passage> findByQuotedTextContaining(String keyword, Pageable pageable);
+
+    // 관리자 대목 수정/삭제(AdminPassageService): 위와 같은 이유로, 단건 조회에도 book/creator/group을
+    // 미리 로딩해둔다(수정 응답도 컨트롤러 단에서 같은 필드를 참조한다).
+    @EntityGraph(attributePaths = {"book", "creator", "group"})
+    Optional<Passage> findWithAssociationsById(Long id);
 }

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminCommentServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminCommentServiceTest.java
@@ -35,7 +35,7 @@ class AdminCommentServiceTest {
     @Test
     @DisplayName("존재하지 않는 댓글을 삭제하려 하면 예외가 발생한다")
     void deleteFailsWhenCommentNotFound() {
-        given(commentRepository.findById(1L)).willReturn(Optional.empty());
+        given(commentRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminCommentService.deleteComment(1L)).isInstanceOf(CommentException.class);
     }
@@ -43,7 +43,7 @@ class AdminCommentServiceTest {
     @Test
     @DisplayName("댓글을 삭제하면 답글을 먼저 지운 뒤 본인을 지운다")
     void deleteCommentRemovesRepliesBeforeItself() {
-        given(commentRepository.findById(1L)).willReturn(Optional.of(mock(Comment.class)));
+        given(commentRepository.findWithAssociationsById(1L)).willReturn(Optional.of(mock(Comment.class)));
 
         adminCommentService.deleteComment(1L);
 

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminGroupServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminGroupServiceTest.java
@@ -40,7 +40,7 @@ class AdminGroupServiceTest {
     @Test
     @DisplayName("존재하지 않는 모임을 수정하려 하면 예외가 발생한다")
     void updateFailsWhenGroupNotFound() {
-        given(groupRepository.findById(1L)).willReturn(Optional.empty());
+        given(groupRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminGroupService.updateGroup(1L, "이름", 4, LocalDate.now(), LocalDate.now().plusDays(1)))
                 .isInstanceOf(GroupException.class);
@@ -50,7 +50,7 @@ class AdminGroupServiceTest {
     @DisplayName("모임을 수정하면 현재 참여 인원을 기준으로 설정이 바뀐다")
     void updateGroupDelegatesToEntity() {
         Group group = mock(Group.class);
-        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupRepository.findWithAssociationsById(1L)).willReturn(Optional.of(group));
         given(groupMemberRepository.countByGroupId(1L)).willReturn(3L);
         LocalDate start = LocalDate.of(2026, 1, 1);
         LocalDate end = LocalDate.of(2026, 2, 1);
@@ -64,7 +64,7 @@ class AdminGroupServiceTest {
     @Test
     @DisplayName("존재하지 않는 모임을 삭제하려 하면 예외가 발생한다")
     void deleteFailsWhenGroupNotFound() {
-        given(groupRepository.findById(1L)).willReturn(Optional.empty());
+        given(groupRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminGroupService.deleteGroup(1L)).isInstanceOf(GroupException.class);
     }
@@ -72,7 +72,7 @@ class AdminGroupServiceTest {
     @Test
     @DisplayName("모임을 삭제하면 cascade 삭제기가 호출된다")
     void deleteGroupDelegatesToCascadeDeleter() {
-        given(groupRepository.findById(1L)).willReturn(Optional.of(mock(Group.class)));
+        given(groupRepository.findWithAssociationsById(1L)).willReturn(Optional.of(mock(Group.class)));
 
         adminGroupService.deleteGroup(1L);
 

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminOpinionServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminOpinionServiceTest.java
@@ -41,7 +41,7 @@ class AdminOpinionServiceTest {
     @Test
     @DisplayName("존재하지 않는 의견을 삭제하려 하면 예외가 발생한다")
     void deleteFailsWhenOpinionNotFound() {
-        given(opinionRepository.findById(1L)).willReturn(Optional.empty());
+        given(opinionRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminOpinionService.deleteOpinion(1L)).isInstanceOf(OpinionException.class);
     }
@@ -53,7 +53,7 @@ class AdminOpinionServiceTest {
         given(passage.getId()).willReturn(100L);
         Opinion opinion = mock(Opinion.class);
         given(opinion.getPassage()).willReturn(passage);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findWithAssociationsById(1L)).willReturn(Optional.of(opinion));
         given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(false);
         given(passageRepository.findById(100L)).willReturn(Optional.of(passage));
 
@@ -70,7 +70,7 @@ class AdminOpinionServiceTest {
         given(passage.getId()).willReturn(100L);
         Opinion opinion = mock(Opinion.class);
         given(opinion.getPassage()).willReturn(passage);
-        given(opinionRepository.findById(1L)).willReturn(Optional.of(opinion));
+        given(opinionRepository.findWithAssociationsById(1L)).willReturn(Optional.of(opinion));
         given(opinionRepository.existsByPassageIdAndDeletedAtIsNullAndIdNot(100L, 1L)).willReturn(true);
 
         adminOpinionService.deleteOpinion(1L);

--- a/src/test/java/com/nexters/palang/domain/admin/application/AdminPassageServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/admin/application/AdminPassageServiceTest.java
@@ -37,7 +37,7 @@ class AdminPassageServiceTest {
     @Test
     @DisplayName("존재하지 않는 대목을 수정하려 하면 예외가 발생한다")
     void updateFailsWhenPassageNotFound() {
-        given(passageRepository.findById(1L)).willReturn(Optional.empty());
+        given(passageRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminPassageService.updatePassage(1L, "내용", 10, false))
                 .isInstanceOf(PassageException.class);
@@ -47,7 +47,7 @@ class AdminPassageServiceTest {
     @DisplayName("대목을 수정하면 인용문/페이지/스포일러 여부가 바뀐다")
     void updatePassageChangesContent() {
         Passage passage = mock(Passage.class);
-        given(passageRepository.findById(1L)).willReturn(Optional.of(passage));
+        given(passageRepository.findWithAssociationsById(1L)).willReturn(Optional.of(passage));
 
         Passage result = adminPassageService.updatePassage(1L, "새 인용문", 20, true);
 
@@ -59,7 +59,7 @@ class AdminPassageServiceTest {
     @Test
     @DisplayName("존재하지 않는 대목을 삭제하려 하면 예외가 발생한다")
     void deleteFailsWhenPassageNotFound() {
-        given(passageRepository.findById(1L)).willReturn(Optional.empty());
+        given(passageRepository.findWithAssociationsById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminPassageService.deletePassage(1L)).isInstanceOf(PassageException.class);
     }
@@ -67,7 +67,7 @@ class AdminPassageServiceTest {
     @Test
     @DisplayName("대목을 삭제하면 cascade 삭제기가 호출된다")
     void deletePassageDelegatesToCascadeDeleter() {
-        given(passageRepository.findById(1L)).willReturn(Optional.of(mock(Passage.class)));
+        given(passageRepository.findWithAssociationsById(1L)).willReturn(Optional.of(mock(Passage.class)));
 
         adminPassageService.deletePassage(1L);
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #163

## 🚀 개요
> 관리자 페이지에서 유저/책을 제외한 대목·의견·댓글·모임 탭이 전부 500(서버 내부 오류)이 뜨는 문제를 고칩니다. 원인은 dev/prod의 `open-in-view: false` 설정과 컨트롤러 단에서 지연 로딩 연관관계를 읽는 Admin Mapper들의 충돌이었습니다.

## 📄 작업 내용
- dev 서버 로그로 원인 확인: `LazyInitializationException: Could not initialize proxy [...Book#1] - no session` — `AdminPassageMapper.toSummary`가 트랜잭션이 끝난 컨트롤러 단에서 `passage.getBook().getTitle()`을 호출하면서 발생. 로컬은 `open-in-view` 기본값(true)이라 재현되지 않았고, dev/prod만 `false`로 명시돼 있어 배포 후에만 드러났습니다.
- `PassageRepository.findByQuotedTextContaining` / `OpinionRepository.findByContentContaining` / `CommentRepository.findByContentContaining` / `GroupRepository.findByNameContaining`에 `@EntityGraph`를 추가해, 각 Mapper가 실제로 읽는 연관관계(book/creator/group, passage/user, user, book/host)만 미리 로딩하도록 변경.
- 각 리포지토리에 단건 조회용 `findWithAssociationsById`를 추가하고, `AdminPassageService`/`AdminOpinionService`/`AdminCommentService`/`AdminGroupService`의 `getExistingXxx`(수정·삭제 공용)가 기존 `findById` 대신 이걸 쓰도록 변경 — 검색(GET)뿐 아니라 수정(PATCH) 응답도 같은 컨트롤러 단 매핑을 거치므로 동일한 문제가 있었습니다.
- `Book`은 Admin Mapper가 지연 연관관계를 참조하지 않아 이번 수정 대상에서 제외(원래도 정상 동작).
- 위 리포지토리 메서드를 스텁하던 Mockito 단위 테스트(`AdminPassageServiceTest`/`AdminOpinionServiceTest`/`AdminCommentServiceTest`/`AdminGroupServiceTest`) 4개를 `findWithAssociationsById` 기준으로 갱신.

## 📸 스크린샷 / 테스트 결과 (선택)
- 원인 재현: dev에 로그인 토큰으로 `GET /api/admin/passages`/`opinions`/`comments`/`groups`를 호출하면 500, `docker logs`로 위 스택트레이스를 직접 확인했습니다.
- `./gradlew test --tests "*Admin*"` — 38개 전체 통과.
- `./gradlew test` — 644개 중 3개 실패, 전부 로컬 Redis 미기동으로 인한 기존 실패(`RedisConnectionFailureException`)이며 이 PR과 무관합니다.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- `findWithAssociationsById`가 검색용 EntityGraph와 완전히 같은 attributePaths를 쓰는데, 단건 조회는 원래 코드처럼 필요한 필드만(예: Comment는 opinion.getId()만 쓰므로 opinion은 fetch 안 함) 최소로 유지했습니다 — 프록시의 getId()는 초기화 없이도 안전하다는 전제인데, 혹시 이 전제가 깨질 여지(예: equals/hashCode가 프록시를 완전히 비교하는 경우)가 있는지 확인 부탁드립니다.
- 근본적으로 "컨트롤러 단에서 지연 연관관계를 읽는" 패턴 자체가 open-in-view: false와는 계속 충돌 소지가 있습니다. 이번엔 발견된 4곳만 EntityGraph로 땜질했는데, 앞으로 Admin 도메인에 필드를 추가할 때마다 같은 문제가 재발할 수 있어 — 매핑을 서비스 트랜잭션 안으로 옮기는 더 근본적인 리팩토링이 필요한지 의견 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 관리자 화면에서 댓글, 모임, 의견, 대목의 상세 정보와 연관 정보가 안정적으로 표시되도록 개선했습니다.
  * 검색 및 수정·삭제 과정에서 관련 정보가 누락되거나 오류가 발생하는 문제를 완화했습니다.

* **테스트**
  * 관리자 콘텐츠의 수정·삭제 및 조회 시나리오를 변경된 동작에 맞게 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->