### PR TITLE
Fix/#166 샘플 도서 404 - ISBN 기준 조회 + 시더 추가

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/application/BookService.java
+++ b/src/main/java/com/nexters/palang/domain/book/application/BookService.java
@@ -4,6 +4,7 @@ import com.nexters.palang.domain.book.common.error.BookErrorCode;
 import com.nexters.palang.domain.book.common.error.BookException;
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
 import com.nexters.palang.domain.book.domain.UserBookStatus;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
 import com.nexters.palang.domain.book.infrastructure.AladinSearchResult;
@@ -134,14 +135,10 @@ public class BookService {
 
     // 비로그인 사용자와, 로그인했지만 서재에 책이 하나도 없는 계정은 홈에서 실제 서재 대신 고정 샘플 도서
     // 1건을 본다 (기획 확정, 이슈 #119). opinionCountScope=MINE(마이페이지, 본인이 남긴 흔적 수)일 때 책
-    // 전체 흔적 수(17)를 그대로 노출하면 "내가 남긴 흔적 수"가 17인 것처럼 잘못 보이므로, scope별로 값이
-    // 다른 고정 projection을 따로 둔다.
-    private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK = new BookActivityProjection(
-            18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
-            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 17L);
-    private static final BookActivityProjection GUEST_SAMPLE_LIBRARY_BOOK_MINE = new BookActivityProjection(
-            18L, "빵충 사육 준수 사항", "김혜영 (지은이)", "안전가옥",
-            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg", 13L, 0L);
+    // 전체 흔적 수를 그대로 노출하면 "내가 남긴 흔적 수"가 그만큼인 것처럼 잘못 보이므로, scope별로 값이
+    // 다르다. 어느 스크린이든 이 두 값은 실제 book row와 무관한 고정 표시값이다.
+    private static final long SAMPLE_LIBRARY_BOOK_PASSAGE_COUNT = 13L;
+    private static final long SAMPLE_LIBRARY_BOOK_OPINION_COUNT = 17L;
 
     // 내 서재는 홈 캐러셀과 달리 가운데 기준 없이 최근 흔적 순으로 나열하며, 표준 page/size 페이지네이션을 사용한다.
     public Page<BookActivityProjection> getMyLibraryBooks(Long userId, Pageable pageable, OpinionCountScope opinionCountScope) {
@@ -158,11 +155,24 @@ public class BookService {
     // 샘플 도서는 실제로는 1건뿐이므로 첫 페이지(offset 0)에서만 내려주고, 이후 페이지는 빈 목록을 반환한다.
     // 그렇지 않으면 요청한 모든 페이지에서 같은 샘플 도서가 계속 반복 노출된다.
     private Page<BookActivityProjection> sampleLibraryPage(Pageable pageable, OpinionCountScope opinionCountScope) {
-        BookActivityProjection sample = opinionCountScope == OpinionCountScope.MINE
-                ? GUEST_SAMPLE_LIBRARY_BOOK_MINE
-                : GUEST_SAMPLE_LIBRARY_BOOK;
-        List<BookActivityProjection> content = pageable.getOffset() == 0 ? List.of(sample) : List.of();
-        return new PageImpl<>(content, pageable, 1);
+        if (pageable.getOffset() != 0) {
+            return new PageImpl<>(List.of(), pageable, 1);
+        }
+        // ISBN으로 찾는다: 이 책의 로컬 PK는 환경(dev/prod)마다 다를 수 있어, PK를 그대로 하드코딩하면
+        // 그 PK가 없는 환경에서 존재하지 않는 도서를 가리키게 된다(SampleLibraryBookSeeder가 앱 시작
+        // 시 없으면 만들어 두지만, 그 전이라면 이 조회가 비어 있을 수 있다).
+        return bookRepository.findByIsbn(SampleLibraryBook.ISBN)
+                .map(book -> sampleLibraryPageOf(book, pageable, opinionCountScope))
+                .orElseGet(() -> Page.empty(pageable));
+    }
+
+    private Page<BookActivityProjection> sampleLibraryPageOf(
+            Book book, Pageable pageable, OpinionCountScope opinionCountScope) {
+        long opinionCount = opinionCountScope == OpinionCountScope.MINE ? 0L : SAMPLE_LIBRARY_BOOK_OPINION_COUNT;
+        BookActivityProjection sample = new BookActivityProjection(
+                book.getId(), book.getTitle(), book.getAuthor(), book.getPublisher(), book.getCoverImageUrl(),
+                SAMPLE_LIBRARY_BOOK_PASSAGE_COUNT, opinionCount);
+        return new PageImpl<>(List.of(sample), pageable, 1);
     }
 
     public Page<Book> getRecentBooks(Long userId, String keyword, Pageable pageable) {

--- a/src/main/java/com/nexters/palang/domain/book/domain/SampleLibraryBook.java
+++ b/src/main/java/com/nexters/palang/domain/book/domain/SampleLibraryBook.java
@@ -1,0 +1,19 @@
+package com.nexters.palang.domain.book.domain;
+
+// 비로그인 사용자와, 로그인했지만 서재에 책이 하나도 없는 계정이 홈에서 보는 고정 샘플 도서
+// (기획 확정, 이슈 #119)의 시드 값. ISBN으로 조회해 이 책의 실제 book row(SampleLibraryBookSeeder가
+// 앱 시작 시 없으면 생성)를 찾아 그 환경의 실제 id를 쓴다 — 환경마다 로컬 PK가 다를 수 있어, PK를
+// 직접 하드코딩하면 그 PK가 없는 환경(예: 이 책이 한 번도 만들어진 적 없는 prod)에서 404가 난다.
+public final class SampleLibraryBook {
+
+    public static final String ISBN = "9791194891178";
+    public static final String TITLE = "빵충 사육 준수 사항";
+    public static final String AUTHOR = "김혜영 (지은이)";
+    public static final String PUBLISHER = "안전가옥";
+    public static final int PAGE_COUNT = 388;
+    public static final String COVER_IMAGE_URL =
+            "https://image.aladin.co.kr/product/39872/66/cover200/k242130313_1.jpg";
+
+    private SampleLibraryBook() {
+    }
+}

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/BookRepository.java
@@ -2,11 +2,16 @@ package com.nexters.palang.domain.book.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    // 홈 화면 고정 샘플 도서(SampleLibraryBookSeeder/BookService#sampleLibraryPage) 조회용. 환경마다
+    // 이 책의 로컬 PK가 다를 수 있어 ISBN으로 찾는다.
+    Optional<Book> findByIsbn(String isbn);
 
     // title_normalized 백필 대상(BookTitleNormalizationBackfillRunner) 조회용. 기존 도서가 많을 때
     // 한 번에 전부 불러오지 않도록, id 기준 키셋 페이지네이션으로 한 배치씩만 조회한다. offset

--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeeder.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeeder.java
@@ -1,0 +1,43 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// BookService#sampleLibraryPage(홈 고정 샘플 도서, 이슈 #119)는 ISBN으로 book row를 찾아 그 id를
+// 쓴다. 이 책이 dev에서는 실사용 중 우연히 만들어졌지만 prod에는 만들어진 적이 없어 row 자체가
+// 없었고, 그 결과 샘플 카드를 눌러 상세로 들어가면 404가 나는 문제가 있었다(#166). 앱 시작 시 이
+// 책이 없으면 한 번 만들어 둬서, 어느 환경에서든 항상 유효한 book id를 참조하도록 한다. 이미 있으면
+// 아무 일도 하지 않으므로 재배포/재기동해도 안전하다(멱등적).
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SampleLibraryBookSeeder implements ApplicationRunner {
+
+    private final BookRepository bookRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (bookRepository.findByIsbn(SampleLibraryBook.ISBN).isPresent()) {
+            return;
+        }
+        Book book = Book.builder()
+                .title(SampleLibraryBook.TITLE)
+                .author(SampleLibraryBook.AUTHOR)
+                .publisher(SampleLibraryBook.PUBLISHER)
+                .pageCount(SampleLibraryBook.PAGE_COUNT)
+                .isbn(SampleLibraryBook.ISBN)
+                .coverImageUrl(SampleLibraryBook.COVER_IMAGE_URL)
+                .source(BookSource.API)
+                .build();
+        bookRepository.save(book);
+        log.info("홈 고정 샘플 도서 row 생성 완료 (isbn={})", SampleLibraryBook.ISBN);
+    }
+}

--- a/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/application/BookServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.nexters.palang.domain.book.domain.Book;
 import com.nexters.palang.domain.book.domain.BookSource;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
 import com.nexters.palang.domain.book.infrastructure.AladinBookApiClient;
 import com.nexters.palang.domain.book.infrastructure.AladinSearchResult;
 import com.nexters.palang.domain.book.domain.ReadingStatus;
@@ -403,6 +404,8 @@ class BookServiceTest {
     @DisplayName("비로그인 사용자가 내 서재를 조회하면 리포지토리 대신 고정 샘플 도서 1건을 반환한다")
     void getMyLibraryBooksReturnsSampleWhenGuest() {
         Pageable pageable = PageRequest.of(0, 20);
+        given(bookRepository.findByIsbn(SampleLibraryBook.ISBN))
+                .willReturn(Optional.of(book(18L, "빵충 사육 준수 사항")));
 
         Page<BookActivityProjection> results = bookService.getMyLibraryBooks(null, pageable, OpinionCountScope.ALL);
 
@@ -417,6 +420,8 @@ class BookServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
         given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.ALL))
                 .willReturn(new PageImpl<>(List.of(), pageable, 0));
+        given(bookRepository.findByIsbn(SampleLibraryBook.ISBN))
+                .willReturn(Optional.of(book(18L, "빵충 사육 준수 사항")));
 
         Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.ALL);
 
@@ -431,6 +436,8 @@ class BookServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
         given(bookQueryRepository.findMyLibraryBooks(10L, pageable, OpinionCountScope.MINE))
                 .willReturn(new PageImpl<>(List.of(), pageable, 0));
+        given(bookRepository.findByIsbn(SampleLibraryBook.ISBN))
+                .willReturn(Optional.of(book(18L, "빵충 사육 준수 사항")));
 
         Page<BookActivityProjection> results = bookService.getMyLibraryBooks(10L, pageable, OpinionCountScope.MINE);
 

--- a/src/test/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeederTest.java
+++ b/src/test/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeederTest.java
@@ -1,0 +1,55 @@
+package com.nexters.palang.domain.book.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class SampleLibraryBookSeederTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Test
+    @DisplayName("샘플 도서가 없는 환경(예: prod)이면 앱 시작 시 ISBN으로 하나 만들어 둔다")
+    void createsSampleBookWhenMissing() {
+        SampleLibraryBookSeeder seeder = new SampleLibraryBookSeeder(bookRepository);
+
+        seeder.run(null);
+
+        Book created = bookRepository.findByIsbn(SampleLibraryBook.ISBN).orElseThrow();
+        assertThat(created.getTitle()).isEqualTo(SampleLibraryBook.TITLE);
+    }
+
+    @Test
+    @DisplayName("샘플 도서가 이미 있으면(예: dev) 다시 만들지 않는다")
+    void doesNotDuplicateWhenAlreadyPresent() {
+        Book existing = entityManager.persistAndFlush(Book.builder()
+                .title(SampleLibraryBook.TITLE)
+                .author(SampleLibraryBook.AUTHOR)
+                .publisher(SampleLibraryBook.PUBLISHER)
+                .pageCount(SampleLibraryBook.PAGE_COUNT)
+                .isbn(SampleLibraryBook.ISBN)
+                .build());
+        entityManager.clear();
+        SampleLibraryBookSeeder seeder = new SampleLibraryBookSeeder(bookRepository);
+
+        seeder.run(null);
+
+        assertThat(bookRepository.count()).isEqualTo(1);
+        assertThat(bookRepository.findByIsbn(SampleLibraryBook.ISBN).orElseThrow().getId())
+                .isEqualTo(existing.getId());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #166

## 🚀 개요
> 홈에서 (비로그인/서재가 빈 계정에게) 보여주는 고정 샘플 도서 카드를 눌렀을 때 prod에서만 `GET /api/books/{id}/passages`가 404가 나던 문제를 고칩니다. 원인은 샘플 도서 id가 dev DB에서 우연히 부여된 로컬 PK(18)로 하드코딩돼 있었고, 그 책이 prod DB에는 아예 만들어진 적이 없었기 때문입니다.

## 📄 작업 내용
- `BookRepository`에 `findByIsbn(String isbn)` 추가.
- `BookService`의 하드코딩된 `GUEST_SAMPLE_LIBRARY_BOOK`/`GUEST_SAMPLE_LIBRARY_BOOK_MINE`(id=18L 포함) 상수를 제거하고, ISBN으로 조회한 실제 `Book` row의 id/title/author/publisher/coverImageUrl을 사용하도록 `sampleLibraryPage`를 변경. passageCount/opinionCount는 기존처럼 실제 데이터와 무관한 고정 표시값(13 / 17 또는 0)을 유지.
- 샘플 도서의 시드 값(ISBN/제목/작가/출판사/페이지수/커버이미지)을 `SampleLibraryBook` 상수 클래스로 분리 — `BookService`(표시용 fallback 불필요, 실제 row에서 읽음)와 신규 시더가 공유.
- `SampleLibraryBookSeeder`(`ApplicationRunner`) 추가: 기존 `BookTitleNormalizationBackfillRunner`와 동일한 패턴으로, 앱 시작 시 이 ISBN의 책이 없으면 한 번 만들어 둔다. 이미 있으면(dev) 아무 일도 하지 않아 멱등적이다. 이 러너 덕분에 prod 배포 시 별도 수동 데이터 작업 없이 자동으로 해결된다.
- `BookServiceTest`의 샘플 도서 관련 테스트에 `bookRepository.findByIsbn` 스텁 추가, `SampleLibraryBookSeederTest` 신규 작성(`@DataJpaTest`).

## 📸 스크린샷 / 테스트 결과 (선택)
- 원인 재현: `curl https://api.pallang.co.kr/api/books/18` → 404, `curl https://api-dev.pallang.co.kr/api/books/18` → 200 (같은 책이 dev에만 존재함을 확인).
- `./gradlew test --tests "*Book*"` — 139개 중 3개 실패, 전부 로컬 Redis 미기동으로 인한 기존 실패(`AladinBookApiClientCacheTest`)이며 이 PR과 무관.
- `./gradlew test` 전체 — 646개 중 동일한 기존 3건만 실패.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 샘플 도서의 passageCount/opinionCount(13 / 17 또는 0)는 기존 코드부터 실제 데이터와 무관한 고정 표시값이었는데, 이번에도 그대로 유지했습니다 — 실제 흔적/의견 수를 보여주는 게 맞다면 별도 이슈로 분리하는 게 좋을지 의견 부탁드립니다.
- `SampleLibraryBookSeeder`가 앱 시작 시 자동으로 book row를 만들어 두므로 prod 배포 후 별도 데이터 작업이 필요 없지만, 배포 직후 아주 짧은 시간 동안(시더가 아직 안 돈 시점) 서재가 빈 계정이 홈을 보면 샘플 카드 없이 빈 목록이 보일 수 있습니다(404 대신 빈 응답이라 이전보다는 안전합니다) — 허용 가능한 수준인지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 비로그인 사용자와 서재가 비어 있는 사용자에게 표시되는 샘플 도서를 안정적으로 제공합니다.
  * 애플리케이션 시작 시 샘플 도서가 없으면 자동 생성하며, 이미 존재하는 경우 중복 생성하지 않습니다.

* **버그 수정**
  * 환경별 식별자 차이로 샘플 도서 조회가 실패하던 문제를 개선했습니다.
  * 샘플 도서의 실제 정보를 기반으로 페이지와 의견 수를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->