### PR TITLE
Fix/#169 샘플 도서 예시 대목/의견 미표시

### DIFF
--- a/src/main/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeeder.java
+++ b/src/main/java/com/nexters/palang/domain/book/infrastructure/SampleLibraryBookSeeder.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,10 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 // 없었고, 그 결과 샘플 카드를 눌러 상세로 들어가면 404가 나는 문제가 있었다(#166). 앱 시작 시 이
 // 책이 없으면 한 번 만들어 둬서, 어느 환경에서든 항상 유효한 book id를 참조하도록 한다. 이미 있으면
 // 아무 일도 하지 않으므로 재배포/재기동해도 안전하다(멱등적).
+// OpinionGuestSampleSeedRunner가 이 book row를 전제로 샘플 대목/의견을 만들기 때문에, @Order로
+// 이 러너가 먼저 실행되도록 순서를 보장한다.
 @Slf4j
 @Component
+@Order(SampleLibraryBookSeeder.ORDER)
 @RequiredArgsConstructor
 public class SampleLibraryBookSeeder implements ApplicationRunner {
+
+    public static final int ORDER = 0;
 
     private final BookRepository bookRepository;
 

--- a/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunner.java
+++ b/src/main/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunner.java
@@ -1,7 +1,9 @@
 package com.nexters.palang.domain.opinion.infrastructure;
 
 import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
 import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.book.infrastructure.SampleLibraryBookSeeder;
 import com.nexters.palang.domain.decoration.domain.Decoration;
 import com.nexters.palang.domain.decoration.domain.EffectType;
 import com.nexters.palang.domain.opinion.domain.Opinion;
@@ -16,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -24,13 +27,13 @@ import org.springframework.transaction.support.TransactionTemplate;
 // 앱 시작 시 한 번 샘플 계정과 그 계정의 흔적 2건(대목 2개)을 만들어둔다. 이 프로젝트엔 Flyway 등
 // 마이그레이션 도구가 없어 BookTitleNormalizationBackfillRunner와 같은 방식(기동 시 자동 실행)을 따른다.
 // 샘플 계정에 이미 흔적이 있으면(=이미 씨딩됨) 아무 일도 하지 않으므로 재배포/재기동해도 안전하다(멱등적).
-// bookId=18("빵충 사육 준수 사항")이 없는 환경(로컬/테스트 DB 등)에서는 조용히 건너뛴다 — 이 도서는
-// BookService.GUEST_SAMPLE_LIBRARY_BOOK에서도 이미 같은 방식으로 하드코딩되어 있는 전제다.
+// 샘플 도서는 환경마다 로컬 PK가 달라 ISBN(SampleLibraryBook)으로 찾는다(#166) — SampleLibraryBookSeeder가
+// 먼저 그 book row를 만들어둬야 하므로 @Order로 이 러너보다 먼저 실행되게 한다. 그래도 아직 없는
+// 환경(로컬/테스트 DB 등)에서는 조용히 건너뛴다.
 @Slf4j
 @Component
+@Order(SampleLibraryBookSeeder.ORDER + 1)
 public class OpinionGuestSampleSeedRunner implements ApplicationRunner {
-
-    private static final Long SAMPLE_BOOK_ID = 18L;
 
     private static final int SAMPLE_PAGE_33 = 33;
     private static final String SAMPLE_QUOTE_33 = "이 모든 건 챗지피티 덕분이었다. 담당자가 준 자료를 복사해서 "
@@ -78,9 +81,9 @@ public class OpinionGuestSampleSeedRunner implements ApplicationRunner {
                 return false;
             }
 
-            Book book = bookRepository.findById(SAMPLE_BOOK_ID).orElse(null);
+            Book book = bookRepository.findByIsbn(SampleLibraryBook.ISBN).orElse(null);
             if (book == null) {
-                log.info("샘플 도서(id={})가 없어 비로그인 미리보기 흔적 씨딩을 건너뜁니다.", SAMPLE_BOOK_ID);
+                log.info("샘플 도서(isbn={})가 없어 비로그인 미리보기 흔적 씨딩을 건너뜁니다.", SampleLibraryBook.ISBN);
                 return false;
             }
 

--- a/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunnerTest.java
+++ b/src/test/java/com/nexters/palang/domain/opinion/infrastructure/OpinionGuestSampleSeedRunnerTest.java
@@ -1,0 +1,89 @@
+package com.nexters.palang.domain.opinion.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nexters.palang.domain.book.domain.Book;
+import com.nexters.palang.domain.book.domain.SampleLibraryBook;
+import com.nexters.palang.domain.book.infrastructure.BookRepository;
+import com.nexters.palang.domain.passage.infrastructure.PassageRepository;
+import com.nexters.palang.domain.user.domain.GuestSampleAccount;
+import com.nexters.palang.domain.user.infrastructure.UserRepository;
+import com.nexters.palang.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class OpinionGuestSampleSeedRunnerTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private PassageRepository passageRepository;
+
+    @Autowired
+    private OpinionRepository opinionRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private OpinionGuestSampleSeedRunner runner() {
+        return new OpinionGuestSampleSeedRunner(
+                userRepository, bookRepository, passageRepository, opinionRepository, transactionManager);
+    }
+
+    @Test
+    @DisplayName("ISBN으로 샘플 도서를 찾을 수 있으면 샘플 계정과 대목/의견을 만든다")
+    void seedsSampleOpinionsWhenSampleBookExists() {
+        bookRepository.save(Book.builder()
+                .title(SampleLibraryBook.TITLE)
+                .author(SampleLibraryBook.AUTHOR)
+                .publisher(SampleLibraryBook.PUBLISHER)
+                .pageCount(SampleLibraryBook.PAGE_COUNT)
+                .isbn(SampleLibraryBook.ISBN)
+                .build());
+
+        runner().run(null);
+
+        assertThat(passageRepository.count()).isEqualTo(2);
+        assertThat(opinionRepository.count()).isEqualTo(2);
+        assertThat(userRepository.findBySnsProviderAndSnsId(GuestSampleAccount.SNS_PROVIDER, GuestSampleAccount.SNS_ID))
+                .isPresent();
+    }
+
+    @Test
+    @DisplayName("샘플 도서(ISBN)가 아직 없는 환경에서는 아무것도 만들지 않는다")
+    void skipsWhenSampleBookMissing() {
+        runner().run(null);
+
+        assertThat(passageRepository.count()).isZero();
+        assertThat(opinionRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("이미 씨딩되어 있으면 다시 실행해도 중복 생성하지 않는다")
+    void doesNotDuplicateWhenAlreadySeeded() {
+        bookRepository.save(Book.builder()
+                .title(SampleLibraryBook.TITLE)
+                .author(SampleLibraryBook.AUTHOR)
+                .publisher(SampleLibraryBook.PUBLISHER)
+                .pageCount(SampleLibraryBook.PAGE_COUNT)
+                .isbn(SampleLibraryBook.ISBN)
+                .build());
+        OpinionGuestSampleSeedRunner runner = runner();
+        runner.run(null);
+
+        runner.run(null);
+
+        assertThat(passageRepository.count()).isEqualTo(2);
+        assertThat(opinionRepository.count()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #169

## 🚀 개요
- prod에서 샘플 도서(홈 화면 고정 카드) 상세로 들어가면 예시 대목/의견이 0개로 보이던 문제를 수정했습니다. 원인은 실제 대목/의견을 씨딩하는 `OpinionGuestSampleSeedRunner`가 #166 이전의 옛 하드코딩 `bookId=18`로 book을 찾고 있었기 때문입니다.

## 📄 작업 내용
- `OpinionGuestSampleSeedRunner`: `bookRepository.findById(18L)` 대신 `bookRepository.findByIsbn(SampleLibraryBook.ISBN)`으로 샘플 book을 조회하도록 수정 (#166에서 도입한 ISBN 기준 조회 방식과 일치)
- `SampleLibraryBookSeeder`(book row 생성)가 `OpinionGuestSampleSeedRunner`(대목/의견 생성)보다 먼저 실행되도록 두 `ApplicationRunner`에 `@Order` 지정 — 순서 보장 없이는 최초 기동 시 book이 아직 없어 씨딩이 건너뛰어질 수 있음
- `OpinionGuestSampleSeedRunnerTest` 신규 작성: 샘플 book 존재 시 대목 2개/의견 2개 생성, book 없을 때 건너뜀, 재실행 시 중복 생성 안 함 검증

## 📸 스크린샷 / 테스트 결과 (선택)
- `./gradlew test` 통과 (관련 테스트: `OpinionGuestSampleSeedRunnerTest` 3건, `SampleLibraryBookSeederTest` 2건, `BookServiceTest` 27건 모두 통과)
- 무관한 기존 실패: `AladinBookApiClientCacheTest`(로컬 Redis 미실행), `NotificationRepositoryTest`(동시각 정렬 플레이키) — 이번 변경과 무관, 단독 실행 시 통과 확인

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [ ] 서버 실행 확인
- [ ] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
- 홈 카드에 표시되는 "대목 13개 / 의견 17개"는 실제 book row와 무관한 고정 표시값(`BookService.SAMPLE_LIBRARY_BOOK_PASSAGE_COUNT`/`..._OPINION_COUNT`)이라, 이번 수정 후에도 실제 상세 화면 개수(2/2)와는 다르게 보입니다. 이 고정값을 실제 씨딩 개수에 맞출지는 별도 논의가 필요할 것 같습니다.
- `ApplicationRunner` 실행 순서를 `@Order`로 명시적으로 강제했습니다 — 기존에는 두 러너 모두 순서 미지정이라 최초 배포 시 우연에 의존하고 있었습니다.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGkkcMzuV3iWsbSRkqeuwv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선**
  - 샘플 도서와 관련 의견 데이터가 정해진 순서에 따라 안정적으로 생성됩니다.
  - 도서를 ISBN 기준으로 조회하여 환경별 식별자 차이로 인한 오류를 줄였습니다.
  - 대상 도서가 없을 경우 안내 후 데이터 생성을 건너뜁니다.
  - 초기화 작업을 반복 실행해도 샘플 데이터가 중복 생성되지 않습니다.

- **테스트**
  - 샘플 데이터 생성, 대상 도서 부재, 중복 실행 상황을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->